### PR TITLE
drop version from API URLs

### DIFF
--- a/config/api_router.py
+++ b/config/api_router.py
@@ -10,7 +10,7 @@ else:
     router = SimpleRouter()
 
 router.register("users", UserViewSet)
-router.register("v1/opportunity", OpportunityViewSet)
+router.register("opportunity", OpportunityViewSet)
 
 app_name = "api"
 urlpatterns = router.urls


### PR DESCRIPTION
We can add it later using [accept header versioning](https://www.django-rest-framework.org/api-guide/versioning/#acceptheaderversioning) if needed