### PR TITLE
create organization for user on signup

### DIFF
--- a/commcare_connect/templates/base.html
+++ b/commcare_connect/templates/base.html
@@ -46,9 +46,11 @@
                 <a class="nav-link {% active_link "about" %}" href="{% url 'about' %}">About</a>
               </li>
               {% if request.user.is_authenticated %}
+                {% if request.org %}
                 <li class="nav-item">
                   <a class="nav-link {% active_link "list || create || edit" namespace='opportunity' %}" href="{% url 'opportunity:list' request.org.slug %}">{% translate "Opportunities" %}</a>
                 </li>
+                {% endif %}
                 <li class="nav-item">
                   <a class="nav-link {% active_link "users:detail" %}" href="{% url 'users:detail' request.user.pk %}">{% translate "My Profile" %}</a>
                 </li>

--- a/commcare_connect/users/models.py
+++ b/commcare_connect/users/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.urls import reverse
@@ -39,6 +40,9 @@ class User(AbstractUser):
 class Organization(BaseModel):
     name = models.CharField(max_length=255)
     slug = models.SlugField(max_length=255, unique=True)
+    members = models.ManyToManyField(
+        settings.AUTH_USER_MODEL, related_name="organizations", through="UserOrganizationMembership"
+    )
 
     def save(self, *args, **kwargs):
         if not self.id:

--- a/commcare_connect/users/signals.py
+++ b/commcare_connect/users/signals.py
@@ -1,0 +1,17 @@
+from allauth.account.signals import user_signed_up
+from django.dispatch import receiver
+
+from commcare_connect.users.models import Organization, User, UserOrganizationMembership
+
+
+@receiver(user_signed_up)
+def create_org_for_user(request, user, **kwargs):
+    if not user.members.exists():
+        _create_default_org_for_user(user)
+
+
+def _create_default_org_for_user(user: User):
+    organization = Organization.objects.create(name=user.email.split("@")[0])
+    organization.members.add(user, through_defaults={"role": UserOrganizationMembership.Role.ADMIN})
+    organization.save()
+    return organization


### PR DESCRIPTION
In future we'll probably implement membership management and invitations but for now we just need users to belong to an organization.