### PR TITLE
Remove django logging config for EBS

### DIFF
--- a/.ebextensions/logging.config
+++ b/.ebextensions/logging.config
@@ -1,9 +1,0 @@
-commands:
-    00_create_dir:
-        command: mkdir -p /opt/python/log
-    01_create_file:
-        command: touch /opt/python/log/django.log
-    02_change_permissions:
-        command: chmod g+s /opt/python/log/django.log
-    03_change_owner:
-        command: chown webapp:webapp /opt/python/log/django.log

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -140,37 +140,29 @@ LOGGING = {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "verbose",
-        },
-        "file": {
-            "level": "DEBUG",
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "maxBytes": 10 * 1024 * 1024,
-            "backupCount": 20,
-            "filename": "/opt/python/log/django.log",
-        },
+        }
     },
-    "root": {"level": "DEBUG", "handlers": ["console", "file"]},
+    "root": {"level": "DEBUG", "handlers": ["console"]},
     "loggers": {
         "django.db.backends": {
             "level": "DEBUG",
-            "handlers": ["console", "file"],
+            "handlers": ["console"],
             "propagate": True,
         },
         # # Errors logged by the SDK itself
         # "sentry_sdk": {"level": "ERROR", "handlers": ["console"], "propagate": False},
         "django.security.DisallowedHost": {
             "level": "DEBUG",
-            "handlers": ["console", "file"],
+            "handlers": ["console"],
             "propagate": True,
         },
         "django": {
-            "handlers": ["console", "file"],
+            "handlers": ["console"],
             "level": "DEBUG",
             "propagate": True,
         },
         "django.server": {
-            "handlers": ["console", "file"],
+            "handlers": ["console"],
             "level": "DEBUG",
             "propagate": True,
         },


### PR DESCRIPTION
Removed the logging config as this config was running into permission errors on the Elastic Beanstalk EC2 instance whenever Django tried to rotate the logfile.

We can still access the logs as they are captured directly from the stdout by EBS.