### PR TITLE
export user visit data including flattened form data

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -6,7 +6,7 @@ from commcare_connect.opportunity.models import Opportunity, UserVisit
 from commcare_connect.opportunity.tables import UserVisitTable
 
 
-def export_user_visits(opportunity: Opportunity) -> Dataset:
+def export_user_visit_data(opportunity: Opportunity) -> Dataset:
     """Export all user visits for an opportunity."""
     user_visits = UserVisit.objects.filter(opportunity=opportunity)
     table = UserVisitTable(user_visits)

--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -1,0 +1,16 @@
+from django_tables2.export import TableExport
+
+from commcare_connect.opportunity.models import Opportunity, UserVisit
+from commcare_connect.opportunity.tables import UserVisitTable
+
+
+def export_user_visits(opportunity: Opportunity, export_format: str) -> TableExport:
+    """
+    Export user visits for a given opportunity to a CSV file.
+    """
+    if not TableExport.is_valid_format(export_format):
+        raise ValueError(f"Invalid export format: {export_format}")
+    user_visits = UserVisit.objects.filter(opportunity=opportunity)
+    table = UserVisitTable(user_visits)
+    exporter = TableExport(export_format, table, exclude_columns=("visit_date",))
+    return exporter

--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -1,16 +1,21 @@
-from django_tables2.export import TableExport
+from django.utils.encoding import force_str
+from tablib import Dataset
 
 from commcare_connect.opportunity.models import Opportunity, UserVisit
 from commcare_connect.opportunity.tables import UserVisitTable
 
 
-def export_user_visits(opportunity: Opportunity, export_format: str) -> TableExport:
-    """
-    Export user visits for a given opportunity to a CSV file.
-    """
-    if not TableExport.is_valid_format(export_format):
-        raise ValueError(f"Invalid export format: {export_format}")
+def export_user_visits(opportunity: Opportunity) -> Dataset:
     user_visits = UserVisit.objects.filter(opportunity=opportunity)
     table = UserVisitTable(user_visits)
-    exporter = TableExport(export_format, table, exclude_columns=("visit_date",))
-    return exporter
+    exclude_columns = ("visit_date",)
+    columns = [
+        column
+        for column in table.columns.iterall()
+        if not (column.column.exclude_from_export or column.name in exclude_columns)
+    ]
+
+    dataset = Dataset(title="Export", headers=[force_str(column.header, strings_only=True) for column in columns])
+    for row in table.rows:
+        dataset.append([force_str(row.get_cell_value(column.name), strings_only=True) for column in columns])
+    return dataset

--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -1,4 +1,5 @@
 from django.utils.encoding import force_str
+from flatten_dict import flatten
 from tablib import Dataset
 
 from commcare_connect.opportunity.models import Opportunity, UserVisit
@@ -6,6 +7,7 @@ from commcare_connect.opportunity.tables import UserVisitTable
 
 
 def export_user_visits(opportunity: Opportunity) -> Dataset:
+    """Export all user visits for an opportunity."""
     user_visits = UserVisit.objects.filter(opportunity=opportunity)
     table = UserVisitTable(user_visits)
     exclude_columns = ("visit_date",)
@@ -14,8 +16,36 @@ def export_user_visits(opportunity: Opportunity) -> Dataset:
         for column in table.columns.iterall()
         if not (column.column.exclude_from_export or column.name in exclude_columns)
     ]
+    base_data = [[row.get_cell_value(column.name) for column in columns] for row in table.rows]
+    base_headers = [force_str(column.header, strings_only=True) for column in columns]
+    return get_flattened_dataset(base_headers, base_data)
 
-    dataset = Dataset(title="Export", headers=[force_str(column.header, strings_only=True) for column in columns])
-    for row in table.rows:
-        dataset.append([force_str(row.get_cell_value(column.name), strings_only=True) for column in columns])
+
+def get_flattened_dataset(headers: list[str], data: list[list]) -> Dataset:
+    """Flatten the form json and add it to the dataset.
+
+    :param headers: The headers for the dataset.
+    :param data: The data for the dataset. It is expected that the last column in each row
+        is the form JSON data.
+    """
+    schema = set()
+    flat_data = []
+    for row in data:
+        form_json = row.pop()
+        flat_json = flatten(form_json, reducer="dot", enumerate_types=(list,))
+        flat_data.append(flat_json)
+        schema.update(flat_json.keys())
+
+    schema = sorted(schema, key=_schema_sort)
+    headers = headers[:-1] + schema
+    dataset = Dataset(title="Export", headers=headers)
+
+    for row, flat_json in zip(data, flat_data):
+        row.extend(flat_json.get(key, "") for key in schema)
+        dataset.append([force_str(col, strings_only=True) for col in row])
+
     return dataset
+
+
+def _schema_sort(item):
+    return len(item), item

--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -48,4 +48,4 @@ def get_flattened_dataset(headers: list[str], data: list[list]) -> Dataset:
 
 
 def _schema_sort(item):
-    return len(item), item
+    return len(item.split(".")), item

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -21,11 +21,18 @@ class OpportunityAccessTable(tables.Table):
 
 
 class UserVisitTable(tables.Table):
+    # export only columns
+    username = columns.Column(verbose_name="Username", accessor="user.username", visible=False)
+    form_json = columns.Column(verbose_name="Form JSON", accessor="form_json", visible=False)
+    visit_date_export = columns.DateTimeColumn(
+        verbose_name="Visit date", accessor="visit_date", format="c", visible=False
+    )
+
     deliver_form = columns.Column(verbose_name="Form Name", accessor="deliver_form.name")
 
     class Meta:
         model = UserVisit
         fields = ("user.name", "visit_date", "status")
-        sequence = ("user.name", "deliver_form", "visit_date", "status")
+        sequence = ("visit_date", "visit_date_export", "username", "user.name", "deliver_form", "status")
         empty_text = "No forms."
         orderable = False

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -27,9 +27,9 @@ def test_export_user_visits(user):
             ),
         ]
     )
-    exporter = export_user_visits(deliver_form.opportunity, "csv")
+    exporter = export_user_visits(deliver_form.opportunity)
     # TODO: update with username
-    assert exporter.export() == (
+    assert exporter.export("csv") == (
         "Visit date,Username,Name of User,Form Name,Status,Form JSON\r\n"
         f"{date1.isoformat()},,{user.name},{deliver_form.name},Pending,"
         "{'form': {'name': 'test_form1'}}\r\n"

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -1,0 +1,38 @@
+from django.utils.timezone import now
+
+from commcare_connect.opportunity.export import export_user_visits
+from commcare_connect.opportunity.models import UserVisit
+from commcare_connect.opportunity.tests.factories import DeliverFormFactory
+
+
+def test_export_user_visits(user):
+    deliver_form = DeliverFormFactory()
+    date1 = now()
+    date2 = now()
+    UserVisit.objects.bulk_create(
+        [
+            UserVisit(
+                opportunity=deliver_form.opportunity,
+                user=user,
+                visit_date=date1,
+                deliver_form=deliver_form,
+                form_json={"form": {"name": "test_form1"}},
+            ),
+            UserVisit(
+                opportunity=deliver_form.opportunity,
+                user=user,
+                visit_date=date2,
+                deliver_form=deliver_form,
+                form_json={"form": {"name": "test_form2"}},
+            ),
+        ]
+    )
+    exporter = export_user_visits(deliver_form.opportunity, "csv")
+    # TODO: update with username
+    assert exporter.export() == (
+        "Visit date,Username,Name of User,Form Name,Status,Form JSON\r\n"
+        f"{date1.isoformat()},,{user.name},{deliver_form.name},Pending,"
+        "{'form': {'name': 'test_form1'}}\r\n"
+        f"{date2.isoformat()},,{user.name},{deliver_form.name},Pending,"
+        "{'form': {'name': 'test_form2'}}\r\n"
+    )

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -1,12 +1,12 @@
 import pytest
 from django.utils.timezone import now
 
-from commcare_connect.opportunity.export import export_user_visits, get_flattened_dataset
+from commcare_connect.opportunity.export import export_user_visit_data, get_flattened_dataset
 from commcare_connect.opportunity.models import UserVisit
 from commcare_connect.opportunity.tests.factories import DeliverFormFactory
 
 
-def test_export_user_visits(user):
+def test_export_user_visit_data(user):
     deliver_form = DeliverFormFactory()
     date1 = now()
     date2 = now()
@@ -28,7 +28,7 @@ def test_export_user_visits(user):
             ),
         ]
     )
-    exporter = export_user_visits(deliver_form.opportunity)
+    exporter = export_user_visit_data(deliver_form.opportunity)
     # TODO: update with username
     assert exporter.export("csv") == (
         "Visit date,Username,Name of User,Form Name,Status,form.name,form.group.q\r\n"

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -1,7 +1,6 @@
 from django.urls import path
 
 from commcare_connect.opportunity.views import (
-    ExportUserVisits,
     OpportunityCreate,
     OpportunityDetail,
     OpportunityEdit,
@@ -9,6 +8,7 @@ from commcare_connect.opportunity.views import (
     OpportunityUserLearnProgress,
     OpportunityUserTableView,
     OpportunityUserVisitTableView,
+    export_user_visits,
 )
 
 app_name = "opportunity"
@@ -19,7 +19,7 @@ urlpatterns = [
     path("<int:pk>/", view=OpportunityDetail.as_view(), name="detail"),
     path("<int:pk>/user_table/", view=OpportunityUserTableView.as_view(), name="user_table"),
     path("<int:pk>/visit_table/", view=OpportunityUserVisitTableView.as_view(), name="visit_table"),
-    path("<int:pk>/visit_export/", view=ExportUserVisits.as_view(), name="visit_export"),
+    path("<int:pk>/visit_export/", view=export_user_visits, name="visit_export"),
     path(
         "<int:opp_id>/learn_progress/<int:pk>",
         view=OpportunityUserLearnProgress.as_view(),

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from commcare_connect.opportunity.views import (
+    ExportUserVisits,
     OpportunityCreate,
     OpportunityDetail,
     OpportunityEdit,
@@ -18,6 +19,7 @@ urlpatterns = [
     path("<int:pk>/", view=OpportunityDetail.as_view(), name="detail"),
     path("<int:pk>/user_table/", view=OpportunityUserTableView.as_view(), name="user_table"),
     path("<int:pk>/visit_table/", view=OpportunityUserVisitTableView.as_view(), name="visit_table"),
+    path("<int:pk>/visit_export/", view=ExportUserVisits.as_view(), name="visit_export"),
     path(
         "<int:opp_id>/learn_progress/<int:pk>",
         view=OpportunityUserLearnProgress.as_view(),

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -118,7 +118,7 @@ class ExportUserVisits(OrganizationUserMixin, DetailView):
             return HttpResponseBadRequest(f"Invalid export format: {export_format}")
 
         dataset = export_user_visits(opportunity)
-        response = HttpResponse(content_type=self.content_type())
+        response = HttpResponse(content_type=TableExport.FORMATS[export_format])
         response["Content-Disposition"] = 'attachment; filename="user_visits.csv"'
         response.write(dataset.export(export_format))
         return response

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1,6 +1,7 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.http import HttpResponse, HttpResponseBadRequest
-from django.shortcuts import get_object_or_404
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from django_tables2 import SingleTableView
@@ -115,7 +116,8 @@ class ExportUserVisits(OrganizationUserMixin, DetailView):
         opportunity = get_object_or_404(Opportunity, organization=self.request.org, id=opportunity_id)
         export_format = request.GET.get("_export", None)
         if not TableExport.is_valid_format(export_format):
-            return HttpResponseBadRequest(f"Invalid export format: {export_format}")
+            messages.error(request, f"Invalid export format: {export_format}")
+            return redirect("opportunity:detail", self.request.org.slug, opportunity_id)
 
         dataset = export_user_visits(opportunity)
         response = HttpResponse(content_type=TableExport.FORMATS[export_format])

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from django_tables2 import SingleTableView
 
+from commcare_connect.opportunity.export import export_user_visits
 from commcare_connect.opportunity.forms import OpportunityChangeForm, OpportunityCreationForm
 from commcare_connect.opportunity.models import CompletedModule, Opportunity, OpportunityAccess, UserVisit
 from commcare_connect.opportunity.tables import OpportunityAccessTable, UserVisitTable
@@ -105,3 +106,12 @@ class OpportunityUserLearnProgress(DetailView):
             opportunity_id=self.kwargs.get("opp_id"),
         )
         return context
+
+
+class ExportUserVisits(OrganizationUserMixin, DetailView):
+    def get(self, request, *args, **kwargs):
+        opportunity_id = self.kwargs["pk"]
+        opportunity = get_object_or_404(Opportunity, organization=self.request.org, id=opportunity_id)
+        export_format = request.GET.get("_export", None)
+        exporter = export_user_visits(opportunity, export_format)
+        return exporter.response()

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -78,7 +78,7 @@ class OpportunityUserTableView(OrganizationUserMixin, SingleTableView):
     def get_queryset(self):
         opportunity_id = self.kwargs["pk"]
         opportunity = get_object_or_404(Opportunity, organization=self.request.org, id=opportunity_id)
-        return OpportunityAccess.objects.filter(opportunity=opportunity)
+        return OpportunityAccess.objects.filter(opportunity=opportunity).order_by("user__name")
 
 
 class OpportunityUserVisitTableView(OrganizationUserMixin, SingleTableView):
@@ -90,10 +90,10 @@ class OpportunityUserVisitTableView(OrganizationUserMixin, SingleTableView):
     def get_queryset(self):
         opportunity_id = self.kwargs["pk"]
         opportunity = get_object_or_404(Opportunity, organization=self.request.org, id=opportunity_id)
-        return UserVisit.objects.filter(opportunity=opportunity)
+        return UserVisit.objects.filter(opportunity=opportunity).order_by("visit_date")
 
 
-class OpportunityUserLearnProgress(DetailView):
+class OpportunityUserLearnProgress(OrganizationUserMixin, DetailView):
     template_name = "opportunity/user_learn_progress.html"
 
     def get_queryset(self):

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -98,9 +98,19 @@
           </div>
         </div>
         <div class="tab-pane fade" id="deliver-tab-pane" role="tabpanel" aria-labelledby="deliver-tab" tabindex="0">
-          <div class="bg-light clearfix my-2 float-end">
-            <button type="button" class="btn btn-primary mx-2">{% translate "Export User Visits" %}</button>
-            <button type="button" class="btn btn-primary">{% translate "Import Verified Visits" %}</button>
+          <div class="btn-toolbar justify-content-end my-2" role="toolbar">
+            <div class="btn-group" role="group" aria-label="First group">
+              <div class="btn-group" role="group">
+                <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                  {% translate "Export User Visits" %}
+                </button>
+                <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "CSV" %}">CSV</a></li>
+                  <li><a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "xlsx" %}">Excel</a></li>
+                </ul>
+              </div>
+              <button type="button" class="btn btn-primary">{% translate "Import Verified Visits" %}</button>
+            </div>
           </div>
           <div hx-get="{% url "opportunity:visit_table" org_slug=request.org.slug pk=opportunity.pk %}{% querystring %}"
                hx-trigger="load" hx-swap="outerHTML">

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -8,14 +8,36 @@
   <div class="container">
     <div class="mt-2 pt-4 px-4">
       <div class="row align-items-center">
-        <div class="col-8">
+        <div class="col-6">
           <h1 class="display-5 mb-0">{{ object.name }}</h1>
         </div>
-        <div class="col-4">
-          <a class="float-end btn btn-primary rounded-circle"
-             href="{% url 'opportunity:edit' org_slug=request.org.slug pk=opportunity.id %}">
-            <i class="bi bi-pencil"></i>
-          </a>
+        <div class="col-6">
+          <div class="btn-toolbar justify-content-end my-2" role="toolbar">
+            <div class="btn-group" role="group" aria-label="First group">
+              <div class="btn-group" role="group">
+                <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                  {% translate "Export User Visits" %}
+                </button>
+                <ul class="dropdown-menu">
+                  <li>
+                    <a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "csv" %}">
+                      {% translate "CSV" %}
+                    </a>
+                  </li>
+                  <li>
+                    <a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "xlsx" %}">
+                      {% translate "Excel" %}
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <button type="button" class="btn btn-primary">{% translate "Import Verified Visits" %}</button>
+              <a class="float-end btn btn-primary"
+                href="{% url 'opportunity:edit' org_slug=request.org.slug pk=opportunity.id %}">
+                <i class="bi bi-pencil"></i>
+              </a>
+            </div>
+          </div>
         </div>
       </div>
       <small title="End date"><i class="bi bi-clock"></i> Ends on <b>{{ object.end_date }}</b></small>
@@ -98,20 +120,6 @@
           </div>
         </div>
         <div class="tab-pane fade" id="deliver-tab-pane" role="tabpanel" aria-labelledby="deliver-tab" tabindex="0">
-          <div class="btn-toolbar justify-content-end my-2" role="toolbar">
-            <div class="btn-group" role="group" aria-label="First group">
-              <div class="btn-group" role="group">
-                <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-                  {% translate "Export User Visits" %}
-                </button>
-                <ul class="dropdown-menu">
-                  <li><a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "csv" %}">CSV</a></li>
-                  <li><a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "xlsx" %}">Excel</a></li>
-                </ul>
-              </div>
-              <button type="button" class="btn btn-primary">{% translate "Import Verified Visits" %}</button>
-            </div>
-          </div>
           <div hx-get="{% url "opportunity:visit_table" org_slug=request.org.slug pk=opportunity.pk %}{% querystring %}"
                hx-trigger="load" hx-swap="outerHTML">
             {% include "tables/table_placeholder.html" with num_cols=4 %}

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% load django_tables2 %}
 
 {% block title %}{{ request.org }} - {{ opportunity.name }}{% endblock %}
@@ -97,6 +98,10 @@
           </div>
         </div>
         <div class="tab-pane fade" id="deliver-tab-pane" role="tabpanel" aria-labelledby="deliver-tab" tabindex="0">
+          <div class="bg-light clearfix my-2 float-end">
+            <button type="button" class="btn btn-primary mx-2">{% translate "Export User Visits" %}</button>
+            <button type="button" class="btn btn-primary">{% translate "Import Verified Visits" %}</button>
+          </div>
           <div hx-get="{% url "opportunity:visit_table" org_slug=request.org.slug pk=opportunity.pk %}{% querystring %}"
                hx-trigger="load" hx-swap="outerHTML">
             {% include "tables/table_placeholder.html" with num_cols=4 %}

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -105,7 +105,7 @@
                   {% translate "Export User Visits" %}
                 </button>
                 <ul class="dropdown-menu">
-                  <li><a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "CSV" %}">CSV</a></li>
+                  <li><a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "csv" %}">CSV</a></li>
                   <li><a class="dropdown-item" href="{% url "opportunity:visit_export" org_slug=request.org.slug pk=opportunity.pk %}{% export_url "xlsx" %}">Excel</a></li>
                 </ul>
               </div>

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,6 +8,7 @@ httpx[http2]
 celery
 jsonpath-ng
 quickcache
+tablib[xlsx]
 
 # Django
 # ------------------------------------------------------------------------------

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,6 +9,7 @@ celery
 jsonpath-ng
 quickcache
 tablib[xlsx]
+flatten-dict
 
 # Django
 # ------------------------------------------------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -99,6 +99,8 @@ drf-spectacular==0.26.4
     # via -r requirements/base.in
 et-xmlfile==1.1.0
     # via openpyxl
+flatten-dict==0.4.2
+    # via -r requirements/base.in
 h11==0.14.0
     # via httpcore
 h2==4.1.0
@@ -180,6 +182,7 @@ rpds-py==0.9.2
     #   referencing
 six==1.16.0
     # via
+    #   flatten-dict
     #   jsonpath-ng
     #   python-dateutil
     #   quickcache

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -97,6 +97,8 @@ djangorestframework==3.14.0
     #   drf-spectacular
 drf-spectacular==0.26.4
     # via -r requirements/base.in
+et-xmlfile==1.1.0
+    # via openpyxl
 h11==0.14.0
     # via httpcore
 h2==4.1.0
@@ -128,6 +130,8 @@ kombu==5.3.1
     # via celery
 oauthlib==3.2.2
     # via requests-oauthlib
+openpyxl==3.1.2
+    # via tablib
 pillow==10.0.0
     # via -r requirements/base.in
 ply==3.11
@@ -186,6 +190,8 @@ sniffio==1.3.0
     #   httpx
 sqlparse==0.4.4
     # via django
+tablib[xlsx]==3.5.0
+    # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
 tzdata==2023.3


### PR DESCRIPTION
This adds an export button to the opportunity detail view that allows you to download the user visit data as a CSV or Excel file.

The data in the file is the same as shown in the user visit table except with the form data appended to the end. The headers for the form data section are flattened path values e.g. `form.group.1.question`

![Peek 2023-08-25 12-05](https://github.com/dimagi/commcare-connect/assets/249606/ef6a12c8-202c-49c9-a09b-445ccf7a0cf1)
