### PR TITLE
Add oauth authentication and token permission to form receiver

### DIFF
--- a/commcare_connect/form_receiver/tests/test_receiver_endpoint.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_endpoint.py
@@ -1,6 +1,7 @@
+import datetime
 from unittest import mock
 
-from rest_framework.test import APIRequestFactory
+from rest_framework.test import APIClient, APIRequestFactory
 
 from commcare_connect.form_receiver.exceptions import ProcessingError
 from commcare_connect.form_receiver.tests.xforms import get_form_json
@@ -13,29 +14,33 @@ receiver_view = FormReceiver.as_view()
 def test_form_receiver_requires_auth(api_rf: APIRequestFactory):
     request = api_rf.post("/api/receiver/", data={"foo": "bar"}, format="json")
     response = receiver_view(request)
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
-def test_form_receiver_only_accept_json(user: User, api_rf: APIRequestFactory):
-    request = api_rf.post("/api/receiver/", data={"foo": "bar"})
-    request.user = user
-    response = receiver_view(request)
+def test_form_receiver_only_accept_json(user: User, api_client: APIClient):
+    add_credentials(api_client, user)
+    response = api_client.post("/api/receiver/", data={"foo": "bar"})
     assert response.status_code == 415
 
 
-def test_form_receiver_validation(user: User, api_rf: APIRequestFactory):
-    request = api_rf.post("/api/receiver/", data={}, format="json")
-    request.user = user
-    response = receiver_view(request)
+def test_form_receiver_validation(user: User, api_client: APIClient):
+    add_credentials(api_client, user)
+    response = api_client.post("/api/receiver/", data={"foo": "bar"}, format="json")
     assert response.status_code == 400
     assert set(response.data) == {"domain", "metadata", "build_id", "app_id", "received_on", "form", "id"}
 
 
-def test_process_xform_error(user: User, api_rf: APIRequestFactory):
-    request = api_rf.post("/api/receiver/", data=get_form_json(), format="json")
-    request.user = user
+def test_process_xform_error(user: User, api_client: APIClient):
+    add_credentials(api_client, user)
     with (mock.patch("commcare_connect.form_receiver.views.process_xform") as process_xform,):
         process_xform.side_effect = ProcessingError("oops, something went wrong")
-        response = receiver_view(request)
+        response = api_client.post("/api/receiver/", data=get_form_json(), format="json")
     assert response.status_code == 400, response.data
     assert response.data == {"detail": "oops, something went wrong"}
+
+
+def add_credentials(api_client: APIClient, user: User):
+    token = user.oauth2_provider_accesstoken.create(
+        expires=datetime.datetime.now() + datetime.timedelta(hours=1), token="token", scope="read write"
+    )
+    api_client.credentials(Authorization=f"Bearer {token}")

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -1,6 +1,7 @@
 import pytest
 from rest_framework.test import APIClient
 
+from commcare_connect.form_receiver.tests.test_receiver_endpoint import add_credentials
 from commcare_connect.form_receiver.tests.xforms import AssessmentStubFactory, LearnModuleJsonFactory, get_form_json
 from commcare_connect.opportunity.models import Assessment, CompletedModule, LearnModule, Opportunity, UserVisit
 from commcare_connect.opportunity.tests.factories import LearnModuleFactory, OpportunityFactory
@@ -103,6 +104,6 @@ def _get_form_json(learn_app, module_id, form_block=None):
 
 
 def make_request(api_client, form_json, user, expected_status_code=200):
-    api_client.force_authenticate(user=user)
+    add_credentials(api_client, user)
     response = api_client.post("/api/receiver/", data=form_json, format="json")
     assert response.status_code == expected_status_code, response.data

--- a/commcare_connect/form_receiver/views.py
+++ b/commcare_connect/form_receiver/views.py
@@ -1,4 +1,5 @@
-from rest_framework import parsers, permissions, status
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication, TokenHasReadWriteScope
+from rest_framework import parsers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -8,7 +9,8 @@ from commcare_connect.form_receiver.serializers import XFormSerializer
 
 class FormReceiver(APIView):
     parser_classes = [parsers.JSONParser]
-    permission_classes = [permissions.IsAuthenticated]
+    authentication_classes = [OAuth2Authentication]
+    permission_classes = [TokenHasReadWriteScope]
 
     def post(self, request):
         serializer = XFormSerializer(data=request.data)


### PR DESCRIPTION
Added OAuth2Authentication and TokenHasReadWrite scope to form receiever api to allow using client credentials.

Connection Settings
<img width="879" alt="image" src="https://github.com/dimagi/commcare-connect/assets/31195143/a3c183d7-94b7-4ff8-8a76-1255ac54d454">
