### PR TITLE
Pkv/fixes data forwarding

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -70,18 +70,21 @@ def process_learn_modules(user, xform: XForm, app: CommCareApp, opportunity: Opp
     :param blocks: A list of learn module form blocks."""
     for module_data in blocks:
         module = get_or_create_learn_module(app, module_data)
-        CompletedModule.objects.update_or_create(
+        completed_module, created = CompletedModule.objects.get_or_create(
             user=user,
             module=module,
             opportunity=opportunity,
+            xform_id=xform.id,
             defaults={
                 "date": xform.received_on,
                 "duration": xform.metadata.duration,
-                "xform_id": xform.id,
                 "app_build_id": xform.build_id,
                 "app_build_version": xform.metadata.app_build_version,
             },
         )
+
+        if not created:
+            raise ProcessingError("Learn Module is already completed")
 
 
 def process_assessments(user, xform: XForm, app: CommCareApp, opportunity: Opportunity, blocks: list[dict]):
@@ -99,18 +102,23 @@ def process_assessments(user, xform: XForm, app: CommCareApp, opportunity: Oppor
             raise ProcessingError("User score must be an integer")
         # TODO: should this move to the opportunity to allow better re-use of the app?
         passing_score = app.passing_score
-        Assessment.objects.create(
+        assessment, created = Assessment.objects.get_or_create(
             user=user,
             app=app,
             opportunity=opportunity,
-            date=xform.received_on,
-            score=score,
-            passing_score=passing_score,
-            passed=score >= passing_score,
             xform_id=xform.id,
-            app_build_id=xform.build_id,
-            app_build_version=xform.metadata.app_build_version,
+            defaults={
+                "date": xform.received_on,
+                "score": score,
+                "passing_score": passing_score,
+                "passed": score >= passing_score,
+                "app_build_id": xform.build_id,
+                "app_build_version": xform.metadata.app_build_version,
+            },
         )
+
+        if not created:
+            return ProcessingError("Learn Assessment is already completed")
 
 
 def process_deliver_form(user, xform):

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -16,7 +16,7 @@ from commcare_connect.opportunity.models import (
 from commcare_connect.users.models import User
 
 LEARN_MODULE_JSONPATH = parse("$..module")
-ASSESSMENT_JSONPATH = parse("assessment where @xmlns")
+ASSESSMENT_JSONPATH = parse("$..assessment")
 
 
 def process_xform(xform: XForm):
@@ -70,15 +70,17 @@ def process_learn_modules(user, xform: XForm, app: CommCareApp, opportunity: Opp
     :param blocks: A list of learn module form blocks."""
     for module_data in blocks:
         module = get_or_create_learn_module(app, module_data)
-        CompletedModule.objects.create(
+        CompletedModule.objects.update_or_create(
             user=user,
             module=module,
             opportunity=opportunity,
-            date=xform.received_on,
-            duration=xform.metadata.duration,
-            xform_id=xform.id,
-            app_build_id=xform.build_id,
-            app_build_version=xform.metadata.app_build_version,
+            defaults={
+                "date": xform.received_on,
+                "duration": xform.metadata.duration,
+                "xform_id": xform.id,
+                "app_build_id": xform.build_id,
+                "app_build_version": xform.metadata.app_build_version,
+            },
         )
 
 

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -15,7 +15,7 @@ class OpportunityAccessTable(tables.Table):
 
     class Meta:
         model = OpportunityAccess
-        fields = ("user.name", "learn_progress", "visit_count")
+        fields = ("user.username", "learn_progress", "visit_count")
         orderable = False
         empty_text = "No learn progress for users."
 
@@ -33,7 +33,15 @@ class UserVisitTable(tables.Table):
 
     class Meta:
         model = UserVisit
-        fields = ("user.name", "visit_date", "status")
-        sequence = ("visit_id", "visit_date", "visit_date_export", "status", "username", "user.name", "deliver_form")
+        fields = ("user.name", "username", "visit_date", "status")
+        sequence = (
+            "visit_id",
+            "visit_date",
+            "visit_date_export",
+            "status",
+            "username",
+            "user.name",
+            "deliver_form",
+        )
         empty_text = "No forms."
         orderable = False

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -7,7 +7,7 @@ from commcare_connect.opportunity.models import UserVisit
 from commcare_connect.opportunity.tests.factories import DeliverFormFactory
 
 
-def test_export_user_visit_data(user):
+def test_export_user_visit_data(mobile_user_with_connect_link):
     deliver_form = DeliverFormFactory()
     date1 = now()
     date2 = now()
@@ -15,14 +15,14 @@ def test_export_user_visit_data(user):
         [
             UserVisit(
                 opportunity=deliver_form.opportunity,
-                user=user,
+                user=mobile_user_with_connect_link,
                 visit_date=date1,
                 deliver_form=deliver_form,
                 form_json={"form": {"name": "test_form1"}},
             ),
             UserVisit(
                 opportunity=deliver_form.opportunity,
-                user=user,
+                user=mobile_user_with_connect_link,
                 visit_date=date2,
                 deliver_form=deliver_form,
                 form_json={"form": {"name": "test_form2", "group": {"q": "b"}}},
@@ -30,11 +30,13 @@ def test_export_user_visit_data(user):
         ]
     )
     exporter = export_user_visit_data(deliver_form.opportunity, DateRanges.LAST_30_DAYS, [])
-    # TODO: update with username
+    username = mobile_user_with_connect_link.username
+    name = mobile_user_with_connect_link.name
+
     assert exporter.export("csv") == (
         "Visit ID,Visit date,Status,Username,Name of User,Form Name,form.name,form.group.q\r\n"
-        f",{date1.isoformat()},Pending,,{user.name},{deliver_form.name},test_form1,\r\n"
-        f",{date2.isoformat()},Pending,,{user.name},{deliver_form.name},test_form2,b\r\n"
+        f",{date1.isoformat()},Pending,{username},{name},{deliver_form.name},test_form1,\r\n"
+        f",{date2.isoformat()},Pending,{username},{name},{deliver_form.name},test_form2,b\r\n"
     )
 
 


### PR DESCRIPTION
- Add jsonpath for assessment modules (missed in the last PR)
- Add `user.username` as the display instead of `user.name`, as `user.name` is not set for ConnectID users