### PR TITLE
add trailing slash and correct data

### DIFF
--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -20,12 +20,12 @@ def get_organization_for_request(request, view_kwargs):
 
 
 def create_hq_user(user, domain, api_key):
-    mobile_worker_api_url = f"{settings.COMMCARE_HQ_URL}/a/{domain}/api/v0.5/user"
+    mobile_worker_api_url = f"{settings.COMMCARE_HQ_URL}/a/{domain}/api/v0.5/user/"
     hq_request = requests.post(
         mobile_worker_api_url,
-        data={
+        json={
             "username": user.username,
-            "connect_user": user.username,
+            "connect_username": user.username,
         },
         headers={"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"},
     )


### PR DESCRIPTION
Without the trailing slash the request was redirecting to a GET