### PR TITLE
use lowered usernames to match hq

### DIFF
--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -71,6 +71,6 @@ class ClaimOpportunityView(APIView):
             if not user_created:
                 return Response("Failed to create user", status=400)
             ConnectIDUserLink.objects.create(
-                commcare_username=self.request.user.username, user=self.request.user, domain=domain
+                commcare_username=self.request.user.username.lower(), user=self.request.user, domain=domain
             )
         return Response(status=201)

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -98,7 +98,9 @@ def start_learn_app(request):
         user_created = create_hq_user(request.user, domain, api_key)
         if not user_created:
             return HttpResponse("Failed to create user", status=400)
-        ConnectIDUserLink.objects.create(commcare_username=request.user.username, user=request.user, domain=domain)
+        ConnectIDUserLink.objects.create(
+            commcare_username=request.user.username.lower(), user=request.user, domain=domain
+        )
     try:
         access_object = OpportunityAccess.objects.get(user=request.user, opportunity=opportunity)
     except OpportunityAccess.DoesNotExist:


### PR DESCRIPTION
Usernames in hq are lowercased. This ensures they are stored correctly in the user link model