### PR TITLE
switch to update and move non unique values to defaults

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -40,8 +40,8 @@ def add_connect_users(user_list: list[str], opportunity_id: str):
     )
     data = result.json()
     for user in data["found_users"]:
-        u, _ = User.objects.get_or_create(
-            username=user["username"], phone_number=user["phone_number"], name=user["name"]
+        u, _ = User.objects.update_or_create(
+            username=user["username"], defaults={"phone_number": user["phone_number"], "name": user["name"]}
         )
         opportunity_access, _ = OpportunityAccess.objects.get_or_create(user=u, opportunity_id=opportunity_id)
         invite_user(u, opportunity_access)


### PR DESCRIPTION
Some users in the db did not have a name previously, this was creating errors when they were added to new opportunities, as the `get` was failing, but `create` violated the unique username constraint. This limits the searching to the unique fields, as well as allowing updates if name or phone number change in connectid.