### PR TITLE
Add opportunity filter to completed modules

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -161,7 +161,9 @@ class OpportunityAccess(models.Model):
     @property
     def learn_progress(self):
         learn_modules = LearnModule.objects.filter(app=self.opportunity.learn_app)
-        completed_modules = CompletedModule.objects.filter(module__in=learn_modules).count()
+        completed_modules = CompletedModule.objects.filter(
+            opportunity=self.opportunity, module__in=learn_modules
+        ).count()
         percentage = (completed_modules / learn_modules.count()) * 100
         return round(percentage, 2)
 


### PR DESCRIPTION
[Bug Ticket](https://dimagi-dev.atlassian.net/browse/CCPC-134)

- The completed modules queryset did not filter by opportunity and it led a wrong count being shown on opportunity details page learn progress section.