### PR TITLE
set default protocol

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -131,3 +131,5 @@ SPECTACULAR_SETTINGS["SERVERS"] = [  # noqa: F405
 ]
 # Your stuff...
 # ------------------------------------------------------------------------------
+
+DEFAULT_HTTP_PROTOCOL = "https"

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -110,3 +110,5 @@ SPECTACULAR_SETTINGS["SERVERS"] = [  # noqa: F405
 # CommCareConnect
 # ------------------------------------------------------------------------------
 CSRF_TRUSTED_ORIGINS = ["https://*.127.0.0.1"] + env.list("CSRF_TRUSTED_ORIGINS", default=[])
+
+DEFAULT_HTTP_PROTOCOL = "https"


### PR DESCRIPTION
This is used by `allauth` in the `build_absolute_uri` and will cause it to use `https` instead of `http`. It looks like the `sites` framework expects the URL to lack a protocol, so I will remove that as well as part of this change.

Right now the constructed URLs begin `http://https://` with `https` coming from the URL in the `Site` object, and `http` coming from `allauth`