### PR TITLE
repeater fixes

### DIFF
--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -86,7 +86,6 @@ class ClaimOpportunityView(APIView):
             user_created = create_hq_user(self.request.user, domain, opportunity.api_key)
             if not user_created:
                 return Response("Failed to create user", status=400)
-            ConnectIDUserLink.objects.create(
-                commcare_username=self.request.user.username.lower(), user=self.request.user, domain=domain
-            )
+            cc_username = f"{self.request.user.username.lower()}@{domain}.commcarehq.org"
+            ConnectIDUserLink.objects.create(commcare_username=cc_username, user=self.request.user, domain=domain)
         return Response(status=201)

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -98,9 +98,8 @@ def start_learn_app(request):
         user_created = create_hq_user(request.user, domain, api_key)
         if not user_created:
             return HttpResponse("Failed to create user", status=400)
-        ConnectIDUserLink.objects.create(
-            commcare_username=request.user.username.lower(), user=request.user, domain=domain
-        )
+        cc_username = f"{request.user.username.lower()}@{domain}.commcarehq.org"
+        ConnectIDUserLink.objects.create(commcare_username=cc_username, user=request.user, domain=domain)
     try:
         access_object = OpportunityAccess.objects.get(user=request.user, opportunity=opportunity)
     except OpportunityAccess.DoesNotExist:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -309,6 +309,7 @@ CONNECTID_CLIENT_ID = env("cid_client_id", default="")
 CONNECTID_CLIENT_SECRET = env("cid_client_secret", default="")
 
 OAUTH2_PROVIDER = {
+    "ACCESS_TOKEN_EXPIRE_SECONDS": "1209600",  # seconds in two weeks
     "RESOURCE_SERVER_INTROSPECTION_URL": f"{CONNECTID_URL}/o/introspect/",
     "RESOURCE_SERVER_INTROSPECTION_CREDENTIALS": (
         CONNECTID_CLIENT_ID,


### PR DESCRIPTION
This pr fixes 2 issues related to repeaters sending data from HQ.

1) HQ doesn't handle refresh tokens correctly for client credentials auth. This sidesteps the issue while I figure out the root cause by extending the length of access tokens.
2) Matching forms to users relies on full usernames, not the short part, which we were not saving.