### PR TITLE
payment updates

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -64,11 +64,11 @@ def _schema_sort(item):
 
 
 def export_empty_payment_table(opportunity: Opportunity) -> Dataset:
-    headers = ["Phone Number", "Name", "Payment Amount"]
+    headers = ["Username", "Phone Number", "Name", "Payment Amount"]
     dataset = Dataset(title="Export", headers=headers)
 
     access_objects = OpportunityAccess.objects.filter(opportunity=opportunity).select_related("user")
     for access in access_objects:
-        row = (access.user.phone_number, access.user.name, "")
+        row = (access.user.username, access.user.phone_number, access.user.name, "")
         dataset.append(row)
     return dataset

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -5,7 +5,6 @@ from commcare_connect.opportunity.models import OpportunityAccess, Payment, User
 
 class OpportunityAccessTable(tables.Table):
     learn_progress = columns.Column(verbose_name="Modules Completed")
-    last_visit_date = columns.DateColumn(accessor="last_visit_date", default="N/A")
     details = columns.LinkColumn(
         "opportunity:user_learn_progress",
         verbose_name="",
@@ -15,7 +14,7 @@ class OpportunityAccessTable(tables.Table):
 
     class Meta:
         model = OpportunityAccess
-        fields = ("user.username", "learn_progress", "visit_count")
+        fields = ("user.username", "learn_progress")
         orderable = False
         empty_text = "No learn progress for users."
 
@@ -52,7 +51,7 @@ class UserVisitTable(tables.Table):
 class PaymentTable(tables.Table):
     class Meta:
         model = Payment
-        fields = ("user.username", "amount", "date_paid")
+        fields = ("opportunity_access.user.name", "opportunity_access.user.username", "amount", "date_paid")
         orderable = False
         empty_text = "No payments"
 

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -179,7 +179,7 @@
         <div class="tab-pane fade" id="payment-tab-pane" role="tabpanel" aria-labelledby="payment-tab" tabindex="0">
           <div hx-get="{% url "opportunity:payment_table" org_slug=request.org.slug pk=opportunity.pk %}{% querystring %}"
                hx-trigger="load" hx-swap="outerHTML">
-            {% include "tables/table_placeholder.html" with num_cols=2 %}
+            {% include "tables/table_placeholder.html" with num_cols=4 %}
           </div>
         </div>
         <div class="tab-pane fade" id="user-status-tab-pane" role="tabpanel" aria-labelledby="user-status-tab" tabindex="0">
@@ -295,7 +295,7 @@
             <div class="col-auto">
               <span id="importFileHelp" class="form-text">
                 {% blocktrans %}
-                  The file must contain at least the "Phone Number" and "Amount" column.
+                  The file must contain at least the "Username" and "Amount" column.
                 {% endblocktrans %}
               </span>
             </div>


### PR DESCRIPTION
This mostly changes payment import/export to anchor on the username rather than phone number, since that is what most of our other views show, but it also tries to clean up the other tabs in the opportunity details page (removing visit dates and counts from the learn progress table).