### PR TITLE
Update deploy.yml

### DIFF
--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -22,7 +22,7 @@ servers:
 healthcheck:
   path: /
   port: 8000
-  max_attempts: 10
+  max_attempts: 20
   interval: 20s
 
 ssh:


### PR DESCRIPTION
At least 50% of my deploys fail during the health check and require manual intervention to finally go through. I have noticed that deploys that succeed tend to get right up to the limit of these attempts (seeing success on the 9th and 10th checks), and those that fail would pass by the time I am able to log into the machine. Extending the max number of tries should allow more of the deploys to go through, and doesn't seem to have a downside (if it passes earlier it still continues on).