### PR TITLE
tabbed table pagination

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -72,6 +72,7 @@ class UserPaymentsTable(tables.Table):
         fields = ("amount", "date_paid")
         orderable = False
         empty_text = "No payments made for this user"
+        template_name = "django_tables2/bootstrap5.html"
 
 
 class UserStatusTable(tables.Table):

--- a/commcare_connect/templates/tables/tabbed_table.html
+++ b/commcare_connect/templates/tables/tabbed_table.html
@@ -1,0 +1,45 @@
+{% extends "django_tables2/bootstrap5.html" %}
+{% load django_tables2 %}
+{% load i18n %}
+
+{% block pagination %}
+{% if table.page and table.paginator.num_pages > 1 %}
+<nav aria-label="Table navigation">
+  <ul class="pagination justify-content-center">
+    {% if table.page.has_previous %}
+    {% block pagination.previous %}
+    <li class="previous page-item">
+      <div hx-get="{{ request.path }}{% querystring table.prefixed_page_field=table.page.previous_page_number %}"
+           hx-trigger="click" hx-swap="outerHTML" hx-target="closest .table-container" class="page-link">
+        <span aria-hidden="true">&laquo;</span>
+        {% trans 'previous' %}
+      </div>
+    </li>
+    {% endblock pagination.previous %}
+    {% endif %}
+    {% if table.page.has_previous or table.page.has_next %}
+    {% block pagination.range %}
+    {% for p in table.page|table_page_range:table.paginator %}
+    <li class="page-item{% if table.page.number == p %} active{% endif %}">
+      <div class="page-link" {% if p != '...' %}hx-get="{{ request.path }}{% querystring table.prefixed_page_field=p %}"
+           hx-trigger="click" hx-swap="outerHTML" hx-target="closest .table-container"{% endif %}>
+        {{ p }}
+      </div>
+    </li>
+    {% endfor %}
+    {% endblock pagination.range %}
+    {% endif %}
+    {% if table.page.has_next %}
+    {% block pagination.next %}
+    <li class="next page-item">
+      <div hx-get="{{ request.path }}{% querystring table.prefixed_page_field=table.page.next_page_number %}" hx-trigger="click" hx-swap="outerHTML" hx-target="closest .table-container" class="page-link">
+        {% trans 'next' %}
+        <span aria-hidden="true">&raquo;</span>
+      </div>
+    </li>
+    {% endblock pagination.next %}
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}
+{% endblock pagination %}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -290,7 +290,7 @@ CACHES = {
     }
 }
 
-DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
+DJANGO_TABLES2_TEMPLATE = "tables/tabbed_table.html"
 DJANGO_TABLES2_TABLE_ATTRS = {
     "class": "table border table-custom",
     "thead": {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/CCPC-161
This should be a fix for the above ticket. It replaces the default pagination controls in the django tables template with custom ones using htmx that take into account our tabbed table setup, by reloading only the relevant table when a pagination control is selected.

This is mostly just copying the pagination block from the [template](https://github.com/jieter/django-tables2/blob/master/django_tables2/templates/django_tables2/bootstrap5.html#L57-L95) we were previously using, and replacing the `<a>` tags with htmx gets that replace the ancestor table element.