### PR TITLE
Fix visit import failing on Over Limit status

### DIFF
--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -125,7 +125,7 @@ def get_status_by_visit_id(dataset) -> dict[int, VisitValidationStatus]:
     for row in dataset:
         row = list(row)
         visit_id = str(row[visit_col_index])
-        status_raw = row[status_col_index].lower()
+        status_raw = row[status_col_index].lower().replace(" ", "_")
         try:
             status_by_visit_id[visit_id] = VisitValidationStatus[status_raw]
         except KeyError:


### PR DESCRIPTION
[QA Bug Ticket](https://dimagi-dev.atlassian.net/browse/QA-5741)

Visit Import were failing when the any of the visits had the Over Limit status. The code that converted the visit status converted Over Limit status to "over limit" without the _ in between. This was causing the import to show that some rows have errors. For the fix i have added a replace method to the status_raw string to replace all the spaces with "_".