### PR TITLE
update deliver api to exclude over limit and add end date

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -11,6 +11,7 @@ from commcare_connect.opportunity.models import (
     OpportunityClaim,
     Payment,
     UserVisit,
+    VisitValidationStatus,
 )
 
 
@@ -131,10 +132,13 @@ class DeliveryProgressSerializer(serializers.Serializer):
     payments = serializers.SerializerMethodField()
     max_payments = serializers.IntegerField(source="opportunityclaim.max_payments")
     payment_accrued = serializers.IntegerField()
+    end_date = serializers.DateField(source="opportunityclaim.end_date")
 
     def get_payments(self, obj):
         return PaymentSerializer(obj.payment_set.all(), many=True).data
 
     def get_deliveries(self, obj):
-        deliveries = UserVisit.objects.filter(opportunity=obj.opportunity, user=obj.user)
+        deliveries = UserVisit.objects.filter(opportunity=obj.opportunity, user=obj.user).exclude(
+            status=VisitValidationStatus.over_limit
+        )
         return UserVisitSerializer(deliveries, many=True).data


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-5740
https://dimagi-dev.atlassian.net/browse/QA-5737

This updates the deliver API to fix two bugs. It adds the user specific end date and excludes visit that exceeded the daily limit from the progress counts.