### PR TITLE
Fix opportunity list pagination

### DIFF
--- a/commcare_connect/templates/opportunity/opportunity_list.html
+++ b/commcare_connect/templates/opportunity/opportunity_list.html
@@ -52,7 +52,7 @@
       </tbody>
     </table>
 
-    {% if page_obj.num_pages > 1 %}
+    {% if page_obj.has_other_pages %}
       <nav aria-label="Page navigation">
         <ul class="pagination justify-content-center">
           {% if page_obj.has_previous %}


### PR DESCRIPTION
Pagination for opportunity list was not loading due to an incorrect check.