### PR TITLE
remove payment name

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -65,8 +65,6 @@ class OpportunityPaymentTable(tables.Table):
 
 
 class UserPaymentsTable(tables.Table):
-    payment_unit_name = columns.Column("Payment Unit Name", accessor="payment_unit.name")
-
     class Meta:
         model = Payment
         fields = ("amount", "date_paid")


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-5755

There is no way to associate payment units with payments so I am removing that column from the table.