### PR TITLE
hide name until accepted

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -192,6 +192,13 @@ class OpportunityAccess(models.Model):
     def total_paid(self):
         return Payment.objects.filter(opportunity_access=self).aggregate(total=Sum("amount")).get("total", 0)
 
+    @property
+    def display_name(self):
+        if self.accepted:
+            return self.user.name
+        else:
+            return "---"
+
 
 class PaymentUnit(models.Model):
     opportunity = models.ForeignKey(Opportunity, on_delete=models.PROTECT)

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -5,6 +5,7 @@ from commcare_connect.opportunity.models import OpportunityAccess, Payment, Paym
 
 
 class OpportunityAccessTable(tables.Table):
+    display_name = columns.Column(verbose_name="Name")
     learn_progress = columns.Column(verbose_name="Modules Completed")
     details = columns.LinkColumn(
         "opportunity:user_learn_progress",
@@ -15,7 +16,7 @@ class OpportunityAccessTable(tables.Table):
 
     class Meta:
         model = OpportunityAccess
-        fields = ("user.name", "user.username", "learn_progress")
+        fields = ("display_name", "user.username", "learn_progress")
         orderable = False
         empty_text = "No learn progress for users."
 
@@ -74,9 +75,11 @@ class UserPaymentsTable(tables.Table):
 
 
 class UserStatusTable(tables.Table):
+    display_name = columns.Column(verbose_name="Name")
+
     class Meta:
         model = OpportunityAccess
-        fields = ("user.name", "user.username", "accepted")
+        fields = ("display_name", "user.username", "accepted")
         empty_text = "No users invited for this opportunity."
         orderable = False
 


### PR DESCRIPTION
This makes the opportunity invite acceptance workflow actually have the intended effect of serving as a consent barrier for personal info. User's who have not accepted will have their names blanked for status until they do. This still allows personal info to bleed through once you submit delivery forms, but since that point is when payment gets involved as well as manual verification of work, that seems necessary.