### PR TITLE
budget updates

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -87,13 +87,16 @@ class OpportunityCreationForm(forms.ModelForm):
             Row(Field("description")),
             Row(Field("end_date")),
             Row(
-                Field("max_visits_per_user", wrapper_class="form-group col-md-6 mb-0"),
-                Field("daily_max_visits_per_user", wrapper_class="form-group col-md-6 mb-0"),
+                Field("max_visits_per_user", wrapper_class="form-group col-md-4 mb-0", x_model="maxVisits"),
+                Field("daily_max_visits_per_user", wrapper_class="form-group col-md-4 mb-0"),
+                Field("budget_per_visit", wrapper_class="form-group col-md-4 mb-0", x_model="visitBudget"),
             ),
             Row(
-                Field("currency", wrapper_class="form-group col-md-2 mb-0"),
-                Field("total_budget", wrapper_class="form-group col-md-5 mb-0"),
-                Field("budget_per_visit", wrapper_class="form-group col-md-5 mb-0"),
+                Field("max_users", wrapper_class="form-group col-md-4 mb-0", x_model="maxUsers"),
+                Field(
+                    "total_budget", wrapper_class="form-group col-md-4 mb-0", disabled=True, x_model="totalBudget()"
+                ),
+                Field("currency", wrapper_class="form-group col-md-4 mb-0"),
             ),
             Row(Field("learn_app")),
             Row(Field("learn_app_description")),
@@ -111,6 +114,7 @@ class OpportunityCreationForm(forms.ModelForm):
         self.fields["deliver_app"] = forms.ChoiceField(choices=app_choices)
         self.fields["deliver_app"].widget.attrs.update({"id": "deliver_app_select"})
         self.fields["api_key"] = forms.CharField(max_length=50)
+        self.fields["max_users"] = forms.IntegerField()
 
     def clean(self):
         cleaned_data = super().clean()

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -23,6 +23,7 @@ class TestOpportunityCreationForm:
             "daily_max_visits_per_user": 10,
             "total_budget": 100,
             "budget_per_visit": 10,
+            "max_users": 10,
             "learn_app": self.learn_app["id"],
             "learn_app_description": FuzzyText(length=150).fuzz(),
             "learn_app_passing_score": random.randint(30, 100),

--- a/commcare_connect/templates/opportunity/opportunity_create.html
+++ b/commcare_connect/templates/opportunity/opportunity_create.html
@@ -7,7 +7,14 @@
 {% block content %}
   <div class="container">
     <h1 class="display-5">Create Opportunity</h1>
-    <form method="post">
+    <form method="post"
+          x-data="{
+            visitBudget: 0,
+            maxUsers: 0,
+            maxVisits: 0,
+            totalBudget() {return this.visitBudget * this.maxUsers * this.maxVisits}
+          }"
+          >
       {% csrf_token %}
       {% crispy form %}
     </form>

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -105,6 +105,7 @@ def start_learn_app(request):
     except OpportunityAccess.DoesNotExist:
         return HttpResponse("user has no access to opportunity", status=400)
     access_object.date_learn_started = datetime.utcnow()
+    access_object.accepted = True
     access_object.save()
     return HttpResponse(status=200)
 


### PR DESCRIPTION

The two commits in this PR address two issues
1) As seen in the screenshot below, it adds a new field of "max users" and automatically calculates the total budget so users do not need a calculator. It does not change anything on the backend, and we still only store the total budget.
2) Marks an opportunity as accepted when the user starts learning. This aligns with common sense understandings of what it means to accept an opportunity, and will be reflected in new language in the mobile UI indicating that starting learning consents to sharing the user info (in this case just name) with the project.

![image](https://github.com/dimagi/commcare-connect/assets/6844721/61618c07-a0bd-4f55-87ce-261f62f367ee)
