### PR TITLE
switch to readonly

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -96,7 +96,10 @@ class OpportunityCreationForm(forms.ModelForm):
             Row(
                 Field("max_users", wrapper_class="form-group col-md-4 mb-0", x_model="maxUsers"),
                 Field(
-                    "total_budget", wrapper_class="form-group col-md-4 mb-0", disabled=True, x_model="totalBudget()"
+                    "total_budget",
+                    wrapper_class="form-group col-md-4 mb-0",
+                    readonly=True,
+                    x_model="totalBudget()",
                 ),
                 Field("currency", wrapper_class="form-group col-md-4 mb-0"),
             ),
@@ -116,6 +119,7 @@ class OpportunityCreationForm(forms.ModelForm):
         self.fields["deliver_app"] = forms.ChoiceField(choices=app_choices)
         self.fields["deliver_app"].widget.attrs.update({"id": "deliver_app_select"})
         self.fields["api_key"] = forms.CharField(max_length=50)
+        self.fields["total_budget"].widget.attrs.update({"class": "form-control-plaintext"})
         self.fields["max_users"] = forms.IntegerField()
 
     def clean(self):


### PR DESCRIPTION
It turns out disabled fields are not submitted on form submission. This arguably makes the UI a little worse, but keeps the form data, and is still clear that field is not editable.

![image](https://github.com/dimagi/commcare-connect/assets/6844721/4319c76c-c894-4f52-bc98-e3a124f580a6)
