### PR TITLE
Add logging to create hq user

### DIFF
--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -36,8 +36,6 @@ def create_hq_user(user, domain, api_key):
         },
         headers={"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"},
     )
-    if hq_request.status_code == 201:
-        return True
     try:
         hq_request.raise_for_status()
     except httpx.HTTPStatusError as e:
@@ -45,7 +43,7 @@ def create_hq_user(user, domain, api_key):
             f"{e.response.status_code} Error response {e.response.text} while creating user {user.username}"
         )
 
-    return False
+    return hq_request.status_code == 201
 
 
 def invite_user(user, opportunity_access):

--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -1,6 +1,4 @@
-import logging
-
-import requests
+import httpx
 from allauth.utils import build_absolute_uri
 from django.conf import settings
 from django.urls import reverse
@@ -9,6 +7,7 @@ from django.utils.translation import gettext
 from commcare_connect.connect_id_client import send_message
 from commcare_connect.connect_id_client.models import Message
 from commcare_connect.organization.models import Organization
+from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 from commcare_connect.utils.sms import send_sms
 
 
@@ -29,7 +28,7 @@ def get_organization_for_request(request, view_kwargs):
 
 def create_hq_user(user, domain, api_key):
     mobile_worker_api_url = f"{settings.COMMCARE_HQ_URL}/a/{domain}/api/v0.5/user/"
-    hq_request = requests.post(
+    hq_request = httpx.post(
         mobile_worker_api_url,
         json={
             "username": user.username,
@@ -39,7 +38,13 @@ def create_hq_user(user, domain, api_key):
     )
     if hq_request.status_code == 201:
         return True
-    logging.info(f"Create User Response: {hq_request.text}")
+    try:
+        hq_request.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        raise CommCareHQAPIException(
+            f"{e.response.status_code} Error response {e.response.text} while creating user {user.username}"
+        )
+
     return False
 
 

--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 from allauth.utils import build_absolute_uri
 from django.conf import settings
@@ -37,6 +39,7 @@ def create_hq_user(user, domain, api_key):
     )
     if hq_request.status_code == 201:
         return True
+    logging.info(f"Create User Response: {hq_request.text}")
     return False
 
 


### PR DESCRIPTION
Create HQ User currently does not log anything when the api request return any status other than 201.
This PR adds logging to the function in case the api return an error.