### PR TITLE
Fix randomly failing test for Claim API Endpoint

### DIFF
--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -76,6 +76,8 @@ class ClaimOpportunityView(APIView):
         opportunity_access = get_object_or_404(OpportunityAccess, user=self.request.user, opportunity=kwargs.get("pk"))
         opportunity = opportunity_access.opportunity
 
+        if OpportunityClaim.objects.filter(opportunity_access=opportunity_access).exists():
+            return Response(status=200, data="Opportunity is already claimed")
         if opportunity.remaining_budget <= 0:
             return Response(status=200, data="Opportunity cannot be claimed. (Budget Exhausted)")
         if opportunity.end_date < datetime.date.today():


### PR DESCRIPTION
This PR fixes the test for Claim API endpoint failing only sometimes causing PR to show a test failure which goes away on subsequent runs. 
This test requests the Claim API endpoint twice to validate that the `Opportunity is Already Claimed` error status is returned. In this case the test status that came back were randomized as the Opportunity Factory sometimes assigns budget which is smaller that the budget required for the max_payments which are claimed by a User and it led to a different status to be returned leading to test failure.