### PR TITLE
return 400 for bad claim and update max_payment logic

### DIFF
--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -78,12 +78,14 @@ class ClaimOpportunityView(APIView):
 
         if OpportunityClaim.objects.filter(opportunity_access=opportunity_access).exists():
             return Response(status=200, data="Opportunity is already claimed")
-        if opportunity.remaining_budget <= 0:
-            return Response(status=200, data="Opportunity cannot be claimed. (Budget Exhausted)")
+        if opportunity.remaining_budget < opportunity.budget_per_visit:
+            return Response(status=400, data="Opportunity cannot be claimed. (Budget Exhausted)")
         if opportunity.end_date < datetime.date.today():
-            return Response(status=200, data="Opportunity cannot be claimed. (End date reached)")
+            return Response(status=400, data="Opportunity cannot be claimed. (End date reached)")
 
-        max_payments = min(opportunity.remaining_budget, opportunity.max_visits_per_user)
+        max_payments = min(
+            opportunity.remaining_budget // opportunity.budget_per_visit, opportunity.max_visits_per_user
+        )
         claim, created = OpportunityClaim.objects.get_or_create(
             opportunity_access=opportunity_access,
             defaults={

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -96,8 +96,7 @@ def test_claim_endpoint_uneven_visits(mobile_user: User, api_client: APIClient):
     api_client.force_authenticate(mobile_user)
     response = api_client.post(f"/api/opportunity/{opportunity.id}/claim")
     assert response.status_code == 201
-    claim = OpportunityClaim.objects.filter(opportunity_access=opportunity_access)
-    assert claim.exists()
+    claim = OpportunityClaim.objects.get(opportunity_access=opportunity_access)
     assert claim.max_payments == 1
 
 

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -13,10 +13,9 @@ from commcare_connect.users.models import User
 from commcare_connect.users.tests.factories import ConnectIdUserLinkFactory
 
 
-def _setup_opportunity_and_access(mobile_user: User, total_budget, end_date, claimed_budget=0, budget_per_visit=10):
+def _setup_opportunity_and_access(mobile_user: User, total_budget, end_date, budget_per_visit=10):
     opportunity = OpportunityFactory(
         total_budget=total_budget,
-        claimed_budget=claimed_budget,
         max_visits_per_user=100,
         end_date=end_date,
         budget_per_visit=budget_per_visit,
@@ -77,9 +76,8 @@ def test_claim_endpoint_already_claimed_opportunity(mobile_user: User, api_clien
 def test_claim_endpoint_less_budget_than_visit(mobile_user: User, api_client: APIClient):
     opportunity, opportunity_access = _setup_opportunity_and_access(
         mobile_user,
-        total_budget=10,
+        total_budget=1,
         end_date=datetime.date.today() + datetime.timedelta(days=100),
-        claimed_budget=9,
         budget_per_visit=2,
     )
     api_client.force_authenticate(mobile_user)
@@ -91,9 +89,8 @@ def test_claim_endpoint_less_budget_than_visit(mobile_user: User, api_client: AP
 def test_claim_endpoint_uneven_visits(mobile_user: User, api_client: APIClient):
     opportunity, opportunity_access = _setup_opportunity_and_access(
         mobile_user,
-        total_budget=10,
+        total_budget=3,
         end_date=datetime.date.today() + datetime.timedelta(days=100),
-        claimed_budget=7,
         budget_per_visit=2,
     )
     api_client.force_authenticate(mobile_user)

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -13,8 +13,14 @@ from commcare_connect.users.models import User
 from commcare_connect.users.tests.factories import ConnectIdUserLinkFactory
 
 
-def _setup_opportunity_and_access(mobile_user: User, total_budget, end_date):
-    opportunity = OpportunityFactory(total_budget=total_budget, max_visits_per_user=100, end_date=end_date)
+def _setup_opportunity_and_access(mobile_user: User, total_budget, end_date, claimed_budget=0, budget_per_visit=10):
+    opportunity = OpportunityFactory(
+        total_budget=total_budget,
+        claimed_budget=claimed_budget,
+        max_visits_per_user=100,
+        end_date=end_date,
+        budget_per_visit=budget_per_visit,
+    )
     opportunity_access = OpportunityAccessFactory(opportunity=opportunity, user=mobile_user)
     ConnectIdUserLinkFactory(
         user=mobile_user, commcare_username="test@ccc-test.commcarehq.org", domain=opportunity.deliver_app.cc_domain
@@ -39,7 +45,7 @@ def test_claim_endpoint_budget_exhausted(mobile_user: User, api_client: APIClien
     )
     api_client.force_authenticate(mobile_user)
     response = api_client.post(f"/api/opportunity/{opportunity.id}/claim")
-    assert response.status_code == 200
+    assert response.status_code == 400
     assert response.data == "Opportunity cannot be claimed. (Budget Exhausted)"
 
 
@@ -49,7 +55,7 @@ def test_claim_endpoint_end_date_exceeded(mobile_user: User, api_client: APIClie
     )
     api_client.force_authenticate(mobile_user)
     response = api_client.post(f"/api/opportunity/{opportunity.id}/claim")
-    assert response.status_code == 200
+    assert response.status_code == 400
     assert response.data == "Opportunity cannot be claimed. (End date reached)"
 
 
@@ -66,6 +72,36 @@ def test_claim_endpoint_already_claimed_opportunity(mobile_user: User, api_clien
     response = api_client.post(f"/api/opportunity/{opportunity.id}/claim")
     assert response.status_code == 200
     assert response.data == "Opportunity is already claimed"
+
+
+def test_claim_endpoint_less_budget_than_visit(mobile_user: User, api_client: APIClient):
+    opportunity, opportunity_access = _setup_opportunity_and_access(
+        mobile_user,
+        total_budget=10,
+        end_date=datetime.date.today() + datetime.timedelta(days=100),
+        claimed_budget=9,
+        budget_per_visit=2,
+    )
+    api_client.force_authenticate(mobile_user)
+    response = api_client.post(f"/api/opportunity/{opportunity.id}/claim")
+    assert response.status_code == 400
+    assert response.data == "Opportunity cannot be claimed. (Budget Exhausted)"
+
+
+def test_claim_endpoint_uneven_visits(mobile_user: User, api_client: APIClient):
+    opportunity, opportunity_access = _setup_opportunity_and_access(
+        mobile_user,
+        total_budget=10,
+        end_date=datetime.date.today() + datetime.timedelta(days=100),
+        claimed_budget=7,
+        budget_per_visit=2,
+    )
+    api_client.force_authenticate(mobile_user)
+    response = api_client.post(f"/api/opportunity/{opportunity.id}/claim")
+    assert response.status_code == 201
+    claim = OpportunityClaim.objects.filter(opportunity_access=opportunity_access)
+    assert claim.exists()
+    assert claim.max_payments == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This fixes 2 bugs in the claim workflows

1) The claim logic was mixing up budgetary limits and visit limits so this fixes that comparison to only use the same units (visits/payments in this case).
2) The API was returning 200 even when the claim failed so mobile assumed it succeeded. These now return 400