### PR TITLE
Fix additional visits save to opportunity total budget

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -284,6 +284,8 @@ def add_budget_existing_users(request, org_slug=None, pk=None):
             OpportunityClaim.objects.filter(pk__in=selected_users).update(
                 max_payments=F("max_payments") + additional_visits, end_date=end_date
             )
+            opportunity.total_budget += additional_visits * opportunity.budget_per_visit * len(selected_users)
+            opportunity.save()
             return redirect("opportunity:detail", org_slug, pk)
 
     return render(

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -279,11 +279,10 @@ def add_budget_existing_users(request, org_slug=None, pk=None):
         if form.is_valid():
             selected_users = form.cleaned_data["selected_users"]
             additional_visits = form.cleaned_data["additional_visits"]
+            update_kwargs = {"max_payments": F("max_payments") + additional_visits}
             if form.cleaned_data["end_date"]:
-                end_date = form.cleaned_data["end_date"]
-            OpportunityClaim.objects.filter(pk__in=selected_users).update(
-                max_payments=F("max_payments") + additional_visits, end_date=end_date
-            )
+                update_kwargs.update({"end_date": form.cleaned_data["end_date"]})
+            OpportunityClaim.objects.filter(pk__in=selected_users).update(**update_kwargs)
             opportunity.total_budget += additional_visits * opportunity.budget_per_visit * len(selected_users)
             opportunity.save()
             return redirect("opportunity:detail", org_slug, pk)


### PR DESCRIPTION
This PR fixes two bugs in Opportuntiy Add budget to exisiting users workflow.
1. Additional visits assigned to users were not added to the total budget for the opportunity
2. When no end date was selected by users the end_date was unbound and led to an error.