### PR TITLE
add defaults to avoid sending nulls

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -26,8 +26,8 @@ class CommCareAppSerializer(serializers.ModelSerializer):
     organization = serializers.SlugRelatedField(read_only=True, slug_field="slug")
     learn_modules = LearnModuleSerializer(many=True)
     install_url = serializers.SerializerMethodField()
-    passing_score = serializers.IntegerField(source="passing_score", default=-1)
-    description = serializers.CharField(source="description", default="")
+    passing_score = serializers.IntegerField(default=-1)
+    description = serializers.CharField(default="")
 
     class Meta:
         model = CommCareApp

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -26,6 +26,8 @@ class CommCareAppSerializer(serializers.ModelSerializer):
     organization = serializers.SlugRelatedField(read_only=True, slug_field="slug")
     learn_modules = LearnModuleSerializer(many=True)
     install_url = serializers.SerializerMethodField()
+    passing_score = serializers.IntegerField(source="passing_score", default=-1)
+    description = serializers.CharField(source="description", default="")
 
     class Meta:
         model = CommCareApp


### PR DESCRIPTION
Mobile currently chokes on null data. This ensures non null data is always sent for these fields. We can revisit the long term state of these chagnes when the mobile deserialization code is updated.