### PR TITLE
allow superusers to view all orgs

### DIFF
--- a/commcare_connect/organization/decorators.py
+++ b/commcare_connect/organization/decorators.py
@@ -7,7 +7,7 @@ from .models import UserOrganizationMembership
 
 
 def _request_user_is_member(request):
-    return request.org and request.org_membership
+    return (request.org and request.org_membership) or request.user.is_superuser
 
 
 def _request_user_is_admin(request):


### PR DESCRIPTION
I have been wanting this for a while. It will make debugging all the opp issues much easier. This is how hq works, so I think it's fine from a privacy perspective but we can revisit after the launch