### PR TITLE
limit celery memory

### DIFF
--- a/deploy/config/deploy.production.yml
+++ b/deploy/config/deploy.production.yml
@@ -11,6 +11,7 @@ servers:
     options:
       # create by ansible
       env-file: '/home/connect/www/commcare-connect/docker.env'
+      m: 1g
     cmd: /start_celery
     labels:
       traefik.enable: false


### PR DESCRIPTION
This limits the celery docker container to half the memory of the machine, to prevent the OOMs from large exports.