### PR TITLE
sum assessments and skip total

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -1,4 +1,4 @@
-from django.db.models import BooleanField, Case, Count, Max, Min, Q, When
+from django.db.models import Case, Count, Max, Min, Q, Sum, When
 
 from commcare_connect.opportunity.models import Opportunity, OpportunityAccess
 
@@ -13,10 +13,11 @@ def get_annotated_opportunity_access(opportunity: Opportunity):
             date_deliver_started=Min(
                 "user__uservisit__visit_date", filter=Q(user__uservisit__opportunity=opportunity)
             ),
-            passed_assessment=Case(
-                When(Q(user__assessments__opportunity=opportunity, user__assessments__passed=True), then=True),
-                default=False,
-                output_field=BooleanField(),
+            passed_assessment=Sum(
+                Case(
+                    When(Q(user__assessments__opportunity=opportunity, user__assessments__passed=True), then=1),
+                    default=0,
+                )
             ),
             completed_modules_count=Count(
                 "user__completed_modules", filter=Q(user__completed_modules__opportunity=opportunity)

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -75,8 +75,7 @@ class UserPaymentsTable(tables.Table):
 
 
 class AggregateColumn(columns.Column):
-    def render_footer(self, bound_column, table):
-        return sum(1 if bound_column.accessor.resolve(row) else 0 for row in table.data)
+    pass
 
 
 class BooleanAggregateColumn(columns.BooleanColumn, AggregateColumn):


### PR DESCRIPTION
It was making a row for every value of `passed_assessment`, this aggregates all values into 1 by summing. If any assessment has value 1 (meaning it is for the right opportunity and is passed), they will get a true value, otherwise a failing value.