### PR TITLE
Fix user status table export aggregates queries

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.utils.encoding import force_str
 from flatten_dict import flatten
 from tablib import Dataset
@@ -83,5 +85,11 @@ def export_user_status_table(opportunity: Opportunity) -> Dataset:
     headers = [force_str(column.header, strings_only=True) for column in columns]
     dataset = Dataset(title="User status export", headers=headers)
     for row in table.rows:
-        dataset.append([row.get_cell_value(column.name) for column in columns])
+        row_value = []
+        for column in columns:
+            col_value = row.get_cell_value(column.name)
+            if isinstance(col_value, datetime.datetime):
+                col_value = col_value.replace(tzinfo=None)
+            row_value.append(col_value)
+        dataset.append(row_value)
     return dataset

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -22,6 +22,7 @@ def get_annotated_opportunity_access(opportunity: Opportunity):
             completed_modules_count=Count(
                 "user__completed_modules", filter=Q(user__completed_modules__opportunity=opportunity)
             ),
+            job_claimed=Case(When(Q(opportunityclaim__isnull=False), then="opportunityclaim__date_claimed")),
         )
         .annotate(
             date_learn_completed=Case(

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -30,7 +30,9 @@ def get_annotated_opportunity_access(opportunity: Opportunity):
             date_learn_completed=Case(
                 When(
                     Q(completed_modules_count=learn_modules_count),
-                    then=Max("user__completed_modules__date"),
+                    then=Max(
+                        "user__completed_modules__date", filter=Q(user__completed_modules__opportunity=opportunity)
+                    ),
                 )
             )
         )

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -20,7 +20,9 @@ def get_annotated_opportunity_access(opportunity: Opportunity):
                 )
             ),
             completed_modules_count=Count(
-                "user__completed_modules", filter=Q(user__completed_modules__opportunity=opportunity)
+                "user__completed_modules",
+                filter=Q(user__completed_modules__opportunity=opportunity),
+                distinct=True,
             ),
             job_claimed=Case(When(Q(opportunityclaim__isnull=False), then="opportunityclaim__date_claimed")),
         )

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -75,7 +75,8 @@ class UserPaymentsTable(tables.Table):
 
 
 class AggregateColumn(columns.Column):
-    pass
+    def render_footer(self, bound_column, table):
+        return sum(1 if bound_column.accessor.resolve(row) else 0 for row in table.data)
 
 
 class BooleanAggregateColumn(columns.BooleanColumn, AggregateColumn):
@@ -85,7 +86,7 @@ class BooleanAggregateColumn(columns.BooleanColumn, AggregateColumn):
 class UserStatusTable(tables.Table):
     display_name = columns.Column(verbose_name="Name", footer="Total")
     accepted = BooleanAggregateColumn(verbose_name="Accepted")
-    claimed = AggregateColumn(verbose_name="Job Claimed", accessor="opportunityclaim.date_claimed")
+    claimed = AggregateColumn(verbose_name="Job Claimed", accessor="job_claimed")
     started_learning = AggregateColumn(verbose_name="Started Learning", accessor="date_learn_started")
     completed_learning = AggregateColumn(verbose_name="Completed Learning", accessor="date_learn_completed")
     passed_assessment = BooleanAggregateColumn(verbose_name="Passed Assessment")

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from django.utils.timezone import now
 from tablib import Dataset
@@ -103,7 +105,7 @@ def test_export_user_status_table_no_data_only(opportunity: Opportunity):
     mobile_users = MobileUserFactory.create_batch(2)
     rows = []
     for mobile_user in sorted(mobile_users, key=lambda x: x.name):
-        date = now()
+        date = datetime.datetime.now()
         OpportunityAccessFactory(opportunity=opportunity, user=mobile_user, accepted=True, date_learn_started=date)
         rows.append((mobile_user.name, mobile_user.username, True, date, "", False, "", "", ""))
     dataset = export_user_status_table(opportunity)
@@ -117,7 +119,7 @@ def test_export_user_status_table_learn_data_only(opportunity: Opportunity):
     mobile_users = MobileUserFactory.create_batch(2)
     rows = []
     for mobile_user in sorted(mobile_users, key=lambda x: x.name):
-        date = now()
+        date = datetime.datetime.now()
         OpportunityAccessFactory(opportunity=opportunity, user=mobile_user, accepted=True, date_learn_started=date)
         for learn_module in opportunity.learn_app.learn_modules.all()[2:]:
             CompletedModuleFactory(module=learn_module, user=mobile_user, opportunity=opportunity, date=date)
@@ -133,7 +135,7 @@ def test_export_user_status_table_learn_assessment_data_only(opportunity: Opport
     mobile_users = MobileUserFactory.create_batch(2)
     rows = []
     for mobile_user in sorted(mobile_users, key=lambda x: x.name):
-        date = now()
+        date = datetime.datetime.now()
         OpportunityAccessFactory(opportunity=opportunity, user=mobile_user, accepted=True, date_learn_started=date)
         for learn_module in opportunity.learn_app.learn_modules.all():
             CompletedModuleFactory(module=learn_module, user=mobile_user, opportunity=opportunity, date=date)
@@ -150,7 +152,7 @@ def test_export_user_status_table_data(opportunity: Opportunity):
     mobile_users = MobileUserFactory.create_batch(2)
     rows = []
     for mobile_user in sorted(mobile_users, key=lambda x: x.name):
-        date = now()
+        date = datetime.datetime.now()
         access = OpportunityAccessFactory(
             opportunity=opportunity, user=mobile_user, accepted=True, date_learn_started=date
         )


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/CCPC-217)

This PR includes fixes for bugs related to the User Status Table.
- Exports through excel were failing due to date with timezone info, this bug is fixed now and the timestamp are converted to naive date time timestamps.
- The date for Completed learn was not showing up for users due to incorrect completed_modules_count being calculated as the `distinct=True` param was not specified for the Count function.
- Fixed the User Status Table not loading up due to None opportunity claims for users who have not yet claimed the opportunity, which also caused the total column to error.