### PR TITLE
descending order by payment

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -164,7 +164,7 @@ class OpportunityPaymentTableView(OrganizationUserMixin, SingleTableView):
         opportunity_id = self.kwargs["pk"]
         opportunity = get_object_or_404(Opportunity, organization=self.request.org, id=opportunity_id)
         return OpportunityAccess.objects.filter(opportunity=opportunity, payment_accrued__gte=0).order_by(
-            "payment_accrued"
+            "-payment_accrued"
         )
 
 


### PR DESCRIPTION
This page is currently ordered in ascending order (those who have accrued the least payment first). This reverses the ordering so the most active users appear first instead of last.