### PR TITLE
reorganize vars and add sentry env

### DIFF
--- a/deploy/production.inventory.yml
+++ b/deploy/production.inventory.yml
@@ -1,12 +1,11 @@
 webservers:
   hosts:
     web0:
-      ansible_user: ubuntu
       ansible_host: 54.146.23.50
-      secrets_file: 'Ansible Secrets - Production'
-      commcare_hq_url: 'https://www.commcarehq.org'
     celery0:
-      ansible_user: ubuntu
       ansible_host: 54.166.178.28
+    vars:
+      ansible_user: ubuntu
       secrets_file: 'Ansible Secrets - Production'
       commcare_hq_url: 'https://www.commcarehq.org'
+      sentry_environment: 'production'


### PR DESCRIPTION
This will stop all of our sentry issues from saying they are in the `staging` env, and does a minor refactor of ansible variables