### PR TITLE
user already created

### DIFF
--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -39,6 +39,8 @@ def create_hq_user(user, domain, api_key):
     try:
         hq_request.raise_for_status()
     except httpx.HTTPStatusError as e:
+        if e.response.status_code == 400 and "already exists" in e.response.text:
+            return True
         raise CommCareHQAPIException(
             f"{e.response.status_code} Error response {e.response.text} while creating user {user.username}"
         )

--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -35,6 +35,7 @@ def create_hq_user(user, domain, api_key):
             "connect_username": user.username,
         },
         headers={"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"},
+        timeout=10,
     )
     try:
         hq_request.raise_for_status()


### PR DESCRIPTION
This solves two related problems that blocked some users for the additional opportunities.

First, the change to `httpx` in https://github.com/dimagi/commcare-connect/pull/196/files created a very short timeout (5 seconds) for the create user call. This lengthens in a but to try to prevent httpx from giving up on the call, something that can still result in the user being created on HQ, but now without connect knowing.

Second, instead of erroring when the user is already created, it allows the function to continue. That way the connect user will be linked to the already created hq user, rather than being permanently blocked. Connect only calls this API if it does not already have a record of creating the user, so as far as I know, the main way we get into this state is the first problem described above, but it is possible there are other ways that I had missed.