### PR TITLE
Fix zero divison error

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -168,10 +168,13 @@ class OpportunityAccess(models.Model):
     @property
     def learn_progress(self):
         learn_modules = LearnModule.objects.filter(app=self.opportunity.learn_app)
+        learn_modules_count = learn_modules.count()
+        if learn_modules_count <= 0:
+            return 0
         completed_modules = CompletedModule.objects.filter(
             opportunity=self.opportunity, module__in=learn_modules, user=self.user
         ).count()
-        percentage = (completed_modules / learn_modules.count()) * 100
+        percentage = (completed_modules / learn_modules_count) * 100
         return round(percentage, 2)
 
     @property


### PR DESCRIPTION
[Sentry error](https://dimagi.sentry.io/issues/4619727337/?environment=staging&project=4505635339829248&query=&referrer=issue-stream&statsPeriod=90d&stream_index=1&utc=true)

There was a zero division error due to some opportunities not having learn modules. The learn modules are used to calculate the learn progress percentage for a user and 0 learn modules led to zero division error in that calculation.
As a fix that calculation checks if the learn modules count is 0 and returns 0 early.