### PR TITLE
Refactor Export Code

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -83,19 +83,7 @@ def export_empty_payment_table(opportunity: Opportunity) -> Dataset:
 def export_user_status_table(opportunity: Opportunity) -> Dataset:
     access_objects = get_annotated_opportunity_access(opportunity)
     table = UserStatusTable(access_objects)
-
-    columns = [column for column in table.columns.iterall()]
-    headers = [force_str(column.header, strings_only=True) for column in columns]
-    dataset = Dataset(title="User status export", headers=headers)
-    for row in table.rows:
-        row_value = []
-        for column in columns:
-            col_value = row.get_cell_value(column.name)
-            if isinstance(col_value, datetime.datetime):
-                col_value = col_value.replace(tzinfo=None)
-            row_value.append(col_value)
-        dataset.append(row_value)
-    return dataset
+    return get_dataset(table, export_title="User status export")
 
 
 def export_deliver_status_table(opportunity: Opportunity) -> Dataset:

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -35,7 +35,7 @@ from config import celery_app
 
 @celery_app.task()
 def create_learn_modules_and_deliver_units(opportunity_id):
-    opportunity = Opportunity.objects.filter(id=opportunity_id).first()
+    opportunity = Opportunity.objects.get(id=opportunity_id)
     learn_app = opportunity.learn_app
     deliver_app = opportunity.deliver_app
     learn_app_connect_blocks = get_connect_blocks_for_app(learn_app.cc_domain, learn_app.cc_app_id)
@@ -70,11 +70,8 @@ def add_connect_users(user_list: list[str], opportunity_id: str):
 def generate_visit_export(opportunity_id: int, date_range: str, status: list[str], export_format: str):
     opportunity = Opportunity.objects.get(id=opportunity_id)
     dataset = export_user_visit_data(opportunity, DateRanges(date_range), [VisitValidationStatus(s) for s in status])
-    content = dataset.export(export_format)
     export_tmp_name = f"{now().isoformat()}_{opportunity.name}_visit_export.{export_format}"
-    if isinstance(content, str):
-        content = content.encode()
-    default_storage.save(export_tmp_name, ContentFile(content))
+    save_export(dataset, export_tmp_name, export_format)
     return export_tmp_name
 
 
@@ -82,11 +79,8 @@ def generate_visit_export(opportunity_id: int, date_range: str, status: list[str
 def generate_payment_export(opportunity_id: int, export_format: str):
     opportunity = Opportunity.objects.get(id=opportunity_id)
     dataset = export_empty_payment_table(opportunity)
-    content = dataset.export(export_format)
     export_tmp_name = f"{now().isoformat()}_{opportunity.name}_payment_export.{export_format}"
-    if isinstance(content, str):
-        content = content.encode()
-    default_storage.save(export_tmp_name, ContentFile(content))
+    save_export(dataset, export_tmp_name, export_format)
     return export_tmp_name
 
 
@@ -94,11 +88,8 @@ def generate_payment_export(opportunity_id: int, export_format: str):
 def generate_user_status_export(opportunity_id: int, export_format: str):
     opportunity = Opportunity.objects.get(id=opportunity_id)
     dataset = export_user_status_table(opportunity)
-    content = dataset.export(export_format)
     export_tmp_name = f"{now().isoformat()}_{opportunity.name}_user_status.{export_format}"
-    if isinstance(content, str):
-        content = content.encode()
-    default_storage.save(export_tmp_name, ContentFile(content))
+    save_export(dataset, export_tmp_name, export_format)
     return export_tmp_name
 
 

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -94,10 +94,10 @@ def generate_user_status_export(opportunity_id: int, export_format: str):
 
 
 @celery_app.task()
-def generate_payment_and_verification_export(opportunity_id: int, export_format: str):
+def generate_deliver_status_export(opportunity_id: int, export_format: str):
     opportunity = Opportunity.objects.get(id=opportunity_id)
     dataset = export_deliver_status_table(opportunity)
-    export_tmp_name = f"{now().isoformat()}_{opportunity.name}_payment_and_verification.{export_format}"
+    export_tmp_name = f"{now().isoformat()}_{opportunity.name}_deliver_status.{export_format}"
     save_export(dataset, export_tmp_name, export_format)
     return export_tmp_name
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -49,7 +49,7 @@ from commcare_connect.opportunity.tables import (
 from commcare_connect.opportunity.tasks import (
     add_connect_users,
     create_learn_modules_and_deliver_units,
-    generate_payment_and_verification_export,
+    generate_deliver_status_export,
     generate_payment_export,
     generate_user_status_export,
     generate_visit_export,
@@ -435,7 +435,7 @@ def export_deliver_status(request, **kwargs):
         return redirect("opportunity:detail", request.org.slug, opportunity_id)
 
     export_format = form.cleaned_data["format"]
-    result = generate_payment_and_verification_export.delay(opportunity_id, export_format)
+    result = generate_deliver_status_export.delay(opportunity_id, export_format)
     redirect_url = reverse("opportunity:detail", args=(request.org.slug, opportunity_id))
     return redirect(f"{redirect_url}?export_task_id={result.id}")
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -129,9 +129,8 @@ class OpportunityDetail(OrganizationUserMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["visit_export_form"] = VisitExportForm()
-        context["payment_export_form"] = PaymentExportForm()
         context["export_task_id"] = self.request.GET.get("export_task_id")
-        context["user_status_export_form"] = PaymentExportForm()
+        context["export_form"] = PaymentExportForm()
         return context
 
 

--- a/commcare_connect/templates/export_modal.html
+++ b/commcare_connect/templates/export_modal.html
@@ -13,7 +13,7 @@
               enctype="multipart/form-data">
           <div class="modal-body">
             <div class="mb-3">
-              {% crispy user_status_export_form %}
+              {% crispy export_form %}
             </div>
           </div>
           <div class="modal-footer">

--- a/commcare_connect/templates/export_modal.html
+++ b/commcare_connect/templates/export_modal.html
@@ -1,0 +1,27 @@
+{% load crispy_forms_tags %}
+
+{% block export_modal %}
+  <!-- Export Template -->
+  <div class="modal fade" id="{{modal_id}}" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h1 class="modal-title fs-5">{{modal_title}}</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <form action="{{export_url}}" method="post"
+              enctype="multipart/form-data">
+          <div class="modal-body">
+            <div class="mb-3">
+              {% crispy user_status_export_form %}
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            <button type="submit" class="btn btn-primary">Export</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock export_modal %}

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -65,14 +65,15 @@
                   {% translate "Import Payment Records" %}
                 </a>
               </li>
+              <li class="dropdown-divider"></li>
               <li>
                 <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportUserStatusModal">
                   <i class="bi bi-file-earmark-arrow-down-fill pe-2"></i>
-                  {% translate "Export Users Status" %}
+                  {% translate "Export User Status" %}
                 </a>
               </li>
               <li>
-                <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportPaymentAndVerificationModal">
+                <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportDeliverStatusModal">
                   <i class="bi bi-file-earmark-arrow-down-fill pe-2"></i>
                   {% translate "Export Deliver Status" %}
                 </a>
@@ -344,29 +345,9 @@
   </div>
 </div>
 
-<!-- Payment Export modal -->
-<div class="modal fade" id="exportPaymentModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h1 class="modal-title fs-5">{% translate "Export Users for Payment" %}</h1>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <form action="{% url "opportunity:payment_export" org_slug=request.org.slug pk=opportunity.pk %}" method="post"
-            enctype="multipart/form-data">
-        <div class="modal-body">
-          <div class="mb-3">
-            {% crispy payment_export_form %}
-          </div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-          <button type="submit" class="btn btn-primary">Export</button>
-        </div>
-      </form>
-    </div>
-  </div>
-</div>
+  <!-- Payment Export modal -->
+  {% url "opportunity:payment_export" org_slug=request.org.slug pk=opportunity.pk as payment_export_url %}
+  {% include "export_modal.html" with modal_id="exportPaymentModal" modal_title=_("Export Users for Payment") export_url=payment_export_url %}
 
 <!-- Payment Import modal -->
 <div class="modal fade" id="importPaymentModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-hidden="true">
@@ -399,51 +380,11 @@
     </div>
   </div>
 </div>
-  <!-- User status Export modal -->
-  <div class="modal fade" id="exportUserStatusModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h1 class="modal-title fs-5">{% translate "Export User Status" %}</h1>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <form action="{% url "opportunity:user_status_export" org_slug=request.org.slug pk=opportunity.pk %}" method="post"
-              enctype="multipart/form-data">
-          <div class="modal-body">
-            <div class="mb-3">
-              {% crispy user_status_export_form %}
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            <button type="submit" class="btn btn-primary">Export</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
+  <!-- User Status Export Modal -->
+  {% url 'opportunity:user_status_export' org_slug=request.org.slug pk=opportunity.pk as user_status_export_url %}
+  {% include "export_modal.html" with modal_id="exportUserStatusModal" modal_title=_("Export User Status") export_url=user_status_export_url %}
 
-  <!-- Payments and Verification Export modal -->
-  <div class="modal fade" id="exportPaymentAndVerificationModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h1 class="modal-title fs-5">{% translate "Export Payments and Verification" %}</h1>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <form action="{% url 'opportunity:deliver_status_export' org_slug=request.org.slug pk=opportunity.pk %}" method="post"
-              enctype="multipart/form-data">
-          <div class="modal-body">
-            <div class="mb-3">
-              {% crispy user_status_export_form %}
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            <button type="submit" class="btn btn-primary">Export</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
+  <!-- Deliver Status Export Modal -->
+  {% url 'opportunity:deliver_status_export' org_slug=request.org.slug pk=opportunity.pk as deliver_status_export_url %}
+  {% include "export_modal.html" with modal_id="exportDeliverStatusModal" modal_title=_("Export Deliver Status") export_url=deliver_status_export_url %}
 {% endblock modal %}

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -347,7 +347,7 @@
 
   <!-- Payment Export modal -->
   {% url "opportunity:payment_export" org_slug=request.org.slug pk=opportunity.pk as payment_export_url %}
-  {% include "export_modal.html" with modal_id="exportPaymentModal" modal_title=_("Export Users for Payment") export_url=payment_export_url %}
+  {% include "export_modal.html" with modal_id="exportPaymentModal" modal_title=_("Export Users for Payment") export_url=payment_export_url export_form=export_form %}
 
 <!-- Payment Import modal -->
 <div class="modal fade" id="importPaymentModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-hidden="true">
@@ -382,9 +382,9 @@
 </div>
   <!-- User Status Export Modal -->
   {% url 'opportunity:user_status_export' org_slug=request.org.slug pk=opportunity.pk as user_status_export_url %}
-  {% include "export_modal.html" with modal_id="exportUserStatusModal" modal_title=_("Export User Status") export_url=user_status_export_url %}
+  {% include "export_modal.html" with modal_id="exportUserStatusModal" modal_title=_("Export User Status") export_url=user_status_export_url export_form=export_form %}
 
   <!-- Deliver Status Export Modal -->
   {% url 'opportunity:deliver_status_export' org_slug=request.org.slug pk=opportunity.pk as deliver_status_export_url %}
-  {% include "export_modal.html" with modal_id="exportDeliverStatusModal" modal_title=_("Export Deliver Status") export_url=deliver_status_export_url %}
+  {% include "export_modal.html" with modal_id="exportDeliverStatusModal" modal_title=_("Export Deliver Status") export_url=deliver_status_export_url export_form=export_form %}
 {% endblock modal %}


### PR DESCRIPTION
There was a lot of duplication of code around the export code for payment export, user status export and deliver status export.

- This PR includes a export_modal template which can be used for exporting data in future.
- Refactored the code to use the save_export helper function