### PR TITLE
Add filtering for web users on add members

### DIFF
--- a/commcare_connect/organization/forms.py
+++ b/commcare_connect/organization/forms.py
@@ -1,6 +1,5 @@
 from crispy_forms import helper, layout
 from django import forms
-from django.db.models import Q
 from django.utils.translation import gettext
 
 from commcare_connect.organization.models import Organization, UserOrganizationMembership
@@ -35,8 +34,8 @@ class MembershipForm(forms.ModelForm):
         self.organization = kwargs.pop("organization")
         super().__init__(*args, **kwargs)
 
-        self.fields["user"].queryset = User.objects.exclude(
-            Q(email__isnull=True) | Q(memberships__organization=self.organization)
+        self.fields["user"].queryset = User.objects.filter(email__isnull=False).exclude(
+            memberships__organization=self.organization
         )
 
         self.helper = helper.FormHelper(self)

--- a/commcare_connect/organization/forms.py
+++ b/commcare_connect/organization/forms.py
@@ -1,8 +1,10 @@
 from crispy_forms import helper, layout
 from django import forms
+from django.db.models import Q
 from django.utils.translation import gettext
 
 from commcare_connect.organization.models import Organization, UserOrganizationMembership
+from commcare_connect.users.models import User
 
 
 class OrganizationChangeForm(forms.ModelForm):
@@ -30,7 +32,12 @@ class MembershipForm(forms.ModelForm):
         labels = {"user": "", "role": ""}
 
     def __init__(self, *args, **kwargs):
+        self.organization = kwargs.pop("organization")
         super().__init__(*args, **kwargs)
+
+        self.fields["user"].queryset = User.objects.exclude(
+            Q(email__isnull=True) | Q(memberships__organization=self.organization)
+        )
 
         self.helper = helper.FormHelper(self)
         self.helper.layout = layout.Layout(

--- a/commcare_connect/organization/views.py
+++ b/commcare_connect/organization/views.py
@@ -15,7 +15,7 @@ def organization_home(request, org_slug):
     org = get_object_or_404(Organization, slug=org_slug)
 
     form = None
-    membership_form = MembershipForm()
+    membership_form = MembershipForm(organization=org)
     if request.method == "POST":
         form = OrganizationChangeForm(request.POST, instance=org)
         if form.is_valid():
@@ -36,7 +36,7 @@ def organization_home(request, org_slug):
 @login_required
 def add_members_form(request, org_slug):
     org = get_object_or_404(Organization, slug=org_slug)
-    form = MembershipForm(request.POST or None)
+    form = MembershipForm(request.POST or None, organization=org)
 
     if form.is_valid():
         form.instance.organization = org


### PR DESCRIPTION
Added a filter to the add member dropdown on organization page to exclude all mobile users and show only the web users that are not already invited to the organization.