### PR TITLE
Added some styling to the tabs

### DIFF
--- a/commcare_connect/static/sass/project.scss
+++ b/commcare_connect/static/sass/project.scss
@@ -18,6 +18,35 @@ $bootstrap-icons-font-dir: '~bootstrap-icons/font/fonts';
   }
 }
 
+.nav-tabs-custom {
+  margin-bottom: 0.5rem;
+  border: 0;
+
+  .nav-item {
+    .nav-link {
+      border: 0;
+      border-radius: 0;
+      text-transform: uppercase;
+      font-size: 12px;
+      font-weight: bold;
+      transition:
+        color 0.15s ease-in-out,
+        background-color 0.15s ease-in-out,
+        border-color 0.15s ease-in-out;
+      color: $secondary;
+    }
+
+    .nav-link:hover {
+      background-color: $gray-200;
+    }
+
+    .active {
+      border-bottom: 2px solid $primary;
+      color: $primary;
+    }
+  }
+}
+
 ///////////////
 // Variables //
 ///////////////

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -221,7 +221,7 @@
     </div>
 
     <div class="pt-2 px-4">
-      <ul class="nav nav-tabs" role="tablist">
+      <ul class="nav nav-tabs nav-tabs-custom" role="tablist">
         <li class="nav-item" role="presentation">
           <button class="nav-link active" id="learn-tab" data-bs-toggle="tab" data-bs-target="#learn-tab-pane"
                   type="button" role="tab" aria-controls="learn-tab-pane" aria-selected="true">


### PR DESCRIPTION
Updated the styling for Detail Tabs to represent active states with primary color and some visual improvements.

Current: 
<img width="1236" alt="image" src="https://github.com/dimagi/commcare-connect/assets/31195143/8460bf7e-342e-44ed-bde9-dd5ef1138b97">

Updated: 
<img width="1251" alt="image" src="https://github.com/dimagi/commcare-connect/assets/31195143/bc6c83fc-747b-4b3f-a7a0-374b844f5490">

