### PR TITLE
Fix broken loading states for learn, deliver dropdowns

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -127,11 +127,13 @@ class OpportunityCreationForm(forms.ModelForm):
                 Row(Field("learn_app")),
                 Row(Field("learn_app_description")),
                 Row(Field("learn_app_passing_score")),
+                data_loading_states=True,
             ),
             Fieldset(
                 "Deliver App",
                 Row(Field("deliver_app_domain")),
                 Row(Field("deliver_app")),
+                data_loading_states=True,
             ),
             Row(Field("api_key")),
             Submit("submit", "Submit"),
@@ -145,13 +147,12 @@ class OpportunityCreationForm(forms.ModelForm):
                     "hx-get": reverse("opportunity:get_applications_by_domain", args=(self.org_slug,)),
                     "hx-include": "#id_learn_app_domain",
                     "hx-trigger": "load, change",
-                    "hx-indicator": "#id_learn_app_domain",
                     "hx-target": "#id_learn_app",
                     "data-loading-disable": True,
                 }
             ),
         )
-        self.fields["learn_app"] = forms.Field(widget=forms.Select)
+        self.fields["learn_app"] = forms.Field(widget=forms.Select(attrs={"data-loading-disable": True}))
         self.fields["learn_app_description"] = forms.CharField(widget=forms.Textarea)
         self.fields["learn_app_passing_score"] = forms.IntegerField(max_value=100, min_value=0)
         self.fields["deliver_app_domain"] = forms.ChoiceField(
@@ -161,13 +162,12 @@ class OpportunityCreationForm(forms.ModelForm):
                     "hx-get": reverse("opportunity:get_applications_by_domain", args=(self.org_slug,)),
                     "hx-include": "#id_deliver_app_domain",
                     "hx-trigger": "load, change",
-                    "hx-indicator": "#id_deliver_app_domain",
                     "hx-target": "#id_deliver_app",
                     "data-loading-disable": True,
                 }
             ),
         )
-        self.fields["deliver_app"] = forms.Field(widget=forms.Select)
+        self.fields["deliver_app"] = forms.Field(widget=forms.Select(attrs={"data-loading-disable": True}))
         self.fields["api_key"] = forms.CharField(max_length=50)
         self.fields["total_budget"].widget.attrs.update({"class": "form-control-plaintext"})
         self.fields["max_users"] = forms.IntegerField()

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -146,13 +146,15 @@ class OpportunityCreationForm(forms.ModelForm):
                 attrs={
                     "hx-get": reverse("opportunity:get_applications_by_domain", args=(self.org_slug,)),
                     "hx-include": "#id_learn_app_domain",
-                    "hx-trigger": "load, change",
+                    "hx-trigger": "load delay:0.3s, change",
                     "hx-target": "#id_learn_app",
                     "data-loading-disable": True,
                 }
             ),
         )
-        self.fields["learn_app"] = forms.Field(widget=forms.Select(attrs={"data-loading-disable": True}))
+        self.fields["learn_app"] = forms.Field(
+            widget=forms.Select(choices=[(None, "Loading...")], attrs={"data-loading-disable": True})
+        )
         self.fields["learn_app_description"] = forms.CharField(widget=forms.Textarea)
         self.fields["learn_app_passing_score"] = forms.IntegerField(max_value=100, min_value=0)
         self.fields["deliver_app_domain"] = forms.ChoiceField(
@@ -161,13 +163,15 @@ class OpportunityCreationForm(forms.ModelForm):
                 attrs={
                     "hx-get": reverse("opportunity:get_applications_by_domain", args=(self.org_slug,)),
                     "hx-include": "#id_deliver_app_domain",
-                    "hx-trigger": "load, change",
+                    "hx-trigger": "load delay:0.3s, change",
                     "hx-target": "#id_deliver_app",
                     "data-loading-disable": True,
                 }
             ),
         )
-        self.fields["deliver_app"] = forms.Field(widget=forms.Select(attrs={"data-loading-disable": True}))
+        self.fields["deliver_app"] = forms.Field(
+            widget=forms.Select(choices=[(None, "Loading...")], attrs={"data-loading-disable": True})
+        )
         self.fields["api_key"] = forms.CharField(max_length=50)
         self.fields["total_budget"].widget.attrs.update({"class": "form-control-plaintext"})
         self.fields["max_users"] = forms.IntegerField()

--- a/commcare_connect/static/js/htmx.js
+++ b/commcare_connect/static/js/htmx.js
@@ -1,0 +1,2 @@
+import htmx from 'htmx.org';
+window.htmx = htmx;

--- a/commcare_connect/static/js/vendors.js
+++ b/commcare_connect/static/js/vendors.js
@@ -1,7 +1,8 @@
 import '@popperjs/core';
 import 'bootstrap';
-import 'htmx.org';
 import Alpine from 'alpinejs';
+import './htmx';
+import 'htmx.org/dist/ext/loading-states';
 
 window.Alpine = Alpine;
 Alpine.start();

--- a/commcare_connect/templates/base.html
+++ b/commcare_connect/templates/base.html
@@ -26,7 +26,6 @@
     <script src="{% static 'bundles/js/vendors-bundle.js' %}" defer></script>
     <!-- place project specific Javascript in this file -->
     <script src="{% static 'bundles/js/project-bundle.js' %}" defer></script>
-    <script src="https://unpkg.com/htmx.org/dist/ext/loading-states.js"></script>
   {% endblock javascript %}
 </head>
 <body>


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/jira/software/c/projects/CCCT/issues/CCCT-235)

This PR fixes 
- the htmx loading-states plugin which was not working correctly as it cannot find the htmx library.
- The disabled states for the Learn and Deliver app dropdown when fetching domain
- Added a small delay 0.3s to let htmx disable the elements before requesting the Applications.

<img width="1343" alt="image" src="https://github.com/dimagi/commcare-connect/assets/31195143/ba72579d-3878-4c24-a547-e95ea86bac5a">
