### PR TITLE
Fix location allow null form processor

### DIFF
--- a/commcare_connect/form_receiver/serializers.py
+++ b/commcare_connect/form_receiver/serializers.py
@@ -38,7 +38,7 @@ class XFormMetadataSerializer(serializers.Serializer):
     timeEnd = serializers.DateTimeField(required=True)
     app_build_version = serializers.CharField(allow_null=True)
     username = serializers.CharField()
-    location = serializers.CharField()
+    location = serializers.CharField(allow_null=True)
 
 
 class XFormSerializer(serializers.Serializer):


### PR DESCRIPTION
The form processor serializer was throwing validation errors for forms that had a null location field. This PR adds the allow_null param for the serializer location field.