### PR TITLE
Fix broken org dropdown

### DIFF
--- a/commcare_connect/static/js/vendors.js
+++ b/commcare_connect/static/js/vendors.js
@@ -1,5 +1,4 @@
 import '@popperjs/core';
-import 'bootstrap';
 import Alpine from 'alpinejs';
 import './htmx';
 import 'htmx.org/dist/ext/loading-states';


### PR DESCRIPTION
The org dropdown which is a bootstrap component was broken due to duplicate import for bootstrap javascript.