### PR TITLE
update request org usage

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -79,7 +79,8 @@ from commcare_connect.utils.commcarehq_api import get_applications_for_user_by_d
 
 class OrganizationUserMixin(LoginRequiredMixin, UserPassesTestMixin):
     def test_func(self):
-        return self.request.org_membership is not None
+        # request.org_membership is a SimpleLazyObject object so `is not None` is always `True`
+        return self.request.org_membership != None  # noqa: E711
 
 
 class OpportunityList(OrganizationUserMixin, ListView):

--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -12,7 +12,7 @@ def get_organization_for_request(request, view_kwargs):
     org_slug = view_kwargs.get("org_slug", None)
     if org_slug:
         try:
-            return Organization.objects.get(slug=org_slug, memberships__user=request.user)
+            return Organization.objects.get(slug=org_slug)
         except Organization.DoesNotExist:
             return None
 


### PR DESCRIPTION
This should fix the issues we have seen with the superuser access features, and a potential security issue.

1) Org was only being set on the request if the user was a member. Superusers are not, and the lack of `request.org` was causing an assortment of 500 errors creating a response. Now superusers actually should have access to all pages without an invite.

2) The org membership check in `OrganizationUserMixin` was incorrectly returning `True` always because `request.org_membership` was never `None`, but rather a `SimpleLazyObject` that evaluated to `None`. 