### PR TITLE
Add total invited users count to User Status table

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -125,7 +125,7 @@ class UserStatusTable(tables.Table):
     passed_assessment = BooleanAggregateColumn(verbose_name="Passed Assessment")
     started_delivery = AggregateColumn(verbose_name="Started Delivery", accessor="date_deliver_started")
     last_visit_date = columns.Column(accessor="last_visit_date_d")
-    view_profile = columns.Column("View Profile", empty_values=())
+    view_profile = AggregateColumn("View Profile", empty_values=(), footer=lambda table: len(table.rows))
 
     class Meta:
         model = OpportunityAccess


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/CCCT-259)

- The last footer column in the User Status Table shows the total users invited to the opportunity i.e the total number of rows in the UserStatusTable.
<img width="1334" alt="image" src="https://github.com/dimagi/commcare-connect/assets/31195143/aa74975d-790b-4cb8-8988-186406413435">
