### PR TITLE
Fix send_message table styling

### DIFF
--- a/commcare_connect/templates/opportunity/send_message.html
+++ b/commcare_connect/templates/opportunity/send_message.html
@@ -32,7 +32,7 @@
           <div class="col-sm">
             <p>Select Users*</p>
             <table class="table table-bordered table-responsive table-condensed">
-              <thead class="table-secondary">
+              <thead class="table-primary">
               <tr>
                 <th><input type="checkbox" class="form-check-input" @click="toggleSelectAll()" x-bind:checked="selectAll" /></th>
                 <th>Name</th>


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/QA-6131)

- Fixes the send message table styling for table header to make it similar to other tables.

<img width="674" alt="image" src="https://github.com/dimagi/commcare-connect/assets/31195143/65355c03-0920-4943-957f-018f41f31227">
