### PR TITLE
Fix remove django allowed hosts errors from logs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -215,7 +215,10 @@ LOGGING = {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "verbose",
-        }
+        },
+        "null": {
+            "class": "logging.NullHandler",
+        },
     },
     "root": {"level": "INFO", "handlers": ["console"]},
     "django.template": {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -223,6 +223,12 @@ LOGGING = {
         "level": env("DJANGO_TEMPLATE_LOG_LEVEL", default="WARN"),
         "propagate": False,
     },
+    "loggers": {
+        "django.security.DisallowedHost": {
+            "handlers": ["null"],
+            "propagate": False,
+        },
+    },
 }
 
 # Celery


### PR DESCRIPTION
This PR removes the recurring Django `Disallowed Host` errors from Django logs and sentry.