### PR TITLE
do not include attachment data in export

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -50,6 +50,7 @@ def get_flattened_dataset(headers: list[str], data: list[list]) -> Dataset:
     flat_data = []
     for row in data:
         form_json = row.pop()
+        form_json.pop("attachments", None)
         flat_json = flatten(form_json, reducer="dot", enumerate_types=(list,))
         flat_data.append(flat_json)
         schema.update(flat_json.keys())


### PR DESCRIPTION
Since attachment ids are the keys of a sub dictionary, when we flatten form data we add four columns to the  for every attachment (ie if 4 forms have `attachments` we add 16 columns). The attachment data isn't particularly useful and this should shrink the export a fair amount.