### PR TITLE
add payment pk

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -154,7 +154,7 @@ class UserVisitSerializer(serializers.ModelSerializer):
 class PaymentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Payment
-        fields = ["amount", "date_paid", "confirmed", "confirmation_date"]
+        fields = ["id", "amount", "date_paid", "confirmed", "confirmation_date"]
 
 
 class DeliveryProgressSerializer(serializers.Serializer):


### PR DESCRIPTION
The pk is needed so the mobile can identify the payment being confirmed.