### PR TITLE
Add API versioning settings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -278,6 +278,8 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
+    "DEFAULT_VERSION": "1.0",
 }
 
 CORS_URLS_REGEX = r"^/api/.*$"


### PR DESCRIPTION
This adds basic settings to allow API versioning with our django rest framework views. We will need to do a custom subclass of the versioning class, but for now this gives mobile something to play with.