### PR TITLE
Fix payment accrued

### DIFF
--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -24,7 +24,6 @@ from commcare_connect.opportunity.models import (
     UserVisit,
     VisitValidationStatus,
 )
-from commcare_connect.opportunity.tasks import approve_completed_work_and_update_payment_accrued
 from commcare_connect.opportunity.tests.factories import (
     DeliverUnitFactory,
     LearnModuleFactory,
@@ -32,6 +31,7 @@ from commcare_connect.opportunity.tests.factories import (
     OpportunityClaimFactory,
     PaymentUnitFactory,
 )
+from commcare_connect.opportunity.visit_import import update_payment_accrued
 from commcare_connect.users.models import User
 
 
@@ -272,7 +272,7 @@ def test_auto_approve_payments_flagged_visit(
     assert visit.status == VisitValidationStatus.pending
 
     # No Payment Approval
-    approve_completed_work_and_update_payment_accrued([visit.completed_work_id])
+    update_payment_accrued(opportunity, users=[user_with_connectid_link])
     access = OpportunityAccess.objects.get(user=user_with_connectid_link, opportunity=opportunity)
     completed_work = CompletedWork.objects.get(opportunity_access=access)
     assert completed_work.status == CompletedWorkStatus.pending
@@ -292,7 +292,7 @@ def test_auto_approve_payments_unflagged_visit(
     assert visit.status == VisitValidationStatus.pending
 
     # Payment Approval
-    approve_completed_work_and_update_payment_accrued([visit.completed_work_id])
+    update_payment_accrued(opportunity, users=[user_with_connectid_link])
     access = OpportunityAccess.objects.get(user=user_with_connectid_link, opportunity=opportunity)
     completed_work = CompletedWork.objects.get(opportunity_access=access)
     assert completed_work.status == CompletedWorkStatus.pending
@@ -313,7 +313,7 @@ def test_auto_approve_payments_approved_visit(
     assert not visit.flagged
 
     # Payment Approval
-    approve_completed_work_and_update_payment_accrued([visit.completed_work_id])
+    update_payment_accrued(opportunity, users=[user_with_connectid_link])
     access = OpportunityAccess.objects.get(user=user_with_connectid_link, opportunity=opportunity)
     completed_work = CompletedWork.objects.get(opportunity_access=access)
     assert completed_work.status == CompletedWorkStatus.approved
@@ -333,7 +333,7 @@ def test_auto_approve_visits_and_payments(
     assert not visit.flagged
     assert visit.status == VisitValidationStatus.approved
 
-    approve_completed_work_and_update_payment_accrued([visit.completed_work_id])
+    update_payment_accrued(opportunity, users=[user_with_connectid_link])
     access = OpportunityAccess.objects.get(user=user_with_connectid_link, opportunity=opportunity)
     completed_work = CompletedWork.objects.get(opportunity_access=access)
     assert completed_work.status == CompletedWorkStatus.approved

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -358,6 +358,16 @@ class CompletedWork(models.Model):
     def completed_count(self):
         """Returns the no of completion of this work. Includes duplicate submissions."""
         visits = self.uservisit_set.values_list("deliver_unit_id", flat=True)
+        return self.calculate_completed(visits)
+
+    @property
+    def approved_count(self):
+        visits = self.uservisit_set.filter(status=VisitValidationStatus.approved).values_list(
+            "deliver_unit_id", flat=True
+        )
+        return self.calculate_completed(visits)
+
+    def calculate_completed(self, visits):
         unit_counts = Counter(visits)
         deliver_units = self.payment_unit.deliver_units.values("id", "optional")
         required_deliver_units = list(
@@ -391,7 +401,7 @@ class CompletedWork(models.Model):
     @property
     def payment_accrued(self):
         """Returns the total payment accrued for this completed work. Includes duplicates"""
-        return self.completed_count * self.payment_unit.amount
+        return self.approved_count * self.payment_unit.amount
 
     @property
     def flags(self):

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -301,9 +301,12 @@ def bulk_approve_completed_work():
         opportunity__auto_approve_payments=True,
     )
     for access in access_objects:
-        completed_works = access.completedwork_set.filter(status=CompletedWorkStatus.pending)
+        completed_works = access.completedwork_set.exlcude(
+            status__in=[CompletedWorkStatus.rejected, CompletedWorkStatus.over_limit]
+        )
+        access.payment_accrued = 0
         for completed_work in completed_works:
-            if completed_work.flags:
+            if completed_work.flags and completed_work.status != CompletedWorkStatus.approved:
                 continue
             completed_count = completed_work.completed_count
             visits = completed_work.uservisit_set.values_list("status", flat=True)

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -283,15 +283,13 @@ def bulk_approve_completed_work():
         )
         access.payment_accrued = 0
         for completed_work in completed_works:
-            if completed_work.flags and completed_work.status != CompletedWorkStatus.approved:
-                continue
-            completed_count = completed_work.completed_count
+            approved_count = completed_work.approved_count
             visits = completed_work.uservisit_set.values_list("status", flat=True)
             if any(visit == "rejected" for visit in visits):
                 completed_work.status = CompletedWorkStatus.rejected
             elif all(visit == "approved" for visit in visits):
                 completed_work.status = CompletedWorkStatus.approved
-            if completed_count > 0 and completed_work.status == CompletedWorkStatus.approved:
-                access.payment_accrued += completed_count * completed_work.payment_unit.amount
+            if approved_count > 0 and completed_work.status == CompletedWorkStatus.approved:
+                access.payment_accrued += approved_count * completed_work.payment_unit.amount
             completed_work.save()
         access.save()

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -288,7 +288,7 @@ def bulk_approve_completed_work():
             completed_count = completed_work.completed_count
             visits = completed_work.uservisit_set.values_list("status", flat=True)
             if any(visit == "rejected" for visit in visits):
-                completed_work.status = CompletedWorkStatus.pending
+                completed_work.status = CompletedWorkStatus.rejected
             elif all(visit == "approved" for visit in visits):
                 completed_work.status = CompletedWorkStatus.approved
             if completed_count > 0 and completed_work.status == CompletedWorkStatus.approved:

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -132,17 +132,14 @@ def update_payment_accrued(opportunity: Opportunity, users):
         for completed_work in completed_works:
             # Auto Approve Payment conditions
             if opportunity.auto_approve_payments:
-                # if flagged continue
-                if completed_work.flags and completed_work.status != CompletedWorkStatus.approved:
-                    continue
                 visits = completed_work.uservisit_set.values_list("status", flat=True)
                 if any(visit == "rejected" for visit in visits):
                     completed_work.status = CompletedWorkStatus.rejected
                 elif all(visit == "approved" for visit in visits):
                     completed_work.status = CompletedWorkStatus.approved
-            completed_count = completed_work.completed_count
-            if completed_count > 0 and completed_work.status == CompletedWorkStatus.approved:
-                access.payment_accrued += completed_count * completed_work.payment_unit.amount
+            approved_count = completed_work.approved_count
+            if approved_count > 0 and completed_work.status == CompletedWorkStatus.approved:
+                access.payment_accrued += approved_count * completed_work.payment_unit.amount
             completed_work.save()
         access.save()
 

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -16,10 +16,7 @@ from commcare_connect.opportunity.models import (
     UserVisit,
     VisitValidationStatus,
 )
-from commcare_connect.opportunity.tasks import (
-    approve_completed_work_and_update_payment_accrued,
-    send_payment_notification,
-)
+from commcare_connect.opportunity.tasks import send_payment_notification
 from commcare_connect.utils.itertools import batched
 
 VISIT_ID_COL = "visit id"
@@ -119,28 +116,34 @@ def _bulk_update_visit_status(opportunity: Opportunity, dataset: Dataset):
 
             UserVisit.objects.bulk_update(to_update, fields=["status", "reason"])
             missing_visits |= set(visit_batch) - seen_visits
-    if opportunity.auto_approve_payments:
-        approve_completed_work_and_update_payment_accrued(list(seen_completed_works))
-    else:
-        # TODO: This should be a task
-        update_payment_accrued(opportunity, users=user_ids)
+    update_payment_accrued(opportunity, users=user_ids)
 
     return VisitImportStatus(seen_visits, missing_visits)
 
 
 def update_payment_accrued(opportunity: Opportunity, users):
     """Updates payment accrued for completed and approved CompletedWork instances."""
-    payment_units = opportunity.paymentunit_set.all()
     access_objects = OpportunityAccess.objects.filter(user__in=users, opportunity=opportunity)
     for access in access_objects:
-        payment_accrued = 0
-        for payment_unit in payment_units:
-            completed_works = access.completedwork_set.filter(
-                payment_unit=payment_unit, status=CompletedWorkStatus.approved
-            )
-            for completed_work in completed_works:
-                payment_accrued += completed_work.completed_count * payment_unit.amount
-        access.payment_accrued = payment_accrued
+        completed_works = access.completedwork_set.exclude(
+            status__in=[CompletedWorkStatus.rejected, CompletedWorkStatus.over_limit]
+        ).select_related("payment_unit")
+        access.payment_accrued = 0
+        for completed_work in completed_works:
+            # Auto Approve Payment conditions
+            if opportunity.auto_approve_payments:
+                # if flagged continue
+                if completed_work.flags and completed_work.status != CompletedWorkStatus.approved:
+                    continue
+                visits = completed_work.uservisit_set.values_list("status", flat=True)
+                if any(visit == "rejected" for visit in visits):
+                    completed_work.status = CompletedWorkStatus.pending
+                elif all(visit == "approved" for visit in visits):
+                    completed_work.status = CompletedWorkStatus.approved
+            completed_count = completed_work.completed_count
+            if completed_count > 0 and completed_work.status == CompletedWorkStatus.approved:
+                access.payment_accrued += completed_count * completed_work.payment_unit.amount
+            completed_work.save()
         access.save()
 
 

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -137,7 +137,7 @@ def update_payment_accrued(opportunity: Opportunity, users):
                     continue
                 visits = completed_work.uservisit_set.values_list("status", flat=True)
                 if any(visit == "rejected" for visit in visits):
-                    completed_work.status = CompletedWorkStatus.pending
+                    completed_work.status = CompletedWorkStatus.rejected
                 elif all(visit == "approved" for visit in visits):
                     completed_work.status = CompletedWorkStatus.approved
             completed_count = completed_work.completed_count


### PR DESCRIPTION
The payment accrued calculation does not calculate the payment correctly when an approved completed work is rejected.
Also combined the similar `update_payment_accrued` and `approve_completed_work_and_update_payment_accrued` function.s 