### PR TITLE
reuse apps

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -4,7 +4,8 @@ from crispy_forms.helper import FormHelper, Layout
 from crispy_forms.layout import HTML, Field, Fieldset, Row, Submit
 from dateutil.relativedelta import relativedelta
 from django import forms
-from django.db.models import TextChoices
+from django.core.exceptions import ValidationError
+from django.db.models import Q, TextChoices
 from django.urls import reverse
 from django.utils.timezone import now
 
@@ -71,11 +72,24 @@ class OpportunityChangeForm(forms.ModelForm):
             help_text="Extends opportunity end date for all users.",
         )
         self.initial["end_date"] = self.instance.end_date.isoformat()
+        self.currently_active = self.instance.active
 
     def clean_users(self):
         user_data = self.cleaned_data["users"]
         split_users = [line.strip() for line in user_data.splitlines() if line.strip()]
         return split_users
+
+    def clean_active(self):
+        active = self.cleaned_data["active"]
+        if active and not self.currently_active:
+            app_ids = (self.instance.learn_app.cc_app_id, self.instance.deliver_app.cc_app_id)
+            if (
+                Opportunity.objects.filter(active=True)
+                .filter(Q(learn_app__cc_app_id__in=app_ids) | Q(deliver_app__cc_app_id__in=app_ids))
+                .exists()
+            ):
+                raise ValidationError("Cannot reactivate opportunity with reused applications", code="app_reused")
+        return active
 
 
 class OpportunityCreationForm(forms.ModelForm):

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -37,6 +37,7 @@ from commcare_connect.opportunity.helpers import (
 )
 from commcare_connect.opportunity.models import (
     BlobMeta,
+    CommCareApp,
     CompletedModule,
     DeliverUnit,
     Opportunity,
@@ -600,11 +601,13 @@ def send_message_mobile_users(request, org_slug=None, pk=None):
 def get_application(request, org_slug=None):
     domain = request.GET.get("learn_app_domain") or request.GET.get("deliver_app_domain")
     applications = get_applications_for_user_by_domain(request.user, domain)
+    existing_apps = set(CommCareApp.objects.filter(cc_domain=domain).values_list("cc_app_id", flat=True))
     options = []
     for app in applications:
-        value = json.dumps(app)
-        name = app["name"]
-        options.append(format_html("<option value='{}'>{}</option>", value, name))
+        if app["id"] not in existing_apps:
+            value = json.dumps(app)
+            name = app["name"]
+            options.append(format_html("<option value='{}'>{}</option>", value, name))
     return HttpResponse("\n".join(options))
 
 


### PR DESCRIPTION
This adds some safety features around reusable apps.
1) Prevents changing an opportunity from inactive to active if either of its apps are already in use.
2) Removes apps already in use in active opportunities from the list of available apps when setting up an opportunity