### PR TITLE
Multi Visit API changes to Opportunity List API.

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -57,7 +57,7 @@ class CommCareAppSerializer(serializers.ModelSerializer):
 class PaymentUnitSerializer(serializers.ModelSerializer):
     class Meta:
         model = PaymentUnit
-        fields = ["id", "name", "max_total", "max_daily"]
+        fields = ["id", "name", "max_total", "max_daily", "amount"]
 
 
 class OpportunityClaimLimitSerializer(serializers.ModelSerializer):

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -14,6 +14,7 @@ from commcare_connect.opportunity.models import (
     OpportunityAccess,
     OpportunityClaim,
     Payment,
+    PaymentUnit,
     UserVisit,
 )
 
@@ -52,6 +53,12 @@ class CommCareAppSerializer(serializers.ModelSerializer):
         return obj.passing_score
 
 
+class PaymentUnitSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PaymentUnit
+        fields = ["id", "name", "max_total", "max_daily"]
+
+
 class OpportunityClaimSerializer(serializers.ModelSerializer):
     max_payments = serializers.SerializerMethodField()
 
@@ -75,6 +82,7 @@ class OpportunitySerializer(serializers.ModelSerializer):
     daily_max_visits_per_user = serializers.SerializerMethodField()
     budget_per_visit = serializers.SerializerMethodField()
     budget_per_user = serializers.SerializerMethodField()
+    payment_units = serializers.SerializerMethodField()
 
     class Meta:
         model = Opportunity
@@ -100,6 +108,7 @@ class OpportunitySerializer(serializers.ModelSerializer):
             "currency",
             "is_active",
             "budget_per_user",
+            "payment_units",
         ]
 
     def get_claim(self, obj):
@@ -131,6 +140,10 @@ class OpportunitySerializer(serializers.ModelSerializer):
 
     def get_budget_per_user(self, obj):
         return obj.budget_per_user
+
+    def get_payment_units(self, obj):
+        payment_units = PaymentUnit.objects.filter(opportunity=obj)
+        return PaymentUnitSerializer(payment_units, many=True).data
 
 
 @quickcache(vary_on=["user.pk", "opportunity.pk"], timeout=60 * 60)


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/CCCT-300)

Changes:
- Opportunity List API now includes a new key `payment_units` which is an array of payment units for the opportunity.
```
payment_units: [
  {
    id: 1,
    name: "Payment Unit 1",
    total_max: 100,
    daily_max: 2
  }
]
```

- Opportunity List API `claim` key updated to include information from different payment unit configurations for the user.
- Note: the `payment_unit` key below is the payment_unit id.
```json
"claim": {
      "max_payments": 200,
      "end_date": "2024-05-06",
      "date_claimed": "2024-04-12",
      "payment_units": [
        {
          "max_visits": 100,
          "payment_unit": 1
        },
        {
          "max_visits": 100,
          "payment_unit": 2
        }
      ]
 }
```