### PR TITLE
add option to not flatten export

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -20,7 +20,7 @@ from commcare_connect.opportunity.tables import CompletedWorkTable, DeliverStatu
 
 
 def export_user_visit_data(
-    opportunity: Opportunity, date_range: DateRanges, status: list[VisitValidationStatus]
+    opportunity: Opportunity, date_range: DateRanges, status: list[VisitValidationStatus], flatten: bool
 ) -> Dataset:
     """Export all user visits for an opportunity."""
     user_visits = UserVisit.objects.filter(opportunity=opportunity)
@@ -42,7 +42,14 @@ def export_user_visit_data(
         for row in table.rows
     ]
     base_headers = [force_str(column.header, strings_only=True) for column in columns]
-    return get_flattened_dataset(base_headers, base_data)
+    if flatten:
+        return get_flattened_dataset(base_headers, base_data)
+    else:
+        base_headers.append("form_json")
+        dataset = Dataset(title="Export", headers=base_headers)
+        for row in base_data:
+            dataset.append([force_str(col, strings_only=True) for col in row])
+        return dataset
 
 
 def get_flattened_dataset(headers: list[str], data: list[list]) -> Dataset:

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -453,7 +453,7 @@ class VisitExportForm(forms.Form):
     format = forms.ChoiceField(choices=(("csv", "CSV"), ("xlsx", "Excel")), initial="xlsx")
     date_range = forms.ChoiceField(choices=DateRanges.choices, initial=DateRanges.LAST_30_DAYS)
     status = forms.MultipleChoiceField(choices=[("all", "All")] + VisitValidationStatus.choices, initial=["all"])
-    flatten_form_data = forms.BooleanField(initial=False)
+    flatten_form_data = forms.BooleanField(initial=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -453,6 +453,7 @@ class VisitExportForm(forms.Form):
     format = forms.ChoiceField(choices=(("csv", "CSV"), ("xlsx", "Excel")), initial="xlsx")
     date_range = forms.ChoiceField(choices=DateRanges.choices, initial=DateRanges.LAST_30_DAYS)
     status = forms.MultipleChoiceField(choices=[("all", "All")] + VisitValidationStatus.choices, initial=["all"])
+    flatten_form_data = forms.BooleanField(initial=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -461,6 +462,7 @@ class VisitExportForm(forms.Form):
             Row(Field("format")),
             Row(Field("date_range")),
             Row(Field("status")),
+            Row(Field("flatten_form_data", css_class="form-check-input", wrapper_class="form-check form-switch")),
         )
         self.helper.form_tag = False
 

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -126,10 +126,12 @@ def invite_user(user_id, opportunity_access_id):
 
 
 @celery_app.task()
-def generate_visit_export(opportunity_id: int, date_range: str, status: list[str], export_format: str):
+def generate_visit_export(opportunity_id: int, date_range: str, status: list[str], export_format: str, flatten: bool):
     opportunity = Opportunity.objects.get(id=opportunity_id)
     logger.info(f"Export for {opportunity.name} with date range {date_range} and status {','.join(status)}")
-    dataset = export_user_visit_data(opportunity, DateRanges(date_range), [VisitValidationStatus(s) for s in status])
+    dataset = export_user_visit_data(
+        opportunity, DateRanges(date_range), [VisitValidationStatus(s) for s in status], flatten
+    )
     export_tmp_name = f"{now().isoformat()}_{opportunity.name}_visit_export.{export_format}"
     save_export(dataset, export_tmp_name, export_format)
     return export_tmp_name

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -44,7 +44,7 @@ def test_export_user_visit_data(mobile_user_with_connect_link):
             ),
         ]
     )
-    exporter = export_user_visit_data(opportunity, DateRanges.LAST_30_DAYS, [])
+    exporter = export_user_visit_data(opportunity, DateRanges.LAST_30_DAYS, [], True)
     username = mobile_user_with_connect_link.username
     name = mobile_user_with_connect_link.name
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -302,8 +302,9 @@ def export_user_visits(request, **kwargs):
     export_format = form.cleaned_data["format"]
     date_range = DateRanges(form.cleaned_data["date_range"])
     status = form.cleaned_data["status"]
+    flatten = form.cleaned_data["flatten_form_data"]
 
-    result = generate_visit_export.delay(opportunity_id, date_range, status, export_format)
+    result = generate_visit_export.delay(opportunity_id, date_range, status, export_format, flatten)
     redirect_url = reverse("opportunity:detail", args=(request.org.slug, opportunity_id))
     return redirect(f"{redirect_url}?export_task_id={result.id}")
 


### PR DESCRIPTION
This is a temporary fix for the export issues we are facing in production. That is primarily caused by the exceptionally wide tables being generated from flattening form data. This creates a toggle, defaulting to leaving the data in a single column as json but keeping the option to have a wide table. I am not sure this is a great solution, but should at least let projects start to get data out.

![image](https://github.com/dimagi/commcare-connect/assets/6844721/cb88a0b0-5fce-43c8-8eea-4fcc9281c9d2)
