### PR TITLE
only count approved child payment units

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -403,9 +403,9 @@ class CompletedWork(models.Model):
         visits = self.uservisit_set.filter(status=VisitValidationStatus.approved).values_list(
             "deliver_unit_id", flat=True
         )
-        return self.calculate_completed(visits)
+        return self.calculate_completed(visits, approved=True)
 
-    def calculate_completed(self, visits):
+    def calculate_completed(self, visits, approved=False):
         unit_counts = Counter(visits)
         deliver_units = self.payment_unit.deliver_units.values("id", "optional")
         required_deliver_units = list(
@@ -428,7 +428,10 @@ class CompletedWork(models.Model):
             )
             child_completed_work_count = 0
             for completed_work in child_completed_works:
-                child_completed_work_count += completed_work.completed_count
+                if approved:
+                    child_completed_work_count += completed_work.approved_count
+                else:
+                    child_completed_work_count += completed_work.completed_count
             number_completed = min(number_completed, child_completed_work_count)
         return number_completed
 


### PR DESCRIPTION
I will add tests to this in a followup PR, but this makes sure that if a dependent payment unit has been rejected, the auto approval will not cause payment to be accrued. Previously, since the child unit showed as completed, even when it was rejected, the parent would be approved and money would accrue.

I am not positive this is the best place to fix this behavior (rather than not approving the payment unit itself), but it seemed like a reasonable option. Open to the idea of moving it to the approval code and rejecting the payment unit in that instance instead.