### PR TITLE
order payment units by pk

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -79,7 +79,7 @@ class OpportunityClaimSerializer(serializers.ModelSerializer):
         return obj.opportunityclaimlimit_set.aggregate(max_visits=Sum("max_visits")).get("max_visits", 0) or -1
 
     def get_payment_units(self, obj):
-        return OpportunityClaimLimitSerializer(obj.opportunityclaimlimit_set.all(), many=True).data
+        return OpportunityClaimLimitSerializer(obj.opportunityclaimlimit_set.order_by("pk").all(), many=True).data
 
 
 class OpportunitySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Enforce consistent ordering (the order of creation) for payment units in the opportunity api.