### PR TITLE
toggle is not required

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -453,7 +453,7 @@ class VisitExportForm(forms.Form):
     format = forms.ChoiceField(choices=(("csv", "CSV"), ("xlsx", "Excel")), initial="xlsx")
     date_range = forms.ChoiceField(choices=DateRanges.choices, initial=DateRanges.LAST_30_DAYS)
     status = forms.MultipleChoiceField(choices=[("all", "All")] + VisitValidationStatus.choices, initial=["all"])
-    flatten_form_data = forms.BooleanField(initial=True)
+    flatten_form_data = forms.BooleanField(initial=True, required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
If boolean fields are not marked with `required=False`, form validation fails when it is unchecked. I find this completely nonsensical and mildly infuriating, but such is life.

[Docs](https://docs.djangoproject.com/en/5.0/ref/forms/fields/#booleanfield)

![image](https://github.com/dimagi/commcare-connect/assets/6844721/605f5a8c-5334-4d68-b8d6-a8207fe0a2d8)
