### PR TITLE
order by payment unit id

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -79,7 +79,9 @@ class OpportunityClaimSerializer(serializers.ModelSerializer):
         return obj.opportunityclaimlimit_set.aggregate(max_visits=Sum("max_visits")).get("max_visits", 0) or -1
 
     def get_payment_units(self, obj):
-        return OpportunityClaimLimitSerializer(obj.opportunityclaimlimit_set.order_by("pk"), many=True).data
+        return OpportunityClaimLimitSerializer(
+            obj.opportunityclaimlimit_set.order_by("payment_unit_id"), many=True
+        ).data
 
 
 class OpportunitySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
We need to order by the PK of the payment unit, not the user's claim on that unit