### PR TITLE
dump form dict as json

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from django.utils.encoding import force_str
 from flatten_dict import flatten
@@ -48,7 +49,10 @@ def export_user_visit_data(
         base_headers.append("form_json")
         dataset = Dataset(title="Export", headers=base_headers)
         for row in base_data:
-            dataset.append([force_str(col, strings_only=True) for col in row])
+            form_json = json.dumps(row.pop())
+            row.append(form_json)
+            row_data = [force_str(col, strings_only=True) for col in row]
+            dataset.append(row_data)
         return dataset
 
 


### PR DESCRIPTION
The form data was being included in the string representation of a python dictionary, rather than json, which prevented using excel JSON functions.