### PR TITLE
currency display

### DIFF
--- a/commcare_connect/reports/tables.py
+++ b/commcare_connect/reports/tables.py
@@ -1,3 +1,4 @@
+from django.utils.safestring import mark_safe
 from django_tables2 import columns, tables
 
 
@@ -11,3 +12,6 @@ class AdminReportTable(tables.Table):
     class Meta:
         empty_text = "No data for this quarter."
         orderable = False
+
+    def render_payments(self, value):
+        return mark_safe("<br>".join(value))


### PR DESCRIPTION
In the admin reports, we need to break up the payment amounts by currency (it doesnt make sense to add 1000 kwacha to 1000 rupees). This sums them separately and displays them together, one per line, in the same cell.