### PR TITLE
add confirmed payments to payment table

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -297,6 +297,15 @@ class OpportunityAccess(models.Model):
         return Payment.objects.filter(opportunity_access=self).aggregate(total=Sum("amount")).get("total", 0) or 0
 
     @property
+    def total_confirmed_paid(self):
+        return (
+            Payment.objects.filter(opportunity_access=self, confirmed=True)
+            .aggregate(total=Sum("amount"))
+            .get("total", 0)
+            or 0
+        )
+
+    @property
     def display_name(self):
         if self.accepted:
             return self.user.name

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -97,7 +97,7 @@ class OpportunityPaymentTable(tables.Table):
 
     class Meta:
         model = OpportunityAccess
-        fields = ("display_name", "username", "payment_accrued", "total_paid")
+        fields = ("display_name", "username", "payment_accrued", "total_paid", "total_confirmed_paid")
         orderable = False
         empty_text = "No user have payments accrued yet."
 


### PR DESCRIPTION
I added the amount of confirmed payment to the payment status table that shows up in the main opportunity info page so it was easy to compare confirmed payments to claimed payments.