### PR TITLE
Update notification data for background notifications

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -119,13 +119,16 @@ def invite_user(user_id, opportunity_access_id):
     )
     message = Message(
         usernames=[user.username],
-        title=gettext(
-            f"You have been invited to a CommCare Connect opportunity - {opportunity_access.opportunity.name}"
-        ),
-        body=gettext(
-            f"You have been invited to a new job in Commcare Connect - {opportunity_access.opportunity.name}"
-        ),
-        data={"action": "ccc_opportunity_summary_page", "opportunity_id": str(opportunity_access.opportunity.id)},
+        data={
+            "action": "ccc_opportunity_summary_page",
+            "opportunity_id": str(opportunity_access.opportunity.id),
+            "title": gettext(
+                f"You have been invited to a CommCare Connect opportunity - {opportunity_access.opportunity.name}"
+            ),
+            "body": gettext(
+                f"You have been invited to a new job in Commcare Connect - {opportunity_access.opportunity.name}"
+            ),
+        },
     )
     send_message(message)
 
@@ -210,12 +213,15 @@ def _get_learn_message(access: OpportunityAccess):
     if last_user_learn_module and is_date_before(last_user_learn_module.date, days=3):
         return Message(
             usernames=[access.user.username],
-            title=gettext(f"Resume your learning journey for {access.opportunity.name}"),
-            body=gettext(
-                f"You have not completed your learning for {access.opportunity.name}."
-                "Please complete the learning modules to start delivering visits."
-            ),
-            data={"action": "ccc_learn_progress", "opportunity_id": str(access.opportunity.id)},
+            data={
+                "action": "ccc_learn_progress",
+                "opportunity_id": str(access.opportunity.id),
+                "title": gettext(f"Resume your learning journey for {access.opportunity.name}"),
+                "body": gettext(
+                    f"You have not completed your learning for {access.opportunity.name}."
+                    "Please complete the learning modules to start delivering visits."
+                ),
+            },
         )
 
 
@@ -230,12 +236,15 @@ def _check_deliver_inactive(access: OpportunityAccess):
 def _get_deliver_message(access: OpportunityAccess):
     return Message(
         usernames=[access.user.username],
-        title=gettext(f"Resume your job for {access.opportunity.name}"),
-        body=gettext(
-            f"You have not completed your delivery visits for {access.opportunity.name}."
-            "To maximise your payout complete all the required service delivery."
-        ),
-        data={"action": "ccc_delivery_progress", "opportunity_id": str(access.opportunity.id)},
+        data={
+            "action": "ccc_delivery_progress",
+            "opportunity_id": str(access.opportunity.id),
+            "title": gettext(f"Resume your job for {access.opportunity.name}"),
+            "body": gettext(
+                f"You have not completed your delivery visits for {access.opportunity.name}."
+                "To maximise your payout complete all the required service delivery."
+            ),
+        },
     )
 
 
@@ -247,11 +256,15 @@ def send_payment_notification(opportunity_id: int, payment_ids: list[int]):
         messages.append(
             Message(
                 usernames=[payment.opportunity_access.user.username],
-                title=gettext("Payment received"),
-                body=gettext(
-                    f"You have received a payment of {opportunity.currency} {payment.amount} for {opportunity.name}."
-                ),
-                data={"action": "ccc_payment", "opportunity_id": str(opportunity.id)},
+                data={
+                    "action": "ccc_payment",
+                    "opportunity_id": str(opportunity.id),
+                    "title": gettext("Payment received"),
+                    "body": gettext(
+                        "You have received a payment of"
+                        f"{opportunity.currency} {payment.amount} for {opportunity.name}.",
+                    ),
+                },
             )
         )
     send_message_bulk(messages)

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -57,8 +57,9 @@ def test_send_inactive_notification_learn_inactive_message(mobile_user: User, op
     )
     access = OpportunityAccess.objects.get(user=mobile_user, opportunity=opportunity)
     message = _get_inactive_message(access)
+    assert message is not None
     assert message.usernames[0] == mobile_user.username
-    assert message.title == f"Resume your learning journey for {opportunity.name}"
+    assert message.data.get("title") == f"Resume your learning journey for {opportunity.name}"
 
 
 def test_send_inactive_notification_deliver_inactive_message(mobile_user: User, opportunity: Opportunity):
@@ -75,8 +76,9 @@ def test_send_inactive_notification_deliver_inactive_message(mobile_user: User, 
     UserVisitFactory.create(user=mobile_user, opportunity=opportunity, visit_date=now() - datetime.timedelta(days=2))
 
     message = _get_inactive_message(access)
+    assert message is not None
     assert message.usernames[0] == mobile_user.username
-    assert message.title == f"Resume your job for {opportunity.name}"
+    assert message.data.get("title") == f"Resume your job for {opportunity.name}"
 
 
 def test_send_inactive_notification_not_claimed_deliver_message(mobile_user: User, opportunity: Opportunity):
@@ -90,8 +92,9 @@ def test_send_inactive_notification_not_claimed_deliver_message(mobile_user: Use
         )
     access = OpportunityAccess.objects.get(user=mobile_user, opportunity=opportunity)
     message = _get_inactive_message(access)
+    assert message is not None
     assert message.usernames[0] == mobile_user.username
-    assert message.title == f"Resume your job for {opportunity.name}"
+    assert message.data.get("title") == f"Resume your job for {opportunity.name}"
 
 
 def test_send_inactive_notification_active_user(mobile_user: User, opportunity: Opportunity):


### PR DESCRIPTION
This PR changes the Notification Payload structure to support notification in background and app killed states.
I have deployed this PR on staging and tested this change with help from the mobile team and the notification are working now in all app states i.e background, foreground and killed.

See comments on this ticket for more info. https://dimagi.atlassian.net/browse/CCCT-77