### PR TITLE
update quarter date calculation

### DIFF
--- a/commcare_connect/reports/tables.py
+++ b/commcare_connect/reports/tables.py
@@ -14,5 +14,8 @@ class AdminReportTable(tables.Table):
         empty_text = "No data for this quarter."
         orderable = False
 
-    def render_payments(self, value):
+    def render_total_payments(self, value):
+        return mark_safe("<br>".join(value))
+
+    def render_approved_payments(self, value):
         return mark_safe("<br>".join(value))

--- a/commcare_connect/reports/views.py
+++ b/commcare_connect/reports/views.py
@@ -34,9 +34,9 @@ def _get_quarters_since_start():
 
 
 def _get_table_data_for_quarter(quarter):
-    quarter_start = date(quarter[0], quarter[1] * 3, 1)
+    quarter_start = date(quarter[0], (quarter[1] - 1) * 3 + 1, 1)
     next_quarter = _increment(quarter)
-    quarter_end = date(next_quarter[0], next_quarter[1] * 3, 1)
+    quarter_end = date(next_quarter[0], (next_quarter[1] - 1) * 3 + 1, 1)
     visit_data = (
         CompletedWork.objects.annotate(work_date=Max("uservisit__visit_date"))
         .filter(


### PR DESCRIPTION
This fixes a couple bugs in the admin report.
1) The `render_X` functions were not updated for new payment column names
2) Quarter start and end dates were wrong. Quarter Q starts on month (Q - 1) * 3 + 1. For example,
    Q1 starts on (1 - 1)*3 +1=1
    Q2 starts on (2 - 1)*3 +1=4