### PR TITLE
Fix claim limit unique key error due to max_visits

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -582,7 +582,9 @@ class OpportunityClaimLimit(models.Model):
                 # claimed limit exceeded for this paymentunit
                 continue
             OpportunityClaimLimit.objects.get_or_create(
-                opportunity_claim=claim, payment_unit=payment_unit, max_visits=min(remaining, payment_unit.max_total)
+                opportunity_claim=claim,
+                payment_unit=payment_unit,
+                defaults={"max_visits": min(remaining, payment_unit.max_total)},
             )
 
 


### PR DESCRIPTION
[QA-Ticket](https://dimagi.atlassian.net/browse/QA-7068)

This bug was recently found in QA. The code throws a unique key error because it tries to create an already-created Claim Limit configuration due to the `max_visits` filter in `get_or_create`. The `max_visits` are only required when a new ClaimLimit is created, so moving it to the `defaults` parameter of `get_or_create` avoids the unique key error and adds `max_visits` specified to any new claim limits that are created.