### PR TITLE
change the default landing page content

### DIFF
--- a/commcare_connect/templates/base.html
+++ b/commcare_connect/templates/base.html
@@ -134,7 +134,10 @@
   {% block breadcrumbs %}{% endblock %}
 
   {% block content %}
-    <p>Use this document as a way to quick start any new project.</p>
+  <div class="mt-4">
+    <h1>CommCare Connect</h1>
+    <p class="lead">Unlocking more impact from Frontline Workers</p>
+  </div>
   {% endblock content %}
 
 </div> <!-- /container -->


### PR DESCRIPTION
I realize we're probably not expecting random people to land on this site, but it still seems better to have something basic in place at https://connect.dimagi.com