### PR TITLE
Fix review_status missing from query

### DIFF
--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -11,11 +11,11 @@ def update_status(completed_works, opportunity_access, compute_payment=True):
             continue
 
         if opportunity_access.opportunity.auto_approve_payments:
-            visits = completed_work.uservisit_set.values_list("status", "reason")
-            if any(status == "rejected" for status, _ in visits):
+            visits = completed_work.uservisit_set.values_list("status", "reason", "review_status")
+            if any(status == "rejected" for status, *_ in visits):
                 completed_work.status = CompletedWorkStatus.rejected
-                completed_work.reason = "\n".join(reason for _, reason in visits if reason)
-            elif all(status == "approved" for status, _ in visits):
+                completed_work.reason = "\n".join(reason for _, reason, _ in visits if reason)
+            elif all(status == "approved" for status, *_ in visits):
                 completed_work.status = CompletedWorkStatus.approved
 
             if (

--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -1,4 +1,4 @@
-from commcare_connect.opportunity.models import CompletedWorkStatus
+from commcare_connect.opportunity.models import CompletedWorkStatus, VisitReviewStatus, VisitValidationStatus
 
 
 def update_status(completed_works, opportunity_access, compute_payment=True):
@@ -12,15 +12,15 @@ def update_status(completed_works, opportunity_access, compute_payment=True):
 
         if opportunity_access.opportunity.auto_approve_payments:
             visits = completed_work.uservisit_set.values_list("status", "reason", "review_status")
-            if any(status == "rejected" for status, *_ in visits):
+            if any(status == VisitValidationStatus.rejected for status, *_ in visits):
                 completed_work.status = CompletedWorkStatus.rejected
                 completed_work.reason = "\n".join(reason for _, reason, _ in visits if reason)
-            elif all(status == "approved" for status, *_ in visits):
+            elif all(status == VisitValidationStatus.approved for status, *_ in visits):
                 completed_work.status = CompletedWorkStatus.approved
 
             if (
                 opportunity_access.opportunity.managed
-                and not all(review_status == "agree" for *_, review_status in visits)
+                and not all(review_status == VisitReviewStatus.agree for *_, review_status in visits)
                 and completed_work.status == CompletedWorkStatus.approved
             ):
                 completed_work.status = CompletedWorkStatus.pending


### PR DESCRIPTION
This and #399 have been due to a merge issue for the changes of the Program Management feature recently deployed to production. The PR that this change was a part of was based on an older version of changes on the main that caused the status updation code to get out of sync with branch and later during merge this caused issues when the code was finally adjusted to the latest changes.