### PR TITLE
handle empty location with catchment areas

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -179,13 +179,14 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
     if opportunity_flags.catchment_areas:
         areas = access.catchmentarea_set.filter(active=True)
         if areas:
-            cur_lat, cur_lon, *_ = xform.metadata.location.split(" ")
             within_catchment = False
-            for area in areas:
-                dist = distance((area.latitude, area.longitude), (cur_lat, cur_lon))
-                if dist.meters < area.radius:
-                    within_catchment = True
-                    break
+            if xform.metadata.location is not None:
+                cur_lat, cur_lon, *_ = xform.metadata.location.split(" ")
+                for area in areas:
+                    dist = distance((area.latitude, area.longitude), (cur_lat, cur_lon))
+                    if dist.meters < area.radius:
+                        within_catchment = True
+                        break
             if not within_catchment:
                 flags.append(["catchment", "Visit outside worker catchment areas"])
     if (


### PR DESCRIPTION
This was crashing when a form with no location was submitted by a user with assigned catchment areas. I think it's a bit debatable whether we should include the flag in that case, but I like that it signals to the reviewer that the user did have an assigned area. One that we are not sure if they were inside.