### PR TITLE
Fix allow PM and NM to view review users visits and payment invoices pages

### DIFF
--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -44,7 +44,7 @@
               Add Budget
             </a>
           </li>
-          {% if object.managed and request.org_membership.is_program_manager or request.user.is_superuser %}
+          {% if object.managed %}
           <li>
             <a class="dropdown-item"
                href="{% url "opportunity:user_visit_review" org_slug=request.org.slug opp_id=opportunity.pk %}">
@@ -52,13 +52,15 @@
              {% translate "Review User Visits" %}
             </a>
           </li>
-          <li>
-            <a class="dropdown-item"
-               href="{% url "opportunity:payment_report" org_slug=request.org.slug pk=opportunity.pk %}">
-              <i class="bi bi-pie-chart-fill pe-2"></i>
-             {% translate "Payment Report" %}
-            </a>
-          </li>
+            {% if request.org_membership.is_program_manager or request.user.is_superuser %}
+              <li>
+                <a class="dropdown-item"
+                   href="{% url "opportunity:payment_report" org_slug=request.org.slug pk=opportunity.pk %}">
+                  <i class="bi bi-pie-chart-fill pe-2"></i>
+                 {% translate "Payment Report" %}
+                </a>
+              </li>
+            {% endif %}
           <li>
             <a class="dropdown-item"
                href="{% url "opportunity:invoice_list" org_slug=request.org.slug pk=opportunity.pk %}">


### PR DESCRIPTION
This PR fixes a bug in conditions that hide the links to Review User Visits and Invoices page for Network Manager users.