### PR TITLE
Handle null currency

### DIFF
--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -285,7 +285,9 @@ def _cache_key(currency_code, date=None):
 def get_exchange_rate(currency_code, date=None):
     # date should be a date object or None for latest rate
 
-    if currency_code in ["USD", None]:
+    if currency_code is None:
+        raise ImportException("Opportunity must have specified currency to import payments")
+    if currency_code == "USD":
         return 1
 
     base_url = "https://openexchangerates.org/api"


### PR DESCRIPTION
This ensures we don't calculate USD amounts for opportunities whose currencies are unknown.