### PR TITLE
adding consistent ordering to visit export

### DIFF
--- a/commcare_connect/opportunity/export.py
+++ b/commcare_connect/opportunity/export.py
@@ -36,6 +36,7 @@ def export_user_visit_data(
         user_visits = user_visits.filter(visit_date__gte=date_range.get_cutoff_date())
     if status and "all" not in status:
         user_visits = user_visits.filter(status__in=status)
+    user_visits = user_visits.order_by("visit_date")
 
     table = UserVisitTable(user_visits)
     exclude_columns = ("visit_date", "form_json", "details", "justification")


### PR DESCRIPTION
I think this should fix the flaky test (and make sure that visit exports are always in the same order, which might be nice anyway).