### PR TITLE
Fix for historical model issue in opportunity 0060 migration.

### DIFF
--- a/commcare_connect/opportunity/migrations/0060_completedwork_payment_date.py
+++ b/commcare_connect/opportunity/migrations/0060_completedwork_payment_date.py
@@ -2,15 +2,17 @@
 
 from django.db import migrations, models, transaction
 
-from commcare_connect.opportunity.models import OpportunityAccess
 from commcare_connect.opportunity.utils.completed_work import update_work_payment_date
 
 
 @transaction.atomic
 def update_paid_date_from_payments(apps, schema_editor):
+    OpportunityAccess = apps.get_model("opportunity.OpportunityAccess")
+    Payment = apps.get_model("opportunity.Payment")
+    CompletedWork = apps.get_model("opportunity.CompletedWork")
     accesses = OpportunityAccess.objects.all()
     for access in accesses:
-        update_work_payment_date(access)
+        update_work_payment_date(access, Payment, CompletedWork)
 
 
 class Migration(migrations.Migration):

--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -44,9 +44,20 @@ def update_status(completed_works, opportunity_access, compute_payment=True):
         opportunity_access.save()
 
 
-def update_work_payment_date(access: OpportunityAccess):
-    payments = Payment.objects.filter(opportunity_access=access).order_by("date_paid")
-    completed_works = CompletedWork.objects.filter(opportunity_access=access).order_by("status_modified_date")
+def update_work_payment_date(access: OpportunityAccess, payment_model_ref=None, completed_work_model_ref=None):
+    """
+    Import models dynamically within the function helps us avoid issues with historical models during migrations.
+    """
+    if not payment_model_ref:
+        payment_model_ref = Payment
+
+    if not completed_work_model_ref:
+        completed_work_model_ref = CompletedWork
+
+    payments = payment_model_ref.objects.filter(opportunity_access=access).order_by("date_paid")
+    completed_works = completed_work_model_ref.objects.filter(opportunity_access=access).order_by(
+        "status_modified_date"
+    )
 
     if not payments or not completed_works:
         return
@@ -76,4 +87,4 @@ def update_work_payment_date(access: OpportunityAccess):
         break
 
     if works_to_update:
-        CompletedWork.objects.bulk_update(works_to_update, ["payment_date"])
+        completed_work_model_ref.objects.bulk_update(works_to_update, ["payment_date"])

--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -44,17 +44,14 @@ def update_status(completed_works, opportunity_access, compute_payment=True):
         opportunity_access.save()
 
 
-def update_work_payment_date(access: OpportunityAccess, payment_model_ref=None, completed_work_model_ref=None):
+def update_work_payment_date(access: OpportunityAccess, payment_model=None, completed_work_model=None):
     """
     Dynamically assign models to avoid issues with historical models during migrations.
     Top-level imports use the current model, which may not match the schema at migration
     time. This ensures we use historical models during migrations and current models in normal execution.
     """
-    if not payment_model_ref:
-        payment_model_ref = Payment
-
-    if not completed_work_model_ref:
-        completed_work_model_ref = CompletedWork
+    payment_model_ref = payment_model or Payment
+    completed_work_model_ref = completed_work_model or CompletedWork
 
     payments = payment_model_ref.objects.filter(opportunity_access=access).order_by("date_paid")
     completed_works = completed_work_model_ref.objects.filter(opportunity_access=access).order_by(

--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -46,7 +46,9 @@ def update_status(completed_works, opportunity_access, compute_payment=True):
 
 def update_work_payment_date(access: OpportunityAccess, payment_model_ref=None, completed_work_model_ref=None):
     """
-    Import models dynamically within the function helps us avoid issues with historical models during migrations.
+    Dynamically assign models to avoid issues with historical models during migrations.
+    Top-level imports use the current model, which may not match the schema at migration
+    time. This ensures we use historical models during migrations and current models in normal execution.
     """
     if not payment_model_ref:
         payment_model_ref = Payment


### PR DESCRIPTION
This PR updates the `update_work_payment_date` function to dynamically assign model references `(Payment and CompletedWork)` within the function. This change ensures compatibility with Django's migration system, where historical models must be used.

By avoiding top-level imports, the function can now:

Use historical models when called from migrations (via `apps.get_model()`).
Fallback to current models when called during normal app execution.
This approach prevents issues caused by schema changes between migration and runtime models, ensuring smoother migrations and consistent behaviour.


For reference- [Historical-models](https://docs.djangoproject.com/en/5.1/topics/migrations/#historical-models)