### PR TITLE
Update Organization Member Invite Flow to Use Text Field

### DIFF
--- a/commcare_connect/organization/forms.py
+++ b/commcare_connect/organization/forms.py
@@ -31,7 +31,7 @@ class MembershipForm(forms.ModelForm):
         max_length=254,
         required=True,
         label="",
-        widget=forms.TextInput(attrs={"placeholder": "Enter email or username"}),
+        widget=forms.TextInput(attrs={"placeholder": "Enter email address or username"}),
     )
 
     class Meta:
@@ -56,10 +56,7 @@ class MembershipForm(forms.ModelForm):
     def clean_email_or_username(self):
         email_or_username = self.cleaned_data["email_or_username"]
         user = (
-            User.objects.filter(
-                Q(email=email_or_username) | Q(username=email_or_username),
-                email__isnull=False,
-            )
+            User.objects.filter(Q(email=email_or_username) | Q(username=email_or_username))
             .exclude(memberships__organization=self.organization)
             .first()
         )

--- a/commcare_connect/organization/forms.py
+++ b/commcare_connect/organization/forms.py
@@ -57,7 +57,7 @@ class MembershipForm(forms.ModelForm):
         user = User.objects.filter(email=email).exclude(memberships__organization=self.organization).first()
 
         if not user:
-            raise ValidationError("User with this email/username does not exist or is already a member")
+            raise ValidationError("User with this email does not exist or is already a member")
 
         self.instance.user = user
         return email

--- a/commcare_connect/organization/forms.py
+++ b/commcare_connect/organization/forms.py
@@ -1,5 +1,7 @@
 from crispy_forms import helper, layout
 from django import forms
+from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.utils.translation import gettext
 
 from commcare_connect.organization.models import Organization, UserOrganizationMembership
@@ -25,28 +27,48 @@ class OrganizationChangeForm(forms.ModelForm):
 
 
 class MembershipForm(forms.ModelForm):
+    email_or_username = forms.CharField(
+        max_length=254,
+        required=True,
+        label="",
+        widget=forms.TextInput(attrs={"placeholder": "Enter email or username"}),
+    )
+
     class Meta:
         model = UserOrganizationMembership
-        fields = ("user", "role")
-        labels = {"user": "", "role": ""}
+        fields = ("role",)
+        labels = {"role": ""}
 
     def __init__(self, *args, **kwargs):
         self.organization = kwargs.pop("organization")
         super().__init__(*args, **kwargs)
 
-        self.fields["user"].queryset = User.objects.filter(email__isnull=False).exclude(
-            memberships__organization=self.organization
-        )
-
         self.helper = helper.FormHelper(self)
         self.helper.layout = layout.Layout(
             layout.Row(
                 layout.HTML("<h4>Add new member</h4>"),
-                layout.Field("user", wrapper_class="col-md-5"),
+                layout.Field("email_or_username", wrapper_class="col-md-5"),
                 layout.Field("role", wrapper_class="col-md-5"),
                 layout.Div(layout.Submit("submit", gettext("Submit")), css_class="col-md-2"),
             ),
         )
+
+    def clean_email_or_username(self):
+        email_or_username = self.cleaned_data["email_or_username"]
+        user = (
+            User.objects.filter(
+                Q(email=email_or_username) | Q(username=email_or_username),
+                email__isnull=False,
+            )
+            .exclude(memberships__organization=self.organization)
+            .first()
+        )
+
+        if not user:
+            raise ValidationError("User with this email/username does not exist or is already a member")
+
+        self.instance.user = user
+        return email_or_username
 
 
 class AddCredentialForm(forms.Form):

--- a/commcare_connect/organization/tests/test_forms.py
+++ b/commcare_connect/organization/tests/test_forms.py
@@ -16,19 +16,17 @@ class TestAddMembersView:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "email_or_username, role, expected_status_code, create_user, expected_role, should_exist",
+        "email, role, expected_status_code, create_user, expected_role, should_exist",
         [
             ("testformember@example.com", "member", 302, True, "member", True),
             ("testforadmin@example.com", "admin", 302, True, "admin", True),
-            ("testforusername", "member", 302, True, "member", True),
-            ("testforusername", "admin", 302, True, "admin", True),
             ("nonexistent@example.com", "member", 302, False, None, False),
             ("existing@example.com", "admin", 302, True, "member", True),
         ],
     )
     def test_add_member(
         self,
-        email_or_username,
+        email,
         role,
         expected_status_code,
         create_user,
@@ -37,20 +35,15 @@ class TestAddMembersView:
         organization,
     ):
         if create_user:
-            user = UserFactory(
-                email=email_or_username if "@" in email_or_username else None,
-                username=email_or_username if "@" not in email_or_username else None,
-            )
+            user = UserFactory(email=email)
 
-            if email_or_username == "existing@example.com":
+            if email == "existing@example.com":
                 organization.members.add(user, through_defaults={"role": expected_role})
 
-        data = {"email_or_username": email_or_username, "role": role}
+        data = {"email": email, "role": role}
         response = self.client.post(self.url, data)
 
-        membership_filter = (
-            {"user__email": email_or_username} if "@" in email_or_username else {"user__username": email_or_username}
-        )
+        membership_filter = {"user__email": email}
 
         assert response.status_code == expected_status_code
         membership_exists = organization.memberships.filter(**membership_filter).exists()

--- a/commcare_connect/organization/tests/test_forms.py
+++ b/commcare_connect/organization/tests/test_forms.py
@@ -1,0 +1,53 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from commcare_connect.organization.models import Organization
+from commcare_connect.users.tests.factories import UserFactory
+
+
+class TestAddMembersView:
+    @pytest.fixture(autouse=True)
+    def setup(self, organization: Organization, client: Client):
+        self.url = reverse("organization:add_members", kwargs={"org_slug": organization.slug})
+        self.user = organization.memberships.filter(role="admin").first().user
+        self.client = client
+        client.force_login(self.user)
+
+    @pytest.mark.django_db
+    def test_add_member_by_email(self, organization):
+        new_user = UserFactory(email="test@example.com")
+        data = {"email_or_username": new_user.email, "role": "member"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        assert response.url == reverse("organization:home", kwargs={"org_slug": organization.slug})
+        membership = organization.memberships.get(user=new_user)
+        assert membership.role == data["role"]
+
+    @pytest.mark.django_db
+    def test_add_member_by_username(self, organization):
+        new_user = UserFactory(username="test")
+        data = {"email_or_username": new_user.username, "role": "member"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        membership = organization.memberships.get(user=new_user)
+        assert membership.role == data["role"]
+        assert not membership.accepted
+
+    @pytest.mark.django_db
+    def test_add_member_nonexistent_user(self, organization):
+        data = {"email_or_username": "nonexistent@example.com", "role": "member"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        assert not organization.memberships.filter(user__email="nonexistent@example.com").exists()
+
+    @pytest.mark.django_db
+    def test_add_existing_member(self, organization):
+        existing_user = UserFactory(email="test@example.com")
+        organization.members.add(existing_user, through_defaults={"role": "member"})
+
+        data = {"email_or_username": existing_user.email, "role": "admin"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        assert organization.memberships.filter(user=existing_user).count() == 1
+        assert organization.memberships.get(user=existing_user).role == "member"


### PR DESCRIPTION
[CCCT-525](https://dimagi.atlassian.net/browse/CCCT-525)

[CCCT-525]: https://dimagi.atlassian.net/browse/CCCT-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Modified the organization member invite flow by replacing the current email selection dropdown with a text field to allow direct entry of user email addresses

<img width="1301" alt="Screenshot 2024-11-06 at 14 28 32" src="https://github.com/user-attachments/assets/e799ccf5-7937-4088-a855-e143e1a9218a">


