### PR TITLE
allow search by username

### DIFF
--- a/commcare_connect/opportunity/admin.py
+++ b/commcare_connect/opportunity/admin.py
@@ -48,6 +48,7 @@ class OpportunityAccessAdmin(admin.ModelAdmin):
     form = OpportunityAccessCreationForm
     list_display = ["get_opp_name", "get_username"]
     actions = ["clear_user_progress"]
+    search_fields = ["user__username"]
 
     @admin.display(description="Opportunity Name")
     def get_opp_name(self, obj):


### PR DESCRIPTION
This allows searching the django admin for opportunity access by username (basically get a list of all opportunities that a user is a member of).