### PR TITLE
 Deadlock Detected in bulk update payments.

### DIFF
--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -271,10 +271,16 @@ def _bulk_update_payments(opportunity: Opportunity, imported_data: Dataset) -> P
             payment = Payment.objects.create(opportunity_access=access, amount=amount, amount_usd=amount_usd)
             seen_users.add(username)
             payment_ids.append(payment.pk)
-            update_work_payment_date(access)
+        process_work_payment_dates(users)
     missing_users = set(usernames) - seen_users
     send_payment_notification.delay(opportunity.id, payment_ids)
     return PaymentImportStatus(seen_users, missing_users)
+
+
+def process_work_payment_dates(accesses: list):
+    with transaction.atomic():
+        for oa in accesses:
+            update_work_payment_date(oa)
 
 
 def _cache_key(currency_code, date=None):

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -261,7 +261,7 @@ def _bulk_update_payments(opportunity: Opportunity, imported_data: Dataset) -> P
     seen_users = set()
     payment_ids = []
     lock_key = f"bulk_update_payments_opportunity_{opportunity.id}"
-    with cache.lock(lock_key, timeout=60):  # Lock expires after 60 seconds if the work is not finished.
+    with cache.lock(lock_key, timeout=60):
         with transaction.atomic():
             usernames = list(payments)
             users = OpportunityAccess.objects.filter(

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -261,7 +261,7 @@ def _bulk_update_payments(opportunity: Opportunity, imported_data: Dataset) -> P
     seen_users = set()
     payment_ids = []
     lock_key = f"bulk_update_payments_opportunity_{opportunity.id}"
-    with cache.lock(lock_key, timeout=60):
+    with cache.lock(lock_key, timeout=300):
         with transaction.atomic():
             usernames = list(payments)
             users = OpportunityAccess.objects.filter(

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -261,7 +261,7 @@ def _bulk_update_payments(opportunity: Opportunity, imported_data: Dataset) -> P
     seen_users = set()
     payment_ids = []
     lock_key = f"bulk_update_payments_opportunity_{opportunity.id}"
-    with cache.lock(lock_key, timeout=300):
+    with cache.lock(lock_key, timeout=600):
         with transaction.atomic():
             usernames = list(payments)
             users = OpportunityAccess.objects.filter(


### PR DESCRIPTION
[CCCT-549](https://dimagi.atlassian.net/browse/CCCT-549)

[Sentry link](https://dimagi.sentry.io/issues/6059769484/?environment=production&project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=11)

- The deadlock error indicates that two separate transactions were trying to access the same data in conflicting orders, even though the code is using a single transaction.atomic() block.
- This suggests there are concurrency issues beyond just the single transaction, likely due to the fact that this is a Celery task.
- The` transaction.atomic()` block only ensures atomicity within a single Celery task, but does not prevent deadlocks between multiple concurrent tasks.

To resolve this, I have used cache lock so that only one bulk update payment is allowed at a time.

[CCCT-549]: https://dimagi.atlassian.net/browse/CCCT-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ