### PR TITLE
UserMessageStatus build method error

### DIFF
--- a/commcare_connect/connect_id_client/models.py
+++ b/commcare_connect/connect_id_client/models.py
@@ -35,7 +35,7 @@ class UserMessageStatus:
 
     @classmethod
     def build(cls, username: str, status: str, *args, **kwargs):
-        error = kwargs.pop("error")
+        error = kwargs.get("error")
         if error is not None:
             raise MessagingError(error)
         return cls(username, MessageStatus(status))

--- a/commcare_connect/connect_id_client/models.py
+++ b/commcare_connect/connect_id_client/models.py
@@ -2,6 +2,10 @@ import dataclasses
 from enum import StrEnum
 
 
+class MessagingError(Exception):
+    pass
+
+
 @dataclasses.dataclass
 class ConnectIdUser:
     name: str
@@ -31,6 +35,9 @@ class UserMessageStatus:
 
     @classmethod
     def build(cls, username: str, status: str, *args, **kwargs):
+        error = kwargs.pop("error")
+        if error is not None:
+            raise MessagingError(error)
         return cls(username, MessageStatus(status))
 
 

--- a/commcare_connect/connect_id_client/models.py
+++ b/commcare_connect/connect_id_client/models.py
@@ -30,7 +30,7 @@ class UserMessageStatus:
     status: MessageStatus
 
     @classmethod
-    def build(cls, username: str, status: str):
+    def build(cls, username: str, status: str, *args, **kwargs):
         return cls(username, MessageStatus(status))
 
 


### PR DESCRIPTION
This fixes the UserMessageStatus.build method error when supplied with the `error` parameter.

[Error Link](https://dimagi.sentry.io/issues/5799897740/?environment=production&project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=4&utc=true)