### PR TITLE
Fix text check causing issues in hq user creation

### DIFF
--- a/commcare_connect/users/helpers.py
+++ b/commcare_connect/users/helpers.py
@@ -34,7 +34,7 @@ def create_hq_user(user, domain, api_key):
     try:
         hq_request.raise_for_status()
     except httpx.HTTPStatusError as e:
-        if e.response.status_code == 400 and "already exists" in e.response.text:
+        if e.response.status_code == 400 and "already taken" in e.response.text:
             return True
         raise CommCareHQAPIException(
             f"{e.response.status_code} Error response {e.response.text} while creating user {user.username}"


### PR DESCRIPTION
This error surfaced recently when QA tried to reopen an opportunity and invite some users. These were already created on HQ. The request returns "Username {} is already taken or reserved" and we are checking for "already exists" in the response text which caused the check for an already existing user to be skipped and raised the API exception.

[Sentry Error Link](https://dimagi.sentry.io/issues/4620204019/?environment=staging&project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0&utc=true)