### PR TITLE
Added the org slug in table

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -374,7 +374,7 @@ class CatchmentAreaTable(tables.Table):
         )
 
 
-class UserVisitReviewTable(tables.Table):
+class UserVisitReviewTable(OrgContextTable):
     pk = columns.CheckBoxColumn(
         accessor="pk",
         verbose_name="",
@@ -389,12 +389,7 @@ class UserVisitReviewTable(tables.Table):
     visit_date = columns.Column()
     created_on = columns.Column(accessor="review_created_on", verbose_name="Review Requested On")
     review_status = columns.Column(verbose_name="Program Manager Review")
-    user_visit = columns.LinkColumn(
-        "opportunity:visit_verification",
-        verbose_name="User Visit",
-        text="View",
-        args=[utils.A("opportunity__organization__slug"), utils.A("pk")],
-    )
+    user_visit = columns.Column(verbose_name="User Visit", empty_values=())
 
     class Meta:
         model = UserVisit
@@ -411,6 +406,13 @@ class UserVisitReviewTable(tables.Table):
             "user_visit",
         )
         empty_text = "No visits submitted for review."
+
+    def render_user_visit(self, record):
+        url = reverse(
+            "opportunity:visit_verification",
+            kwargs={"org_slug": self.org_slug, "pk": record.pk},
+        )
+        return mark_safe(f'<a href="{url}">View</a>')
 
 
 class PaymentReportTable(tables.Table):

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1112,7 +1112,7 @@ def user_visit_review(request, org_slug, opp_id):
     user_visit_reviews = UserVisit.objects.filter(opportunity=opportunity, review_created_on__isnull=False).order_by(
         "visit_date"
     )
-    table = UserVisitReviewTable(user_visit_reviews)
+    table = UserVisitReviewTable(user_visit_reviews, org_slug=request.org.slug)
     if not is_program_manager:
         table.exclude = ("pk",)
     if request.POST and is_program_manager:


### PR DESCRIPTION
[Slack message](https://dimagi.slack.com/archives/C05UNUNH43X/p1732863342736529)

When the Program Manager (PM) tries to view the visit, the system incorrectly picks the organization slug from the opportunity. This is problematic in the case of a managed opportunity because, when the PM views the opportunity, the verification process checks whether the user belongs to that organization. However, it is not necessary for a user belonging to the PM organization to also belong to the NM organization. This fix addresses that issue.