### PR TITLE
Claim Limit Remaining Budget Fix

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -108,18 +108,16 @@ class Opportunity(BaseModel):
 
     @property
     def remaining_budget(self) -> int:
-        if not self.managed:
-            return self.total_budget - self.claimed_budget
-
-        org_pay = self.managedopportunity.org_pay_per_visit * self.allotted_visits
-        total_user_budget = self.total_budget - org_pay
-        return total_user_budget - self.claimed_budget
+        return self.total_budget - self.claimed_budget
 
     @property
     def claimed_budget(self):
         opp_access = OpportunityAccess.objects.filter(opportunity=self)
         opportunity_claim = OpportunityClaim.objects.filter(opportunity_access__in=opp_access)
         claim_limits = OpportunityClaimLimit.objects.filter(opportunity_claim__in=opportunity_claim)
+        org_pay = 0
+        if self.managed:
+            org_pay = self.managedopportunity.org_pay_per_visit
 
         payment_unit_counts = claim_limits.values("payment_unit").annotate(
             visits_count=Sum("max_visits"), amount=F("payment_unit__amount")
@@ -128,7 +126,7 @@ class Opportunity(BaseModel):
         for count in payment_unit_counts:
             visits_count = count["visits_count"]
             amount = count["amount"]
-            claimed += visits_count * amount
+            claimed += visits_count * (amount + org_pay)
 
         return claimed
 

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -108,7 +108,12 @@ class Opportunity(BaseModel):
 
     @property
     def remaining_budget(self) -> int:
-        return self.total_budget - self.claimed_budget
+        if not self.managed:
+            return self.total_budget - self.claimed_budget
+
+        org_pay = self.managedopportunity.org_pay_per_visit * self.allotted_visits
+        total_user_budget = self.total_budget - org_pay
+        return total_user_budget - self.claimed_budget
 
     @property
     def claimed_budget(self):

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -27,18 +27,19 @@ def test_learn_progress(opportunity: Opportunity):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("opportunity", [{}, {"opp_options": {"managed": True}}], indirect=True)
 def test_opportunity_stats(opportunity: Opportunity, user: User):
-    payment_unit_sub = PaymentUnitFactory(
+    payment_unit_sub = PaymentUnitFactory.create(
         opportunity=opportunity, max_total=100, max_daily=10, amount=5, parent_payment_unit=None
     )
-    payment_unit1 = PaymentUnitFactory(
+    payment_unit1 = PaymentUnitFactory.create(
         opportunity=opportunity,
         max_total=100,
         max_daily=10,
         amount=3,
         parent_payment_unit=payment_unit_sub,
     )
-    payment_unit2 = PaymentUnitFactory(
+    payment_unit2 = PaymentUnitFactory.create(
         opportunity=opportunity, max_total=100, max_daily=10, amount=5, parent_payment_unit=None
     )
     assert set(list(opportunity.paymentunit_set.values_list("id", flat=True))) == {
@@ -46,10 +47,17 @@ def test_opportunity_stats(opportunity: Opportunity, user: User):
         payment_unit2.id,
         payment_unit_sub.id,
     }
+    payment_units = [payment_unit_sub, payment_unit1, payment_unit2]
+    budget_per_user = sum(pu.max_total * pu.amount for pu in payment_units)
+    org_pay = 0
+    if opportunity.managed:
+        org_pay = opportunity.managedopportunity.org_pay_per_visit
+        budget_per_user += sum(pu.max_total * org_pay for pu in payment_units)
+    opportunity.total_budget = budget_per_user * 3
 
     payment_units = [payment_unit1, payment_unit2, payment_unit_sub]
     assert opportunity.budget_per_user == sum([p.amount * p.max_total for p in payment_units])
-    assert opportunity.number_of_users == opportunity.total_budget / opportunity.budget_per_user
+    assert opportunity.number_of_users == 3
     assert opportunity.allotted_visits == sum([pu.max_total for pu in payment_units]) * opportunity.number_of_users
     assert opportunity.max_visits_per_user_new == sum([pu.max_total for pu in payment_units])
     assert opportunity.daily_max_visits_per_user_new == sum([pu.max_daily for pu in payment_units])
@@ -61,7 +69,12 @@ def test_opportunity_stats(opportunity: Opportunity, user: User):
     ocl1 = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit1)
     ocl2 = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit2)
 
-    opportunity.claimed_budget == (ocl1.max_visits * payment_unit1.amount) + (ocl2.max_visits * payment_unit2.amount)
+    assert opportunity.claimed_budget == (ocl1.max_visits * payment_unit1.amount) + (
+        ocl2.max_visits * payment_unit2.amount
+    )
+    assert opportunity.remaining_budget == opportunity.total_budget - opportunity.claimed_budget - (
+        opportunity.allotted_visits * org_pay
+    )
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -69,12 +69,10 @@ def test_opportunity_stats(opportunity: Opportunity, user: User):
     ocl1 = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit1)
     ocl2 = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit2)
 
-    assert opportunity.claimed_budget == (ocl1.max_visits * payment_unit1.amount) + (
-        ocl2.max_visits * payment_unit2.amount
+    assert opportunity.claimed_budget == (ocl1.max_visits * (payment_unit1.amount + org_pay)) + (
+        ocl2.max_visits * (payment_unit2.amount + org_pay)
     )
-    assert opportunity.remaining_budget == opportunity.total_budget - opportunity.claimed_budget - (
-        opportunity.allotted_visits * org_pay
-    )
+    assert opportunity.remaining_budget == opportunity.total_budget - opportunity.claimed_budget
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The remaining budget calculation for Managed Opportunities was off due to the org_pay component added to the total budget. To calculate the effective user total budget we have to remove the org_pay component from the total budget, then this user total budget can be used to calculate the remaining budget.

This PR will fix the remaining budget calculation and also fix the bug related to Opportunity Claims getting created for users in opportunities where the budget is exhausted.

[Ticket](https://dimagi.atlassian.net/browse/CCCT-562)