### PR TITLE
add option to include over limit works

### DIFF
--- a/commcare_connect/opportunity/management/commands/auto_approval_opportunities.py
+++ b/commcare_connect/opportunity/management/commands/auto_approval_opportunities.py
@@ -17,9 +17,11 @@ class Command(BaseCommand):
         parser.add_argument(
             "--include-over-limit", action="store_true", help="Also run auto-approval logic on over limit works"
         )
+        parser.add_argument("--update-payment", action="store_true", help="Update payment accrued")
 
     def handle(self, *args, opp: int, **options):
         include_over_limit = options.get("include_over_limit", False)
+        update_payment = options.get("update_payment", False)
         excluded = [CompletedWorkStatus.rejected]
         if not include_over_limit:
             excluded.append(CompletedWorkStatus.over_limit)
@@ -30,7 +32,7 @@ class Command(BaseCommand):
             )
             for access in access_objects:
                 completed_works = access.completedwork_set.exclude(status__in=excluded)
-                update_status(completed_works, access, False)
+                update_status(completed_works, access, update_payment)
 
             self.stdout.write(self.style.SUCCESS(f"Successfully processed opportunity with id {opp}"))
 

--- a/commcare_connect/opportunity/management/commands/auto_approval_opportunities.py
+++ b/commcare_connect/opportunity/management/commands/auto_approval_opportunities.py
@@ -9,19 +9,27 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--opp", type=int, required=True, help="ID of the opportunity to run auto-approval logic on"
+            "--opp",
+            type=int,
+            required=True,
+            help="ID of the opportunity to run auto-approval logic on",
+        )
+        parser.add_argument(
+            "--include-over-limit", action="store_true", help="Also run auto-approval logic on over limit works"
         )
 
     def handle(self, *args, opp: int, **options):
+        include_over_limit = options.get("include_over_limit", False)
+        excluded = [CompletedWorkStatus.rejected]
+        if not include_over_limit:
+            excluded.append(CompletedWorkStatus.over_limit)
         try:
             opportunity = Opportunity.objects.get(id=opp)
             access_objects = OpportunityAccess.objects.filter(
                 opportunity=opportunity, suspended=False, opportunity__auto_approve_payments=True
             )
             for access in access_objects:
-                completed_works = access.completedwork_set.exclude(
-                    status__in=[CompletedWorkStatus.rejected, CompletedWorkStatus.over_limit]
-                )
+                completed_works = access.completedwork_set.exclude(status__in=excluded)
                 update_status(completed_works, access, False)
 
             self.stdout.write(self.style.SUCCESS(f"Successfully processed opportunity with id {opp}"))


### PR DESCRIPTION
This maintains default behavior but allows the option to also process over limit `CompletedWork`, necessary for some data correction.