### PR TITLE
Fix Review creation for Already Approved Visits.

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -866,17 +866,18 @@ def visit_verification(request, org_slug=None, pk=None):
 @org_member_required
 def approve_visit(request, org_slug=None, pk=None):
     user_visit = UserVisit.objects.get(pk=pk)
-    old_status = user_visit.status
-    user_visit.status = VisitValidationStatus.approved
-    if user_visit.opportunity.managed and old_status != VisitValidationStatus.approved:
-        user_visit.review_created_on = now()
-    user_visit.save()
     opp_id = user_visit.opportunity_id
-    access = OpportunityAccess.objects.get(user_id=user_visit.user_id, opportunity_id=opp_id)
-    update_payment_accrued(opportunity=access.opportunity, users=[access.user])
+    if user_visit.status != VisitValidationStatus.approved:
+        user_visit.status = VisitValidationStatus.approved
+        if user_visit.opportunity.managed:
+            user_visit.review_created_on = now()
+        user_visit.save()
+        update_payment_accrued(opportunity=user_visit.opportunity, users=[user_visit.user])
     if user_visit.opportunity.managed:
         return redirect("opportunity:user_visit_review", org_slug, opp_id)
-    return redirect("opportunity:user_visits_list", org_slug=org_slug, opp_id=user_visit.opportunity.id, pk=access.id)
+    return redirect(
+        "opportunity:user_visits_list", org_slug=org_slug, opp_id=opp_id, pk=user_visit.opportunity_access_id
+    )
 
 
 @org_member_required

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -866,8 +866,9 @@ def visit_verification(request, org_slug=None, pk=None):
 @org_member_required
 def approve_visit(request, org_slug=None, pk=None):
     user_visit = UserVisit.objects.get(pk=pk)
+    old_status = user_visit.status
     user_visit.status = VisitValidationStatus.approved
-    if user_visit.opportunity.managed:
+    if user_visit.opportunity.managed and old_status != VisitValidationStatus.approved:
         user_visit.review_created_on = now()
     user_visit.save()
     opp_id = user_visit.opportunity_id


### PR DESCRIPTION
The Approve Visit view allows the review to be created for already approved forms. This PR checks if the status is approved and skips creating the review for those forms.

This is partly related to this [ticket](https://dimagi.atlassian.net/browse/CCCT-578). 