### PR TITLE
Negative average time to convert in funnel performance report.

### DIFF
--- a/commcare_connect/program/helpers.py
+++ b/commcare_connect/program/helpers.py
@@ -64,7 +64,15 @@ def get_annotated_managed_opportunity(program: Program):
             percentage_conversion=calculate_safe_percentage("workers_starting_delivery", "workers_invited"),
             average_time_to_convert=Avg(
                 ExpressionWrapper(
-                    Subquery(earliest_visits) - F("opportunityaccess__invited_date"), output_field=DurationField()
+                    Case(
+                        When(
+                            Q(opportunityaccess__invited_date__isnull=False)
+                            & Q(opportunityaccess__uservisit__isnull=False),
+                            then=Subquery(earliest_visits) - F("opportunityaccess__invited_date"),
+                        ),
+                        default=None,
+                    ),
+                    output_field=DurationField(),
                 ),
                 filter=FILTER_FOR_VALID_VISIT_DATE,
                 distinct=True,

--- a/commcare_connect/program/helpers.py
+++ b/commcare_connect/program/helpers.py
@@ -120,7 +120,7 @@ def get_delivery_performance_report(program: Program, start_date, end_date):
                 distinct=True,
                 filter=date_filter & Q(opportunityaccess__uservisit__completed_work__isnull=False),
             ),
-            deliveries_per_day_per_worker=Case(
+            deliveries_per_worker=Case(
                 When(active_workers=0, then=Value(0)),
                 default=Round(F("total_payment_since_start_date") / F("active_workers"), 2),
                 output_field=FloatField(),

--- a/commcare_connect/program/helpers.py
+++ b/commcare_connect/program/helpers.py
@@ -52,7 +52,7 @@ def get_annotated_managed_opportunity(program: Program):
         .annotate(
             workers_invited=Count("opportunityaccess", distinct=True),
             workers_passing_assessment=Count(
-                "opportunityaccess__assessment__opportunity_access",
+                "opportunityaccess",
                 filter=Q(
                     opportunityaccess__assessment__passed=True,
                 ),

--- a/commcare_connect/program/tables.py
+++ b/commcare_connect/program/tables.py
@@ -285,7 +285,7 @@ class DeliveryPerformanceTable(tables.Table):
     start_date = tables.DateColumn()
     total_workers_starting_delivery = tables.Column(verbose_name=_("Workers Starting Delivery"))
     active_workers = tables.Column(verbose_name=_("Active Workers"))
-    deliveries_per_day_per_worker = tables.Column(verbose_name=_("Deliveries per Day per Worker"))
+    deliveries_per_worker = tables.Column(verbose_name=_("Deliveries per Worker"))
     records_flagged_percentage = tables.Column(verbose_name=_("% Records flagged"))
 
     class Meta:
@@ -297,7 +297,7 @@ class DeliveryPerformanceTable(tables.Table):
             "start_date",
             "total_workers_starting_delivery",
             "active_workers",
-            "deliveries_per_day_per_worker",
+            "deliveries_per_worker",
             "records_flagged_percentage",
         )
         orderable = False

--- a/commcare_connect/program/tests/test_helpers.py
+++ b/commcare_connect/program/tests/test_helpers.py
@@ -69,7 +69,7 @@ class TestGetAnnotatedManagedOpportunity(BaseManagedOpportunityTest):
                 66.67,
                 timedelta(days=1),
             ),
-            ("empty_scenario", [], [], 0, 0, 0, 0.0, None),
+            ("empty_scenario", [], [], 0, 0, 0, 0.0, timedelta(days=0)),
             ("multiple_visits_scenario", [VisitValidationStatus.pending], [True], 1, 1, 1, 100.0, timedelta(days=1)),
             (
                 "excluded_statuses",
@@ -79,7 +79,7 @@ class TestGetAnnotatedManagedOpportunity(BaseManagedOpportunityTest):
                 2,
                 0,
                 0.0,
-                None,
+                timedelta(days=0),
             ),
             (
                 "failed_assessments",
@@ -121,16 +121,14 @@ class TestGetAnnotatedManagedOpportunity(BaseManagedOpportunityTest):
         opps = get_annotated_managed_opportunity(self.program)
         assert len(opps) == 1
         annotated_opp = opps[0]
+        print(scenario, annotated_opp.average_time_to_convert, expected_avg_time_to_convert)
         assert annotated_opp.workers_invited == expected_invited
         assert annotated_opp.workers_passing_assessment == expected_passing
         assert annotated_opp.workers_starting_delivery == expected_delivery
         assert pytest.approx(annotated_opp.percentage_conversion, 0.01) == expected_conversion
 
-        if expected_avg_time_to_convert:
-            diff = abs(annotated_opp.average_time_to_convert - expected_avg_time_to_convert)
-            assert diff < timedelta(minutes=1)
-        else:
-            assert annotated_opp.average_time_to_convert is None
+        diff = abs(annotated_opp.average_time_to_convert - expected_avg_time_to_convert)
+        assert diff < timedelta(minutes=1)
 
 
 @pytest.mark.django_db

--- a/commcare_connect/program/tests/test_helpers.py
+++ b/commcare_connect/program/tests/test_helpers.py
@@ -139,7 +139,7 @@ class TestDeliveryPerformanceReport(BaseManagedOpportunityTest):
     @pytest.mark.parametrize(
         "scenario, visit_statuses, visit_date, flagged_statuses, expected_active_workers, "
         "expected_total_workers, expected_records_flagged_percentage,"
-        "total_payment_units_with_flags,total_payment_since_start_date, delivery_per_day_per_worker",
+        "total_payment_units_with_flags,total_payment_since_start_date, deliveries_per_worker",
         [
             (
                 "basic_scenario",
@@ -224,7 +224,7 @@ class TestDeliveryPerformanceReport(BaseManagedOpportunityTest):
         expected_records_flagged_percentage,
         total_payment_units_with_flags,
         total_payment_since_start_date,
-        delivery_per_day_per_worker,
+        deliveries_per_worker,
     ):
         for i, visit_status in enumerate(visit_statuses):
             self.create_user_with_visit(
@@ -244,4 +244,4 @@ class TestDeliveryPerformanceReport(BaseManagedOpportunityTest):
         assert opps[0].records_flagged_percentage == expected_records_flagged_percentage
         assert opps[0].total_payment_units_with_flags == total_payment_units_with_flags
         assert opps[0].total_payment_since_start_date == total_payment_since_start_date
-        assert opps[0].deliveries_per_day_per_worker == delivery_per_day_per_worker
+        assert opps[0].deliveries_per_worker == deliveries_per_worker


### PR DESCRIPTION
[CCCT-570](https://dimagi.atlassian.net/browse/CCCT-570)
[CCCT-585](https://dimagi.atlassian.net/browse/CCCT-585)

[CCCT-570]: https://dimagi.atlassian.net/browse/CCCT-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCCT-585]: https://dimagi.atlassian.net/browse/CCCT-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ