### PR TITLE
Fix unique key violation error in tests

### DIFF
--- a/commcare_connect/opportunity/tests/factories.py
+++ b/commcare_connect/opportunity/tests/factories.py
@@ -68,6 +68,7 @@ class OpportunityAccessFactory(DjangoModelFactory):
 
     class Meta:
         model = "opportunity.OpportunityAccess"
+        django_get_or_create = ["opportunity", "user"]
 
 
 class OpportunityVerificationFlagsFactory(DjangoModelFactory):


### PR DESCRIPTION
This PR fixes the unique key violation error that randomly occurs in the CI test runner. Using the [django_get_or_create](https://factoryboy.readthedocs.io/en/stable/orms.html#factory.django.DjangoOptions.django_get_or_create) meta option for OpportunityAccessFactory, we can specify to run the `get_or_create` method to create objects when certain fields are present, in this case, `user` and `opportunity`. This will help avoid creating duplicate OpportunityAccess for users.

[Failing CI Run and Test Description](https://github.com/dimagi/commcare-connect/actions/runs/12312178249/job/34363704785)

