### PR TITLE
Check whether paymentunits have deliverunits set before processing

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -232,6 +232,8 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
 
 
 def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Opportunity, deliver_unit_block: dict):
+    if not opportunity.is_setup_complete:
+        raise ProcessingError("Opportunity setup is not complete")
     deliver_unit = get_or_create_deliver_unit(app, deliver_unit_block)
     access = OpportunityAccess.objects.get(opportunity=opportunity, user=user)
     counts = (

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -100,6 +100,9 @@ class Opportunity(BaseModel):
         for pu in self.paymentunit_set.all():
             if not (pu.max_total and pu.max_daily):
                 return False
+            if not pu.deliver_units.exists():
+                # Payment unit must have deliver units configured
+                return False
         return True
 
     @property


### PR DESCRIPTION
## Product Description

Detect when paymentunits don't have deliverunit set.

## Technical Summary

We have been having cases where projects are trying to submit forms and they are failing due to their payment-units being not configured. This will do two things
1. When setting up opportunity, users will get a warning that opportunity is setup is not complete.
2. Server will respond with a more clear message when submissions do occur.


## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Existing processor tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
