### PR TITLE
Fix invite delete conditions

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -182,19 +182,26 @@ class UserStatusTable(OrgContextTable):
             resend_invite_url = reverse(
                 "opportunity:resend_user_invite", args=(self.org_slug, record.opportunity.id, record.id)
             )
-            button_html = f"""<button title="Resend invitation"
-                hx-post="{resend_invite_url}" hx-target="#modalBodyContent" hx-trigger="click"
+            urls = [resend_invite_url]
+            buttons = [
+                """<button title="Resend invitation"
+                hx-post="{}" hx-target="#modalBodyContent" hx-trigger="click"
                 hx-on::after-request="handleResendInviteResponse(event)"
                 class="btn btn-sm btn-success">Resend</button>"""
+            ]
             if record.status == UserInviteStatus.not_found:
                 invite_delete_url = reverse(
                     "opportunity:user_invite_delete", args=(self.org_slug, record.opportunity.id, record.id)
                 )
-                button_html += f"""<button title="Delete invitation"
-                            hx-post="{invite_delete_url}" hx-swap="none"
+                urls.append(invite_delete_url)
+                buttons.append(
+                    """<button title="Delete invitation"
+                            hx-post="{}" hx-swap="none"
                             hx-confirm="Please confirm to delete the User Invite."
                             class="btn btn-sm btn-danger" type="button"><i class="bi bi-trash"></i></button>"""
-            return format_html('<div class="d-flex gap-1">{}</div>', button_html)
+                )
+            button_html = f"""<div class="d-flex gap-1">{"".join(buttons)}</div>"""
+            return format_html(button_html, *urls)
         url = reverse(
             "opportunity:user_profile",
             kwargs={"org_slug": self.org_slug, "opp_id": record.opportunity.id, "pk": record.opportunity_access_id},

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -179,30 +179,22 @@ class UserStatusTable(OrgContextTable):
 
     def render_view_profile(self, record):
         if not getattr(record.opportunity_access, "accepted", False):
-            invite_delete_url = reverse(
-                "opportunity:user_invite_delete",
-                args=(self.org_slug, record.opportunity.id, record.id),
-            )
             resend_invite_url = reverse(
-                "opportunity:resend_user_invite",
-                args=(self.org_slug, record.opportunity.id, record.id),
+                "opportunity:resend_user_invite", args=(self.org_slug, record.opportunity.id, record.id)
             )
-            return format_html(
-                (
-                    """<div class="d-flex gap-1">
-                      <button title="Resend invitation"
-                            hx-post="{}" hx-target="#modalBodyContent" hx-trigger="click"
-                            hx-on::after-request="handleResendInviteResponse(event)"
-                            class="btn btn-sm btn-success">Resend</button>
-                      <button title="Delete invitation"
-                            hx-post="{}" hx-swap="none" hx-confirm="Please confirm to delete the User Invite."
-                            class="btn btn-sm btn-danger" type="button"><i class="bi bi-trash"></i>
-                      </button>
-                    </div>"""
-                ),
-                resend_invite_url,
-                invite_delete_url,
-            )
+            button_html = f"""<button title="Resend invitation"
+                hx-post="{resend_invite_url}" hx-target="#modalBodyContent" hx-trigger="click"
+                hx-on::after-request="handleResendInviteResponse(event)"
+                class="btn btn-sm btn-success">Resend</button>"""
+            if record.status == UserInviteStatus.not_found:
+                invite_delete_url = reverse(
+                    "opportunity:user_invite_delete", args=(self.org_slug, record.opportunity.id, record.id)
+                )
+                button_html += f"""<button title="Delete invitation"
+                            hx-post="{invite_delete_url}" hx-swap="none"
+                            hx-confirm="Please confirm to delete the User Invite."
+                            class="btn btn-sm btn-danger" type="button"><i class="bi bi-trash"></i></button>"""
+            return format_html('<div class="d-flex gap-1">{}</div>', button_html)
         url = reverse(
             "opportunity:user_profile",
             kwargs={"org_slug": self.org_slug, "opp_id": record.opportunity.id, "pk": record.opportunity_access_id},

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1236,7 +1236,9 @@ def invoice_approve(request, org_slug, pk):
 @csrf_exempt
 def user_invite_delete(request, org_slug, opp_id, pk):
     opportunity = get_opportunity_or_404(opp_id, org_slug)
-    invite = get_object_or_404(UserInvite, pk=pk, opportunity=opportunity, status=UserInviteStatus.not_found)
+    invite = get_object_or_404(UserInvite, pk=pk, opportunity=opportunity)
+    if invite.status != UserInviteStatus.not_found:
+        return HttpResponse(status=403, data="User Invite cannot be deleted.")
     invite.delete()
     return HttpResponse(status=200, headers={"HX-Trigger": "userStatusReload"})
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1236,7 +1236,7 @@ def invoice_approve(request, org_slug, pk):
 @csrf_exempt
 def user_invite_delete(request, org_slug, opp_id, pk):
     opportunity = get_opportunity_or_404(opp_id, org_slug)
-    invite = get_object_or_404(UserInvite, pk=pk, opportunity=opportunity)
+    invite = get_object_or_404(UserInvite, pk=pk, opportunity=opportunity, status=UserInviteStatus.not_found)
     invite.delete()
     return HttpResponse(status=200, headers={"HX-Trigger": "userStatusReload"})
 


### PR DESCRIPTION
## Product Description
This PR fixes when the delete button is shown for User Invites. Currently, the button was shown for all invites that were not accepted, but it needs to be shown only in cases when a user was not found in ConnectID.

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/c202ec7c-2dc7-4c49-b9ba-dc700a2f8e8f" />

<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I have tested these changes on staging.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
