### PR TITLE
implement user visits dashboard

### DIFF
--- a/commcare_connect/reports/dashboard/data.py
+++ b/commcare_connect/reports/dashboard/data.py
@@ -1,0 +1,96 @@
+import datetime
+
+from django.db.models import Case, Count, IntegerField, Q, Sum, When
+from django.db.models.functions import TruncDate
+
+from commcare_connect.opportunity.models import OpportunityAccess, UserVisit
+
+
+class UserVisitData:
+    @classmethod
+    def _get_aggregations(cls):
+        return {
+            "total_visits": Count("id"),
+            "flagged_visits": Sum(Case(When(flagged=True, then=1), default=0, output_field=IntegerField())),
+            "approved_visits": Sum(Case(When(status="approved", then=1), default=0, output_field=IntegerField())),
+            "rejected_visits": Sum(Case(When(status="rejected", then=1), default=0, output_field=IntegerField())),
+            "approved_flagged_visits": Sum(
+                Case(When(Q(status="approved") & Q(flagged=True), then=1), default=0, output_field=IntegerField())
+            ),
+            "duplicate_flags": Count(
+                Case(When(flag_reason__flags__contains=["duplicate"], then=1), output_field=IntegerField())
+            ),
+            "gps_flags": Count(Case(When(flag_reason__flags__contains=["gps"], then=1), output_field=IntegerField())),
+            "location_flags": Count(
+                Case(When(flag_reason__flags__contains=["location"], then=1), output_field=IntegerField())
+            ),
+            "duration_flags": Count(
+                Case(When(flag_reason__flags__contains=["duration"], then=1), output_field=IntegerField())
+            ),
+        }
+
+    @classmethod
+    def _get_queryset(cls, opportunity_ids=None, date_gte=None, date_lte=None):
+        queryset = UserVisit.objects.all()
+        if opportunity_ids:
+            queryset = queryset.filter(opportunity_id__in=opportunity_ids)
+        if date_gte:
+            queryset = queryset.filter(visit_date__gte=date_gte)
+        if date_lte:
+            queryset = queryset.filter(visit_date__lte=date_lte)
+        return queryset
+
+    @classmethod
+    def get_data(cls, filterset):
+        queryset = UserVisit.objects.all()
+        if filterset.is_valid():
+            queryset = filterset.filter_queryset(queryset)
+            from_date = filterset.form.cleaned_data["from_date"]
+            to_date = filterset.form.cleaned_data["to_date"]
+        else:
+            to_date = datetime.now().date()
+            from_date = to_date - datetime.timedelta(days=30)
+            queryset = queryset.filter(visit_date__gte=from_date, visit_date__lte=to_date)
+
+        data = {
+            "summary": cls.get_summary(queryset),
+            "time_series": cls.get_time_series(queryset),
+            "funnel": cls.get_funnel_data(filterset),
+        }
+        return data
+
+    @classmethod
+    def get_summary(cls, queryset):
+        return queryset.aggregate(**cls._get_aggregations())
+
+    @classmethod
+    def get_time_series(cls, queryset):
+        return list(
+            queryset.annotate(visit_date_only=TruncDate("visit_date"))
+            .values("visit_date_only")
+            .annotate(**cls._get_aggregations())
+        )
+
+    @classmethod
+    def get_funnel_data(cls, filterset):
+        """Gets funnel metrics from OpportunityAccess"""
+        queryset = OpportunityAccess.objects.all()
+
+        # No date filters for funnel data
+        filterset.form.cleaned_data.pop("from_date", None)
+        filterset.form.cleaned_data.pop("to_date", None)
+
+        if filterset.is_valid():
+            queryset = filterset.filter_queryset(queryset)
+
+        metrics = queryset.aggregate(
+            invited=Count("id", filter=Q(invited_date__isnull=False)),
+            is_accepted=Count("id", filter=Q(accepted=True)),
+            started_learning=Count("id", filter=Q(date_learn_started__isnull=False, accepted=True)),
+        )
+
+        return [
+            {"value": metrics["invited"], "name": "Invited"},
+            {"value": metrics["is_accepted"], "name": "Accepted"},
+            {"value": metrics["started_learning"], "name": "Started Learning"},
+        ]

--- a/commcare_connect/reports/dashboard/views.py
+++ b/commcare_connect/reports/dashboard/views.py
@@ -1,0 +1,55 @@
+import django_filters
+from crispy_forms.layout import Column, Field, Layout, Row
+from django.http import JsonResponse
+from django.views.generic import TemplateView
+
+from commcare_connect.opportunity.models import Opportunity, UserVisit
+from commcare_connect.reports.views import DashboardFilters, SuperUserRequiredMixin
+
+from .data import UserVisitData
+
+
+class UserDashboardFilters(DashboardFilters):
+    opportunity = django_filters.ModelChoiceFilter(
+        queryset=Opportunity.objects.all(),
+        field_name="opportunity",
+        label="Opportunity",
+        empty_label="All opportunities",
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.form.helper.layout = Layout(
+            Row(
+                Column(Field("program", **{"x-on:change": "fetchData()"}), css_class="col-md-2"),
+                Column(Field("organization", **{"x-on:change": "fetchData()"}), css_class="col-md-2"),
+                Column(Field("opportunity", **{"x-on:change": "fetchData()"}), css_class="col-md-2"),
+                Column(Field("from_date", **{"x-on:change": "fetchData()"}), css_class="col-md-2 ms-auto"),
+                Column(Field("to_date", **{"x-on:change": "fetchData()"}), css_class="col-md-2"),
+            )
+        )
+
+    class Meta:
+        model = UserVisit
+        fields = ["program", "organization", "opportunity", "from_date", "to_date"]
+
+
+class UserVisitDashboardView(SuperUserRequiredMixin, TemplateView):
+    template_name = "reports/uservisit_dashboard.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        filterset = UserDashboardFilters(self.request.GET)
+        context["filter"] = filterset
+        return context
+
+    def get(self, request, *args, **kwargs):
+        if request.GET.get("json") == "true":
+            return self.get_filtered_data(request)
+        return super().get(request, *args, **kwargs)
+
+    def get_filtered_data(self, request):
+        filterset = UserDashboardFilters(request.GET)
+        data = UserVisitData.get_data(filterset)
+        return JsonResponse(data)

--- a/commcare_connect/reports/urls.py
+++ b/commcare_connect/reports/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from commcare_connect.reports import views
+from commcare_connect.reports.dashboard.views import UserVisitDashboardView
 
 app_name = "reports"
 
@@ -10,4 +11,5 @@ urlpatterns = [
     path("api/visit_map_data/", views.visit_map_data, name="visit_map_data"),
     path("api/dashboard_stats/", views.dashboard_stats_api, name="dashboard_stats_api"),
     path("api/dashboard_charts/", views.dashboard_charts_api, name="dashboard_charts_api"),
+    path("user_visits/", UserVisitDashboardView.as_view(), name="user_visit_dashboard"),
 ]

--- a/commcare_connect/templates/reports/uservisit_dashboard.html
+++ b/commcare_connect/templates/reports/uservisit_dashboard.html
@@ -1,0 +1,279 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% block javascript %}
+{{ block.super }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.3/echarts.min.js"></script>
+{% endblock %}
+
+{% block content %}
+<h2 class="my-2">Program Visits Dashboard</h2>
+<div x-data="dashboard()">
+    <div class="filters">
+        {% crispy filter.form %}
+    </div>
+
+    <div class="results-container mt-4">
+        <div class="row">
+            <div class="col-md-4">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h6 class="text-muted text-uppercase mb-2">Total Visits</h6>
+                        <h1 class="display-4 mb-0" x-text="results?.summary?.total_visits || 0"></h1>
+                        <small class="text-muted">
+                            + <span x-text="results?.summary_lastday?.total_visits || 0"></span>
+                        </small>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h6 class="text-muted text-uppercase mb-2">Approved Visits</h6>
+                        <h1 class="display-4 mb-0" x-text="results?.summary?.approved_visits || 0"></h1>
+                        <small class="text-muted">
+                            + <span x-text="results?.summary_lastday?.approved_visits || 0"></span>
+                        </small>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h6 class="text-muted text-uppercase mb-2">Rejected Visits</h6>
+                        <h1 class="display-4 mb-0" x-text="results?.summary?.rejected_visits || 0"></h1>
+                        <small class="text-muted">
+                            + <span x-text="results?.summary_lastday?.rejected_visits || 0"></span>
+                        </small>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row mt-4">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-body">
+                        <h6 class="text-muted text-uppercase mb-2">Flag Distribution</h6>
+                        <div id="flagsPieChart" style="height: 400px;"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-6">
+                <div class="card">
+                    <div class="card-body">
+                        <h6 class="text-muted text-uppercase mb-2">Visit Trends</h6>
+                        <div id="timeSeriesChart" style="height: 400px;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row mt-4">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-body">
+                        <h6 class="text-muted text-uppercase mb-2">Conversion</h6>
+                        <div id="funnelChart" style="height: 400px;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block inline_javascript %}
+{{ block.super }}
+<script>
+function dashboard() {
+    let flagsPieChart;
+    let timeSeriesChart;
+    let funnelChart;
+
+    return {
+        dateStart: '',
+        dateEnd: '',
+        selectedOpportunities: [],
+        results: '',
+
+        init() {
+            flagsPieChart = echarts.init(document.getElementById('flagsPieChart'));
+            timeSeriesChart = echarts.init(document.getElementById('timeSeriesChart'));
+            funnelChart = echarts.init(document.getElementById('funnelChart'));
+            this.fetchData();
+        },
+
+        updatePieChart() {
+            if (!this.results?.summary) return;
+
+            const option = {
+                tooltip: {
+                    trigger: 'item',
+                    formatter: '{b}: {c} ({d}%)'
+                },
+                legend: {
+                    orient: 'horizontal',
+                    top: 'top'
+                },
+                series: [{
+                    type: 'pie',
+                    radius: ['40%', '70%'],
+                    label: {
+                        show: true,
+                        position: 'center',
+                        formatter: function() {
+                        var total = 0;
+                        // Calculate total sum of values
+                        for (var i = 0; i < option.series[0].data.length; i++) {
+                            total += option.series[0].data[i].value;
+                        }
+                        return total; // Display total in center
+                        },
+                    },
+                    data: [
+                        { value: this.results.summary.duration_flags, name: 'Duration Flags' },
+                        { value: this.results.summary.location_flags, name: 'Location Flags' },
+                        { value: this.results.summary.gps_flags, name: 'GPS Flags' }
+                    ],
+                    emphasis: {
+                        itemStyle: {
+                            shadowBlur: 10,
+                            shadowOffsetX: 0,
+                            shadowColor: 'rgba(0, 0, 0, 0.5)'
+                        }
+                    }
+                }]
+            };
+            flagsPieChart.setOption(option);
+        },
+
+        updateTimeSeriesChart() {
+            if (!this.results?.time_series) return;
+
+            const dates = this.results.time_series.map(item => item.visit_date_only);
+            const option = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'shadow'
+                    }
+                },
+                legend: {
+                    data: ['Total Visits', 'Duplicate Flags', 'GPS Flags', 'Location Flags', 'Duration Flags'],
+                    top: 'top'
+                },
+                xAxis: {
+                    type: 'category',
+                    data: dates,
+                    axisLabel: {
+                        rotate: 45
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: 'Total Visits',
+                        type: 'bar',
+                        stack: 'total',
+                        emphasis: { focus: 'series' },
+                        data: this.results.time_series.map(item => item.total_visits)
+                    },
+                    {
+                        name: 'Duplicate Flags',
+                        type: 'bar',
+                        stack: 'flags',
+                        emphasis: { focus: 'series' },
+                        data: this.results.time_series.map(item => item.duplicate_flags)
+                    },
+                    {
+                        name: 'GPS Flags',
+                        type: 'bar',
+                        stack: 'flags',
+                        emphasis: { focus: 'series' },
+                        data: this.results.time_series.map(item => item.gps_flags)
+                    },
+                    {
+                        name: 'Location Flags',
+                        type: 'bar',
+                        stack: 'flags',
+                        emphasis: { focus: 'series' },
+                        data: this.results.time_series.map(item => item.location_flags)
+                    },
+                    {
+                        name: 'Duration Flags',
+                        type: 'bar',
+                        stack: 'flags',
+                        emphasis: { focus: 'series' },
+                        data: this.results.time_series.map(item => item.duration_flags)
+                    }
+                ]
+            };
+            timeSeriesChart.setOption(option);
+        },
+
+        updateFunnelChart() {
+            if (!this.results?.funnel) return;
+
+            const option = {
+                color: ['#91cc75', '#5470c6', '#ee6666'],
+                grid: {
+                    top: '10%',
+                    right: '15%'
+                },
+                tooltip: {
+                    trigger: 'item',
+                    formatter: '{b}: {c}'
+                },
+                legend: {
+                    orient: 'vertical',
+                    right: '5%',
+                    top: 'top'
+                },
+                series: [{
+                    name: 'Funnel',
+                    type: 'funnel',
+                    orient: 'horizontal',
+                    left: '5%',
+                    width: '70%',
+                    height: '60%',
+                    sort: 'none',
+                    gap: 2,
+                    label: {
+                        show: true,
+                        position: 'top'
+                    },
+                    emphasis: {
+                        label: {
+                            fontSize: 20
+                        }
+                    },
+                    data: this.results.funnel
+                }]
+            };
+
+            funnelChart.setOption(option);
+        },
+
+        async fetchData() {
+            const params = new URLSearchParams({
+                date_start: this.dateStart,
+                date_end: this.dateEnd,
+                json: true
+            });
+            if (!this.selectedOpportunities.includes('')) {
+                this.selectedOpportunities.forEach(opp => {
+                    params.append('opportunities', opp);
+                });
+            }
+            const response = await fetch(`${window.location.pathname}?${params}`);
+            this.results = await response.json();
+            this.updatePieChart();
+            this.updateTimeSeriesChart();
+            this.updateFunnelChart();
+        }
+    }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Product Description

This implements dashboard specced here https://lucid.app/lucidchart/7e050b6b-5faa-4467-a8b6-e39a6ede58ee/edit?invitationId=inv_df6a7fcf-773d-496a-84e1-8bbf9a7b3832&page=0_0#

<img width="677" alt="Screenshot 2025-01-13 at 8 37 27 AM" src="https://github.com/user-attachments/assets/546c6ea3-60e7-46cf-83dd-52697080909a" />

## Technical Summary

UserVisit data is fetched whenever filters (rendered by django-filters) are changed, the event is detected by alpinejs change hook. Charts are initialised once at beginning, whenever data changes alpinejs updates the data for the charts.

## Safety Assurance

### Safety story

Tested locally and on staging environments. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning for a QA, but Rama is going to verify on staging.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
