### PR TITLE
fix exchange rate fetch

### DIFF
--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -316,7 +316,9 @@ def get_exchange_rate(currency_code, date=None):
         rate = ExchangeRate.objects.get(currency_code=currency_code, rate_date=rate_date).rate
     except ExchangeRate.DoesNotExist:
         rates = fetch_exchange_rates(rate_date)
-        rate = rates["rates"].get(currency_code)
+        rate = rates.get(currency_code)
+        if not rate:
+            raise ImportException("Rate not found for opportunity currency")
         ExchangeRate.objects.create(currency_code=currency_code, rate=rate, rate_date=rate_date)
 
     return rate


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
We already returned the "rates" key from the response on line 301, so we can directly look up the currency code here. I also added some error checking to make sure we don't create null rates.