### PR TITLE
Revert "capture user/org tags in sentry"

### DIFF
--- a/commcare_connect/utils/middleware.py
+++ b/commcare_connect/utils/middleware.py
@@ -1,6 +1,4 @@
-from django.conf import settings
 from django.contrib import messages
-from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponseRedirect
 from django.utils.safestring import mark_safe
 from rest_framework.settings import api_settings
@@ -42,28 +40,3 @@ class CurrentVersionMiddleware:
     def process_view(self, request, view_func, view_args, view_kwargs):
         if hasattr(view_func, "cls") and view_func.cls.versioning_class is not None:
             request.include_version_headers = True
-
-
-class SentryContextMiddleware:
-    """Add details to Sentry context.
-    Should be placed after '"commcare_connect.users.middleware.OrganizationMiddleware",'
-    """
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-        try:
-            import sentry_sdk  # noqa: F401
-        except ImportError:
-            raise MiddlewareNotUsed
-
-        if not getattr(settings, "SENTRY_DSN", None):
-            raise MiddlewareNotUsed
-
-    def process_view(self, request, view_func, view_args, view_kwargs):
-        from sentry_sdk import set_tag, set_user
-
-        if getattr(request, "user", None):
-            set_user({"username": request.user.username})
-
-        if getattr(request, "org", None):
-            set_tag("org", request.org)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -125,7 +125,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "commcare_connect.utils.middleware.CustomErrorHandlingMiddleware",
     "commcare_connect.utils.middleware.CurrentVersionMiddleware",
-    "commcare_connect.utils.middleware.SentryContextMiddleware",
 ]
 
 # STATIC


### PR DESCRIPTION
Reverts dimagi/commcare-connect#449

This was setup incorrectly, causing all requests to 500 https://dimagi.sentry.io/issues/6226579176/?alert_rule_id=14580978&alert_timestamp=1737145963323&alert_type=email&environment=production&notification_uuid=6806dcb1-39f4-4627-9651-8352570c3383&project=4505635339829248&referrer=alert_email