### PR TITLE
Ensure Case-Insensitive Currency Code Comparison

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -237,6 +237,8 @@ class OpportunityInitForm(forms.ModelForm):
         deliver_app = self.cleaned_data["deliver_app"]
         learn_app_domain = self.cleaned_data["learn_app_domain"]
         deliver_app_domain = self.cleaned_data["deliver_app_domain"]
+
+        self.instance.currency = self.cleaned_data["currency"].upper()
         self.instance.learn_app, _ = CommCareApp.objects.get_or_create(
             cc_app_id=learn_app["id"],
             cc_domain=learn_app_domain,
@@ -496,6 +498,8 @@ class OpportunityCreationForm(forms.ModelForm):
         deliver_app = self.cleaned_data["deliver_app"]
         learn_app_domain = self.cleaned_data["learn_app_domain"]
         deliver_app_domain = self.cleaned_data["deliver_app_domain"]
+
+        self.instance.currency = self.cleaned_data["currency"].upper()
         self.instance.learn_app, _ = CommCareApp.objects.get_or_create(
             cc_app_id=learn_app["id"],
             cc_domain=learn_app_domain,

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -238,7 +238,6 @@ class OpportunityInitForm(forms.ModelForm):
         learn_app_domain = self.cleaned_data["learn_app_domain"]
         deliver_app_domain = self.cleaned_data["deliver_app_domain"]
 
-        self.instance.currency = self.cleaned_data["currency"].upper()
         self.instance.learn_app, _ = CommCareApp.objects.get_or_create(
             cc_app_id=learn_app["id"],
             cc_domain=learn_app_domain,
@@ -263,6 +262,7 @@ class OpportunityInitForm(forms.ModelForm):
         )
         self.instance.created_by = self.user.email
         self.instance.modified_by = self.user.email
+        self.instance.currency = self.instance.currency.upper()
 
         if self.managed_opp:
             self.instance.organization = self.cleaned_data.get("organization")
@@ -499,7 +499,8 @@ class OpportunityCreationForm(forms.ModelForm):
         learn_app_domain = self.cleaned_data["learn_app_domain"]
         deliver_app_domain = self.cleaned_data["deliver_app_domain"]
 
-        self.instance.currency = self.cleaned_data["currency"].upper()
+        self.instance.currency = self.instance.currency.upper()
+
         self.instance.learn_app, _ = CommCareApp.objects.get_or_create(
             cc_app_id=learn_app["id"],
             cc_domain=learn_app_domain,

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -331,7 +331,7 @@ def get_exchange_rate(currency_code, date=None):
 
     if currency_code is None:
         raise ImportException("Opportunity must have specified currency to import payments")
-    if currency_code == "USD":
+    if currency_code.upper() == "USD":
         return 1
 
     rate_date = date or now().date()

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -331,7 +331,10 @@ def get_exchange_rate(currency_code, date=None):
 
     if currency_code is None:
         raise ImportException("Opportunity must have specified currency to import payments")
-    if currency_code.upper() == "USD":
+
+    currency_code = currency_code.upper()
+
+    if currency_code == "USD":
         return 1
 
     rate_date = date or now().date()

--- a/commcare_connect/program/forms.py
+++ b/commcare_connect/program/forms.py
@@ -60,6 +60,8 @@ class ProgramForm(forms.ModelForm):
 
         self.instance.modified_by = self.user.email
 
+        self.instance.currency = self.cleaned_data["currency"].upper()
+
         return super().save(commit=commit)
 
 

--- a/commcare_connect/program/forms.py
+++ b/commcare_connect/program/forms.py
@@ -95,6 +95,4 @@ class ManagedOpportunityInitForm(OpportunityInitForm):
     def save(self, commit=True):
         self.instance.program = self.program
         self.instance.currency = self.program.currency
-        print("#####")
-        print(self.instance.currency)
         return super().save(commit=commit)

--- a/commcare_connect/program/forms.py
+++ b/commcare_connect/program/forms.py
@@ -95,4 +95,6 @@ class ManagedOpportunityInitForm(OpportunityInitForm):
     def save(self, commit=True):
         self.instance.program = self.program
         self.instance.currency = self.program.currency
+        print("#####")
+        print(self.instance.currency)
         return super().save(commit=commit)


### PR DESCRIPTION
## Technical Summary

Currently, when the currency code "USD" is in lowercase, the system incorrectly attempts to fetch the rate from the rates API. This update ensures that currency code comparisons are case-insensitive by converting currency_code to uppercase before checking against "USD", preventing unnecessary API calls due to case mismatches.

[Sentry Error](https://dimagi.sentry.io/issues/6289210916/?project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=2)

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
