### PR TITLE
have ten gunicorn workers

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -5,4 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 300 -w 5
+gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 300 -w 10

--- a/docker/start_migrate
+++ b/docker/start_migrate
@@ -8,4 +8,4 @@ set -o nounset
 echo "Django migrate"
 python manage.py migrate_multi --noinput
 echo "Run Gunicorn"
-gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 300 -w 5
+gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 300 -w 10


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
We are still seeing frequent unreachable docker containers but there is no evidence the containers themselves are going down, which leads me to believe the workers are being saturated. This adds extra workers while still staying (mostly) within gunicorn recommendations.