### PR TITLE
Add Program Model to Django Admin

### DIFF
--- a/commcare_connect/program/admin.py
+++ b/commcare_connect/program/admin.py
@@ -5,4 +5,4 @@ from commcare_connect.program.models import Program
 
 @admin.register(Program)
 class ProgramAdmin(admin.ModelAdmin):
-    list_display = ("name", "organization")  # Display program name and organization in the list
+    list_display = ("name", "organization")

--- a/commcare_connect/program/admin.py
+++ b/commcare_connect/program/admin.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+
+from commcare_connect.program.models import Program
+
+
+@admin.register(Program)
+class ProgramAdmin(admin.ModelAdmin):
+    list_display = ("name", "organization")  # Display program name and organization in the list


### PR DESCRIPTION
## Product Description

Currently, it is not straightforward to determine the PM's organisation from the program name in the NM view of our UI. Adding the Program model to the Django admin will make it easier for admins to access and manage program details, including their associated organisations, directly from the admin panel.


- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
