### PR TITLE
add new elastic IPs

### DIFF
--- a/deploy/config/deploy.production.yml
+++ b/deploy/config/deploy.production.yml
@@ -1,7 +1,8 @@
 servers:
   web:
     hosts:
-      - 54.158.97.180
+      - 52.70.100.12
+      - 54.211.180.233
     options:
       # create by ansible
       env-file: '/home/connect/www/commcare-connect/docker.env'

--- a/deploy/production.inventory.yml
+++ b/deploy/production.inventory.yml
@@ -1,7 +1,9 @@
 webservers:
   hosts:
     web0:
-      ansible_host: 54.158.97.180
+      ansible_host: 52.70.100.12
+    web1:
+      ansible_host: 54.211.180.233
     celery0:
       ansible_host: 44.193.193.67
   vars:


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This replaces the existing webserver IP with two new ones, both of which have been set up not to change on restart so we can stop updating the IP every time we modify the instances.