### PR TITLE
Ensure the Transaction is Committed Before Celery Runs download_user_visit_attachments.

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -318,7 +318,7 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
                 completed_work.save()
 
     update_payment_accrued(opportunity, [user.id])
-    download_user_visit_attachments.delay(user_visit.id)
+    transaction.on_commit(lambda: download_user_visit_attachments.delay(user_visit.id))
 
 
 def get_or_create_deliver_unit(app, unit_data):

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -1,4 +1,5 @@
 import datetime
+from functools import partial
 
 from django.db import transaction
 from django.db.models import Count, Q
@@ -318,7 +319,7 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
                 completed_work.save()
 
     update_payment_accrued(opportunity, [user.id])
-    transaction.on_commit(lambda: download_user_visit_attachments.delay(user_visit.id))
+    transaction.on_commit(partial(download_user_visit_attachments.delay, user_visit.id))
 
 
 def get_or_create_deliver_unit(app, unit_data):


### PR DESCRIPTION
## Technical Summary

We have been seeing a high volume of UserVisit.DoesNotExist errors on [Sentry](https://dimagi.sentry.io/issues/6302069322/?project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=0)

This PR ensures that `download_user_visit_attachments.delay(user_visit.id)` is only triggered after the transaction is successfully committed using `transaction.on_commit()`. This guarantees that the Celery task only runs once the `UserVisit` record is available in the database.


## Safety Assurance

This change does not alter any data or logic beyond ensuring the function is called at the right time.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
