### PR TITLE
Fix check if instance and end_date exists

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -128,8 +128,10 @@ class OpportunityChangeForm(
             required=False,
             help_text="Extends opportunity end date for all users.",
         )
-        self.initial["end_date"] = self.instance.end_date.isoformat()
-        self.currently_active = self.instance.active
+        if self.instance:
+            if self.instance.end_date:
+                self.initial["end_date"] = self.instance.end_date.isoformat()
+            self.currently_active = self.instance.active
 
     def clean_active(self):
         active = self.cleaned_data["active"]


### PR DESCRIPTION
## Technical Summary
This fixes an error in the OpportunityChangeForm code related to end_date setter. In the new Opportunity creation flow, when the opportunity is only partially setup, the end date field is None, this adds checks for existence of a valid instance and a valid end_date before setting them in the OpportunityChangeForm.

[Sentry Link](https://dimagi.sentry.io/issues/5168594132/?environment=production&project=4505635339829248&query=is%3Aunresolved%20isoformat&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0)

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
