### PR TITLE
Add pk in rest api calls 

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -25,7 +25,7 @@ from commcare_connect.opportunity.models import (
 class LearnModuleSerializer(serializers.ModelSerializer):
     class Meta:
         model = LearnModule
-        fields = ["slug", "name", "description", "time_estimate"]
+        fields = ["slug", "name", "description", "time_estimate", "id"]
 
 
 class CommCareAppSerializer(serializers.ModelSerializer):
@@ -45,6 +45,7 @@ class CommCareAppSerializer(serializers.ModelSerializer):
             "learn_modules",
             "passing_score",
             "install_url",
+            "id",
         ]
 
     def get_install_url(self, obj):
@@ -74,7 +75,7 @@ class OpportunityClaimSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OpportunityClaim
-        fields = ["max_payments", "end_date", "date_claimed", "payment_units"]
+        fields = ["max_payments", "end_date", "date_claimed", "payment_units", "id"]
 
     def get_max_payments(self, obj):
         # return 1 for old opportunities
@@ -200,13 +201,13 @@ def remove_opportunity_access_cache(user, opportunity):
 class CompletedModuleSerializer(serializers.ModelSerializer):
     class Meta:
         model = CompletedModule
-        fields = ["module", "date", "duration"]
+        fields = ["module", "date", "duration", "id"]
 
 
 class AssessmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Assessment
-        fields = ["date", "score", "passing_score", "passed"]
+        fields = ["date", "score", "passing_score", "passed", "id"]
 
 
 class UserLearnProgressSerializer(serializers.Serializer):

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -4,7 +4,9 @@ import pytest
 from rest_framework.test import APIClient
 
 from commcare_connect.opportunity.api.serializers import (
+    CommCareAppSerializer,
     DeliveryProgressSerializer,
+    OpportunityClaimSerializer,
     OpportunitySerializer,
     PaymentSerializer,
     UserVisitSerializer,
@@ -168,8 +170,8 @@ def test_learn_progress_endpoint(mobile_user: User, api_client: APIClient):
     assert len(response.data["completed_modules"]) == 1
     assert "assessments" in response.data
     assert len(response.data["assessments"]) == 1
-    assert list(response.data["completed_modules"][0].keys()) == ["module", "date", "duration"]
-    assert list(response.data["assessments"][0].keys()) == ["date", "score", "passing_score", "passed"]
+    assert list(response.data["completed_modules"][0].keys()) == ["module", "date", "duration", "id"]
+    assert list(response.data["assessments"][0].keys()) == ["date", "score", "passing_score", "passed", "id"]
 
 
 @pytest.mark.parametrize(
@@ -194,6 +196,9 @@ def test_opportunity_list_endpoint(
     assert response.status_code == 200
     assert len(response.data) == 1
     assert response.data[0].keys() == OpportunitySerializer().get_fields().keys()
+    assert response.data[0]["deliver_app"].keys() == CommCareAppSerializer().get_fields().keys()
+    assert response.data[0]["learn_app"].keys() == CommCareAppSerializer().get_fields().keys()
+    assert response.data[0]["claim"].keys() == OpportunityClaimSerializer().get_fields().keys()
     payment_units = opportunity.paymentunit_set.all()
     assert response.data[0]["max_visits_per_user"] == sum([pu.max_total for pu in payment_units])
     assert response.data[0]["daily_max_visits_per_user"] == sum([pu.max_daily for pu in payment_units])


### PR DESCRIPTION
## Technical Summary

[CCCT-660](https://dimagi.atlassian.net/browse/CCCT-660)
Added unique `id` fields in REST API responses to ensure distinct identity for data.

## Safety Assurance

### Safety story

Updated existing tests to verify the presence of the id field.

### QA Plan
NA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-660]: https://dimagi.atlassian.net/browse/CCCT-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ