### PR TITLE
Make visit import async

### DIFF
--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -124,16 +124,10 @@ class VisitData:
         return iter(astuple(self))
 
 
-def bulk_update_visit_status(opportunity: Opportunity, file: UploadedFile) -> VisitImportStatus:
-    file_format = get_file_extension(file)
-    if file_format not in ("csv", "xlsx"):
-        raise ImportException(f"Invalid file format. Only 'CSV' and 'XLSX' are supported. Got {file_format}")
-    imported_data = get_imported_dataset(file, file_format)
-    return _bulk_update_visit_status(opportunity, imported_data)
-
-
-def _bulk_update_visit_status(opportunity: Opportunity, dataset: Dataset):
-    data_by_visit_id = get_data_by_visit_id(dataset)
+def bulk_update_visit_status(opportunity_id: int, headers: list[str], rows: list[list]):
+    opportunity = Opportunity.objects.get(id=opportunity_id)
+    headers = [header.lower() for header in headers]
+    data_by_visit_id = get_data_by_visit_id(headers, rows)
     visit_ids = list(data_by_visit_id.keys())
     missing_visits = set()
     seen_visits = set()
@@ -180,8 +174,7 @@ def update_payment_accrued(opportunity: Opportunity, users):
             update_status(completed_works, access, compute_payment=True)
 
 
-def get_data_by_visit_id(dataset) -> dict[int, VisitData]:
-    headers = [header.lower() for header in dataset.headers or []]
+def get_data_by_visit_id(headers, rows) -> dict[int, VisitData]:
     if not headers:
         raise ImportException("The uploaded file did not contain any headers")
 
@@ -191,7 +184,7 @@ def get_data_by_visit_id(dataset) -> dict[int, VisitData]:
     justification_col_index = _get_header_index(headers, JUSTIFICATION_COL, required=False)
     data_by_visit_id = {}
     invalid_rows = []
-    for row in dataset:
+    for row in rows:
         row = list(row)
         visit_id = str(row[visit_col_index])
         status_raw = row[status_col_index].lower().strip().replace(" ", "_")


### PR DESCRIPTION
## Product Description

This import has failed due to timeout on gunicorn worker. ([sentry](https://dimagi.sentry.io/issues/6257795631/?project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=6)). Likely it's taking a bit more time, so I have made this async

PRing into similar PR where I added celery util needed by this (https://github.com/dimagi/commcare-connect/pull/492)

## Technical Summary
Simple sync to async process. 

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will test on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Existing tests are modified to test.

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
