### PR TITLE
Make 'Justification' field mandatory for NMs

### DIFF
--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -192,11 +192,9 @@ def test_approve_visit(
         opportunity=opportunity, opportunity_access=access, flagged=True, status=VisitValidationStatus.pending
     )
     user = MembershipFactory.create(organization=opportunity.organization).user
-    print("opportunity.organization.slug", opportunity.organization.slug)
     approve_url = reverse("opportunity:approve_visit", args=(opportunity.organization.slug, visit.id))
     client.force_login(user)
     response = client.post(approve_url, {"justification": justification}, follow=True)
-    print(response.status_code)
     visit.refresh_from_db()
     assert visit.status == VisitValidationStatus.approved
     expected_redirect_url = None

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -23,6 +23,7 @@ from commcare_connect.opportunity.tests.factories import (
 from commcare_connect.organization.models import Organization
 from commcare_connect.program.tests.factories import ManagedOpportunityFactory, ProgramFactory
 from commcare_connect.users.models import User
+from commcare_connect.users.tests.factories import MembershipFactory
 
 
 @pytest.mark.django_db
@@ -169,3 +170,50 @@ def test_add_budget_existing_users_for_managed_opportunity(
     form = response.context["form"]
     assert "additional_visits" in form.errors
     assert form.errors["additional_visits"][0] == "Additional visits exceed the opportunity budget."
+
+
+@pytest.mark.parametrize(
+    "opportunity",
+    [
+        {"opp_options": {"managed": True}},
+        {"opp_options": {"managed": False}},
+    ],
+    indirect=True,
+)
+@pytest.mark.django_db
+def test_approve_visit(
+    client: Client,
+    organization,
+    opportunity,
+):
+    justification = "Justification test."
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    visit = UserVisitFactory.create(
+        opportunity=opportunity, opportunity_access=access, flagged=True, status=VisitValidationStatus.pending
+    )
+    user = MembershipFactory.create(organization=opportunity.organization).user
+    print("opportunity.organization.slug", opportunity.organization.slug)
+    approve_url = reverse("opportunity:approve_visit", args=(opportunity.organization.slug, visit.id))
+    client.force_login(user)
+    response = client.post(approve_url, {"justification": justification}, follow=True)
+    print(response.status_code)
+    visit.refresh_from_db()
+    assert visit.status == VisitValidationStatus.approved
+    expected_redirect_url = None
+    if opportunity.managed:
+        assert justification == visit.justification
+        expected_redirect_url = reverse(
+            "opportunity:user_visit_review",
+            kwargs={"org_slug": opportunity.organization.slug, "opp_id": opportunity.id},
+        )
+    else:
+        expected_redirect_url = reverse(
+            "opportunity:user_visits_list",
+            kwargs={
+                "org_slug": opportunity.organization.slug,
+                "opp_id": opportunity.id,
+                "pk": visit.opportunity_access_id,
+            },
+        )
+    assert response.redirect_chain[-1][0] == expected_redirect_url
+    assert response.status_code == HTTPStatus.OK

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -870,6 +870,7 @@ def visit_verification(request, org_slug=None, pk=None):
 
 
 @org_member_required
+@require_POST
 def approve_visit(request, org_slug=None, pk=None):
     user_visit = UserVisit.objects.get(pk=pk)
     opp_id = user_visit.opportunity_id
@@ -877,8 +878,11 @@ def approve_visit(request, org_slug=None, pk=None):
         user_visit.status = VisitValidationStatus.approved
         if user_visit.opportunity.managed:
             user_visit.review_created_on = now()
+            user_visit.justification = request.POST.get("justification")
+
         user_visit.save()
         update_payment_accrued(opportunity=user_visit.opportunity, users=[user_visit.user])
+
     if user_visit.opportunity.managed:
         return redirect("opportunity:user_visit_review", org_slug, opp_id)
     return redirect(

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -17,6 +17,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from django.utils.timezone import now
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
@@ -311,6 +312,10 @@ class OpportunityDetail(OrganizationUserMixin, DetailView):
         context["visit_export_form"] = VisitExportForm()
         context["export_form"] = PaymentExportForm()
         context["user_is_network_manager"] = object.managed and object.organization == self.request.org
+        import_visit_helper_text = _(
+            'The file must contain at least the "Visit ID"{extra} and "Status" column. The import is case-insensitive.'
+        ).format(extra=_(', "Justification"') if object.managed else "")
+        context["import_visit_helper_text"] = import_visit_helper_text
         return context
 
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -878,13 +878,19 @@ def approve_visit(request, org_slug=None, pk=None):
         user_visit.status = VisitValidationStatus.approved
         if user_visit.opportunity.managed:
             user_visit.review_created_on = now()
-            user_visit.justification = request.POST.get("justification")
+
+            if user_visit.flagged:
+                justification = request.POST.get("justification")
+                if not justification:
+                    messages.error(request, "Justification is mandatory for flagged visits.")
+                user_visit.justification = justification
 
         user_visit.save()
         update_payment_accrued(opportunity=user_visit.opportunity, users=[user_visit.user])
 
     if user_visit.opportunity.managed:
         return redirect("opportunity:user_visit_review", org_slug, opp_id)
+
     return redirect(
         "opportunity:user_visits_list", org_slug=org_slug, opp_id=opp_id, pk=user_visit.opportunity_access_id
     )

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -166,7 +166,6 @@ def _bulk_update_visit_status(opportunity: Opportunity, dataset: Dataset):
                     to_update.append(visit)
                 user_ids.add(visit.user_id)
 
-            print(missing_justifications)
             if missing_justifications:
                 raise ImportException(get_missing_justification_message(missing_justifications))
 

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -436,10 +436,17 @@
             <input class="form-control" type="file" id="importFile" name="visits" required>
             <div class="col-auto">
               <span id="importFileHelp" class="form-text">
-                {% blocktrans %}
-                  The file must contain at least the "Visit ID" and "Status" column.
-                  The import is case-insensitive.
-                {% endblocktrans %}
+                {% if opportunity.managed %}
+                  {% blocktrans %}
+                      The file must contain at least the "Visit ID", "Justification", and "Status" column.
+                      The import is case-insensitive.
+                  {% endblocktrans %}
+                {% else %}
+                  {% blocktrans %}
+                      The file must contain at least the "Visit ID" and "Status" column.
+                      The import is case-insensitive.
+                  {% endblocktrans %}
+                {% endif %}
               </span>
             </div>
           </div>

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -436,17 +436,12 @@
             <input class="form-control" type="file" id="importFile" name="visits" required>
             <div class="col-auto">
               <span id="importFileHelp" class="form-text">
+                {% blocktrans %}The file must contain at least the "Visit ID"{% endblocktrans %}
                 {% if opportunity.managed %}
-                  {% blocktrans %}
-                      The file must contain at least the "Visit ID", "Justification", and "Status" column.
-                      The import is case-insensitive.
-                  {% endblocktrans %}
-                {% else %}
-                  {% blocktrans %}
-                      The file must contain at least the "Visit ID" and "Status" column.
-                      The import is case-insensitive.
-                  {% endblocktrans %}
+                  {% blocktrans %}, "Justification"{% endblocktrans %}
                 {% endif %}
+                {% blocktrans %}, and "Status" column.
+                The import is case-insensitive.{% endblocktrans %}
               </span>
             </div>
           </div>

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -436,12 +436,7 @@
             <input class="form-control" type="file" id="importFile" name="visits" required>
             <div class="col-auto">
               <span id="importFileHelp" class="form-text">
-                {% blocktrans %}The file must contain at least the "Visit ID"{% endblocktrans %}
-                {% if opportunity.managed %}
-                  {% blocktrans %}, "Justification"{% endblocktrans %}
-                {% endif %}
-                {% blocktrans %}, and "Status" column.
-                The import is case-insensitive.{% endblocktrans %}
+                {{ import_visit_helper_text }}
               </span>
             </div>
           </div>

--- a/commcare_connect/templates/opportunity/visit_verification.html
+++ b/commcare_connect/templates/opportunity/visit_verification.html
@@ -149,8 +149,12 @@
         <button class="btn btn-success" disabled>Approve</button>
         <button class="btn btn-danger" disabled>Reject</button>
       {% else %}
-        <a class="btn btn-success" href="{% url 'opportunity:approve_visit' org_slug=request.org.slug pk=visit.id  %}" role="button">Approve</a>
-        <button class="btn btn-danger" role="button" data-bs-toggle="modal" data-bs-target="#user-visit-reject-modal">Reject</a>
+        {% if visit.flagged and visit.opportunity.managed %}
+          <button id="flagged_approve" class="btn btn-danger" role="button" data-bs-toggle="modal" data-bs-target="#justification-modal">Approve</button>
+        {% else %}
+          <button class="btn btn-success"  hx-post="{% url 'opportunity:approve_visit' org_slug=request.org.slug pk=visit.id %}" role="button">Approve</button>
+        {% end if%}
+        <button class="btn btn-danger" role="button" data-bs-toggle="modal" data-bs-target="#user-visit-reject-modal">Reject</button>
       {% endif %}
     </div>
   </div>
@@ -175,6 +179,32 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
           <button type="submit" class="btn btn-danger">Reject</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock modal %}
+
+{% block modal %}
+<div class="modal" tabindex="-1" id="justification-modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Approve Visit</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form action="{% url 'opportunity:approve_visit' org_slug=request.org.slug pk=visit.id  %}" method="post">
+        <div class="modal-body">
+            {% csrf_token %}
+            <div class="mb-3">
+              <label for="rejection-reason" class="form-label">Justification</label>
+              <textarea class="form-control" id="justification" rows="3" name="reason">{{ justification }}</textarea>
+            </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-danger">Approve</button>
         </div>
       </form>
     </div>

--- a/commcare_connect/templates/opportunity/visit_verification.html
+++ b/commcare_connect/templates/opportunity/visit_verification.html
@@ -150,10 +150,13 @@
         <button class="btn btn-danger" disabled>Reject</button>
       {% else %}
         {% if visit.flagged and visit.opportunity.managed %}
-          <button id="flagged_approve" class="btn btn-danger" role="button" data-bs-toggle="modal" data-bs-target="#justification-modal">Approve</button>
+          <button class="btn btn-success" role="button" data-bs-toggle="modal" data-bs-target="#justification-modal">Approve</button>
         {% else %}
-          <button class="btn btn-success"  hx-post="{% url 'opportunity:approve_visit' org_slug=request.org.slug pk=visit.id %}" role="button">Approve</button>
-        {% end if%}
+          <form method="POST" class="d-inline-block" action="{% url "opportunity:approve_visit" org_slug=request.org.slug pk=visit.id %}">
+            {% csrf_token %}
+             <button class="btn btn-success">Approve</button>
+          </form>
+        {% endif %}
         <button class="btn btn-danger" role="button" data-bs-toggle="modal" data-bs-target="#user-visit-reject-modal">Reject</button>
       {% endif %}
     </div>
@@ -184,9 +187,8 @@
     </div>
   </div>
 </div>
-{% endblock modal %}
 
-{% block modal %}
+
 <div class="modal" tabindex="-1" id="justification-modal">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -198,19 +200,20 @@
         <div class="modal-body">
             {% csrf_token %}
             <div class="mb-3">
-              <label for="rejection-reason" class="form-label">Justification</label>
-              <textarea class="form-control" id="justification" rows="3" name="reason">{{ justification }}</textarea>
+              <label for="justification" class="form-label">Justification</label>
+              <textarea required class="form-control" id="justification" rows="3" name="justification">{{ justification }}</textarea>
             </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-          <button type="submit" class="btn btn-danger">Approve</button>
+          <button type="submit" class="btn btn-success">Approve</button>
         </div>
       </form>
     </div>
   </div>
 </div>
 {% endblock modal %}
+
 
 {% block inline_javascript %}
 {{ block.super }}


### PR DESCRIPTION
## Product Description

<img width="717" alt="Screenshot 2025-03-12 at 10 27 33" src="https://github.com/user-attachments/assets/899c0bd6-ddbb-419d-880e-cc73596cf252" />

![Screenshot 2025-03-13 at 11 39 08](https://github.com/user-attachments/assets/c5d45d99-6ec9-441a-9fdc-3df64e48c1ac)



## Technical Summary

Added mandatory justification for flagged visits in managed opportunity cases. This applies both when manually approving visits and when importing visits via file [CCCT-836.](https://dimagi.atlassian.net/browse/CCCT-836)

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Existing tests are passing. Added new test cases for different scenarios.


### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
