### PR TITLE
Fix Total Eligible Users and Total ConnectID Counts

### DIFF
--- a/commcare_connect/reports/helpers.py
+++ b/commcare_connect/reports/helpers.py
@@ -24,11 +24,11 @@ def _get_cumulative_count(count_data: dict[str, int]):
     from_date = datetime.strptime(ADMIN_REPORT_START, "%Y-%m").date()
     to_date = datetime.today().date()
     timeseries = get_month_series(from_date, to_date)
-    total_eligible_user_count = 0
+    total_count = 0
     for month in timeseries:
         key = month.strftime("%Y-%m")
-        total_eligible_user_count += count_data.get(key, 0)
-        data[key] = total_eligible_user_count
+        total_count += count_data.get(key, 0)
+        data[key] = total_count
     return data
 
 

--- a/commcare_connect/reports/helpers.py
+++ b/commcare_connect/reports/helpers.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from django.db import models
-from django.db.models.functions import ExtractDay, TruncMonth
+from django.db.models.functions import Coalesce, ExtractDay, TruncMonth
 from django.utils.timezone import now
 
 from commcare_connect.connect_id_client import fetch_user_counts
@@ -15,6 +15,38 @@ from commcare_connect.opportunity.models import (
     VisitValidationStatus,
 )
 from commcare_connect.utils.datetime import get_month_series, get_start_end_dates_from_month_range
+
+ADMIN_REPORT_START = "2023-01"
+
+
+def _get_cumulative_count(count_data: dict[str, int]):
+    data = defaultdict(int)
+    from_date = datetime.strptime(ADMIN_REPORT_START, "%Y-%m").date()
+    to_date = datetime.today().date()
+    timeseries = get_month_series(from_date, to_date)
+    total_eligible_user_count = 0
+    for month in timeseries:
+        key = month.strftime("%Y-%m")
+        total_eligible_user_count += count_data.get(key, 0)
+        data[key] = total_eligible_user_count
+    return data
+
+
+def get_connectid_user_counts_cumulative():
+    connectid_user_count = fetch_user_counts()
+    return _get_cumulative_count(connectid_user_count)
+
+
+def get_eligible_user_counts_cumulative():
+    visit_data = (
+        CompletedWork.objects.filter(status=CompletedWorkStatus.approved, saved_approved_count__gt=0)
+        .annotate(month_group=TruncMonth(Coalesce("status_modified_date", "date_created")))
+        .values("month_group")
+        .annotate(users=models.Count("opportunity_access__user_id", distinct=True))
+        .order_by("month_group")
+    )
+    visit_data_dict = {item["month_group"].strftime("%Y-%m"): item["users"] for item in visit_data}
+    return _get_cumulative_count(visit_data_dict)
 
 
 def get_table_data_for_year_month(
@@ -187,14 +219,14 @@ def get_table_data_for_year_month(
             }
         )
 
-    connectid_user_count = fetch_user_counts()
-    total_connectid_user_count = 0
-    total_eligible_user_count = 0
+    connectid_user_count = get_connectid_user_counts_cumulative()
+    total_eligible_user_counts = get_eligible_user_counts_cumulative()
     for group_key in visit_data_dict.keys():
         month_group = group_key[0]
-        total_connectid_user_count += connectid_user_count.get(month_group, 0)
-        total_eligible_user_count += visit_data_dict[group_key].get("users", 0)
         visit_data_dict[group_key].update(
-            {"connectid_users": total_connectid_user_count, "total_eligible_users": total_eligible_user_count}
+            {
+                "connectid_users": connectid_user_count.get(month_group, 0),
+                "total_eligible_users": total_eligible_user_counts.get(month_group, 0),
+            }
         )
     return list(visit_data_dict.values())

--- a/commcare_connect/reports/helpers.py
+++ b/commcare_connect/reports/helpers.py
@@ -118,11 +118,7 @@ def get_table_data_for_year_month(
         models.F("payment_date") - models.Subquery(max_visit_date), output_field=models.DurationField()
     )
     base_visit_data_qs = CompletedWork.objects.filter(
-        **filter_kwargs,
-        status=CompletedWorkStatus.approved,
-        saved_approved_count__gt=0,
-        saved_payment_accrued_usd__gt=0,
-        saved_org_payment_accrued_usd__gt=0,
+        **filter_kwargs, status=CompletedWorkStatus.approved, saved_approved_count__gt=0
     )
     visit_data = (
         base_visit_data_qs.annotate(
@@ -152,7 +148,10 @@ def get_table_data_for_year_month(
         visit_data_dict[group_key].update(item)
 
     visit_time_to_payment_data = (
-        base_visit_data_qs.filter(payment_date__range=(start_date, end_date))
+        base_visit_data_qs.filter(
+            payment_date__range=(start_date, end_date),
+            saved_payment_accrued_usd__gt=0,
+        )
         .annotate(
             month_group=TruncMonth("payment_date"),
             delivery_type_name=models.F("opportunity_access__opportunity__delivery_type__name"),

--- a/commcare_connect/reports/tests/test_reports.py
+++ b/commcare_connect/reports/tests/test_reports.py
@@ -141,14 +141,14 @@ def test_get_table_data_for_year_month(from_date, to_date, httpx_mock):
         assert date(row["month_group"].year, row["month_group"].month, 1) in months
         total_connectid_user_count += connectid_user_counts.get(row["month_group"].strftime("%Y-%m"))
         assert row["connectid_users"] == total_connectid_user_count
-        assert row["total_eligible_users"] == (i + 1) * 9
-        assert row["users"] == 9
-        assert row["services"] == 9
+        assert row["total_eligible_users"] == (i + 1) * 10
+        assert row["users"] == 10
+        assert row["services"] == 10
         assert row["avg_time_to_payment"] == 50
         assert 0 <= row["max_time_to_payment"] <= 90
         assert row["flw_amount_earned"] == 4500
         assert row["flw_amount_paid"] == 4500
-        assert row["nm_amount_earned"] == 5400
+        assert row["nm_amount_earned"] == 5500
         assert row["nm_amount_paid"] == 1000
         assert row["nm_other_amount_paid"] == 1000
         assert row["avg_top_paid_flws"] == 900
@@ -205,13 +205,13 @@ def test_get_table_data_for_year_month_by_delivery_type(delivery_type, httpx_moc
         ):
             continue
         assert row["delivery_type_name"] in delivery_type_slugs
-        assert row["users"] == 4
-        assert row["services"] == 4
+        assert row["users"] == 5
+        assert row["services"] == 5
         assert row["avg_time_to_payment"] == 25
         assert row["max_time_to_payment"] == 40
         assert row["flw_amount_earned"] == 1000
         assert row["flw_amount_paid"] == 1000
-        assert row["nm_amount_earned"] == 1400
+        assert row["nm_amount_earned"] == 1500
         assert row["nm_amount_paid"] == 500
         assert row["avg_top_paid_flws"] == 400
 
@@ -260,13 +260,13 @@ def test_get_table_data_for_year_month_by_country_currency(opp_currency, filter_
             if row["month_group"].month != now.month or row["month_group"].year != now.year:
                 continue
 
-            assert row["users"] == 9
-            assert row["services"] == 9
+            assert row["users"] == 10
+            assert row["services"] == 10
             assert row["avg_time_to_payment"] == 50
             assert 0 <= row["max_time_to_payment"] <= 90
             assert row["flw_amount_earned"] == 4500
             assert row["flw_amount_paid"] == 4500
-            assert row["nm_amount_earned"] == 5400
+            assert row["nm_amount_earned"] == 5500
             assert row["nm_amount_paid"] == 1000
             assert row["nm_other_amount_paid"] == 1000
             assert row["avg_top_paid_flws"] == 900


### PR DESCRIPTION
## Product Description
This PR Fixes
- Total Eligible User and Total ConnectID Accounts cumulative counts
    - Added Fixed windows for calculating cumulative counts and using those in queries
- Fixed Eligible User Count queryset filtering
    - Removed filters related to payment data in user counts filtering
    - Moved these filters to the time to payment data queryset     

## Safety Assurance
### Safety story

### Automated test coverage
- Automated tests cover these changes.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
