### PR TITLE
Cloudwatch Log Groups and Stream Names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-ruby@v1
 
       - name: Install Kamal
-        run: gem install kamal -v '~> 1.0.0'
+        run: gem install kamal -v '~> 1.9.2'
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2.5.1

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,7 +32,7 @@ Deploying commcare-connect uses the following tools:
 (requires Ruby)
 
 ```bash
-gem install kamal -v '~> 1.0.0'
+gem install kamal -v '~> 1.9.2'
 ```
 
 ### Ansible

--- a/deploy/config/deploy.production.yml
+++ b/deploy/config/deploy.production.yml
@@ -6,6 +6,10 @@ servers:
     options:
       # create by ansible
       env-file: '/home/connect/www/commcare-connect/docker.env'
+    logging:
+      options:
+        awslogs-group: 'commcare-connect-web'
+        tag: 'web-{{.ID}}'
   celery:
     hosts:
       - 44.193.193.67
@@ -15,3 +19,7 @@ servers:
     cmd: /start_celery
     labels:
       traefik.enable: false
+    logging:
+      options:
+        awslogs-group: 'commcare-connect-celery'
+        tag: 'celery-{{.ID}}'

--- a/deploy/config/deploy.staging.yml
+++ b/deploy/config/deploy.staging.yml
@@ -21,4 +21,4 @@ servers:
     logging:
       options:
         awslogs-group: 'commcare-connect-staging-celery'
-        tag: 'web-{{.ID}}'
+        tag: 'celery-{{.ID}}'

--- a/deploy/config/deploy.staging.yml
+++ b/deploy/config/deploy.staging.yml
@@ -5,6 +5,10 @@ servers:
     options:
       # create by ansible
       env-file: '/home/connect/www/commcare-connect/docker.env'
+    logging:
+      options:
+        awslogs-group: 'commcare-connect-staging-web'
+        tag: 'web-{{.ID}}'
   celery:
     hosts:
       - 54.172.148.144
@@ -14,3 +18,7 @@ servers:
     cmd: /start_celery
     labels:
       traefik.enable: false
+    logging:
+      options:
+        awslogs-group: 'commcare-connect-staging-celery'
+        tag: 'web-{{.ID}}'

--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -15,7 +15,6 @@ logging:
   driver: awslogs
   options:
     awslogs-region: 'us-east-1'
-    awslogs-group: 'commcare-connect'
 
 builder:
   multiarch: false


### PR DESCRIPTION
## Product Description
Added Log Groups for staging and production services.

Cloudwatch Log Group Names
- commcare-connect-web
- commcare-connect-celery
- commcare-connect-staging-web
- commcare-connect-staging-celery

Stream names are generated from container type now (web, celery) and container_id now. 

## Safety Assurance

### Safety story



### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
