### PR TITLE
Fix for Export/Import PM Review Visit Being Visible on Normal Opportunities

### DIFF
--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -118,19 +118,6 @@
           {% endif%}
           <li class="dropdown-divider"></li>
           <li>
-            <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportPMReviewModal">
-              <i class="bi bi-file-earmark-arrow-down-fill pe-2"></i>
-              {% translate "Export PM Review Visits" %}
-            </a>
-          </li>
-          <li>
-            <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#importPMReviewModal">
-              <i class="bi bi-file-earmark-arrow-up-fill pe-2"></i>
-               {% translate "Import PM Review Visits" %}
-            </a>
-          </li>
-          <li class="dropdown-divider"></li>
-          <li>
             <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportVisitModal">
               <i class="bi bi-file-earmark-arrow-down-fill pe-2"></i>
               {% translate "Export User Visits" %}

--- a/commcare_connect/templates/opportunity/opportunity_detail.html
+++ b/commcare_connect/templates/opportunity/opportunity_detail.html
@@ -100,6 +100,22 @@
               {% translate "Configure Verification Flags" %}
             </a>
           </li>
+          {% endif %}
+          {% if object.managed and request.org_membership.is_program_manager %}
+            <li class="dropdown-divider"></li>
+            <li>
+              <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportPMReviewModal">
+                <i class="bi bi-file-earmark-arrow-down-fill pe-2"></i>
+                {% translate "Export PM Review Visits" %}
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#importPMReviewModal">
+                <i class="bi bi-file-earmark-arrow-up-fill pe-2"></i>
+                 {% translate "Import PM Review Visits" %}
+              </a>
+            </li>
+          {% endif%}
           <li class="dropdown-divider"></li>
           <li>
             <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportPMReviewModal">
@@ -113,7 +129,6 @@
                {% translate "Import PM Review Visits" %}
             </a>
           </li>
-          {% endif %}
           <li class="dropdown-divider"></li>
           <li>
             <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#exportVisitModal">


### PR DESCRIPTION
## Product Description

This PR fixes the if condition, as `export/import PM review visit options` are visible on normal opportunities as well.

## Safety Assurance

### Safety story

Only the if condition was changed, so the update is low risk.


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
