### PR TITLE
Better error response to the well know errors.

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -241,7 +241,8 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
 
     if not payment_unit:
         raise ProcessingError(
-            f"Payment unit is not configured for the deliver app: {app.name} in opportunity: {opportunity.name}"
+            f"Payment unit is not configured for the deliver unit: "
+            f"{deliver_unit.name} in opportunity: {opportunity.name}"
         )
 
     access = None

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 from allauth.utils import build_absolute_uri
 from django.conf import settings
+from django.core.cache import cache
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db import transaction
@@ -357,3 +358,20 @@ def generate_catchment_area_export(opportunity_id: int, export_format: str):
     export_tmp_name = f"{now().isoformat()}_{opportunity.name}_catchment_area.{export_format}"
     save_export(dataset, export_tmp_name, export_format)
     return export_tmp_name
+
+
+def update_payment_accrued(opportunity: Opportunity, users):
+    """Updates payment accrued for completed and approved CompletedWork instances."""
+    access_objects = OpportunityAccess.objects.filter(user__in=users, opportunity=opportunity, suspended=False)
+    for access in access_objects:
+        with cache.lock(f"update_payment_accrued_lock_{access.id}", timeout=900):
+            completed_works = access.completedwork_set.exclude(status=CompletedWorkStatus.rejected).select_related(
+                "payment_unit"
+            )
+            update_status(completed_works, access, compute_payment=True)
+
+
+@celery_app.task()
+def process_payment_accrued(opp_id, user_ids):
+    opportunity = Opportunity.objects.get(id=opp_id)
+    update_payment_accrued(opportunity, user_ids)

--- a/commcare_connect/opportunity/tests/test_visit_import.py
+++ b/commcare_connect/opportunity/tests/test_visit_import.py
@@ -24,6 +24,7 @@ from commcare_connect.opportunity.models import (
     VisitReviewStatus,
     VisitValidationStatus,
 )
+from commcare_connect.opportunity.tasks import update_payment_accrued
 from commcare_connect.opportunity.tests.factories import (
     CatchmentAreaFactory,
     CompletedWorkFactory,
@@ -48,7 +49,6 @@ from commcare_connect.opportunity.visit_import import (
     _bulk_update_visit_status,
     get_data_by_visit_id,
     get_missing_justification_message,
-    update_payment_accrued,
 )
 from commcare_connect.program.tests.factories import ManagedOpportunityFactory
 from commcare_connect.users.models import User

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -102,6 +102,7 @@ from commcare_connect.opportunity.tasks import (
     invite_user,
     send_push_notification_task,
     send_sms_task,
+    update_payment_accrued,
     update_user_and_send_invite,
 )
 from commcare_connect.opportunity.visit_import import (
@@ -112,7 +113,6 @@ from commcare_connect.opportunity.visit_import import (
     bulk_update_visit_review_status,
     bulk_update_visit_status,
     get_exchange_rate,
-    update_payment_accrued,
 )
 from commcare_connect.organization.decorators import org_admin_required, org_member_required, org_viewer_required
 from commcare_connect.program.models import ManagedOpportunity, ProgramApplication


### PR DESCRIPTION
## Product Description

This PR addresses the recent system exit issue in our form processor code, as observed in Sentry. Additionally, it improves error messages to enhance clarity. The form processor has been generating an excessive number of `500` exceptions due to `ECD` making suboptimal requests. This update ensures that error messages provide clearer explanations, helping users understand what went wrong.

## Issues Observed:

### 1. System exits:

  - Recently, we have been experiencing too many system exits, mainly because the form processor is taking too long (more than 5 minutes) in cases where a user has many visits. [HQ READ_TIMEOUT](https://github.com/dimagi/commcare-hq/blob/master/corehq/motech/const.py#L93) is of 5 minutes
  - I observed this in one particular [opportunity](https://connect.dimagi.com/a/solina/opportunity/411/) where the users had more than 1,500 visits.
  - My understanding is that the payment accrual process appears to be the main culprit.
  - To address this, I attempted to make it a celery task. However, I’m unsure how comfortable we are with this approach.
  - Would love to hear your thoughts on this!

### 2. Users without proper opportunity access hitting the API:

  - Users who are not invited to an opportunity are directly accessing the API. This  is happening because the support team, while testing certain ECD-related scenarios, is unaware that a specific user hasn’t been invited but still attempts to access the API, which requires proper opportunity access.
  -Sentry error: [OpportunityAccess.DoesNotExist](https://dimagi.sentry.io/issues/6193158874/?environment=production&project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=3).

  
### 3. Deliver unit missing a payment unit:

  - There are cases where a deliver unit does not have an associated payment unit.
  - Ideally, this should not happen, but since it frequently triggers Sentry errors and is repeatedly flagged by the support team, developers end up debugging the same issue multiple times.
  -Sentry error: [OpportunityClaimLimit.DoesNotExist](https://dimagi.sentry.io/issues/5164073901/?environment=production&project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=0).


## Safety Assurance
This update is safe, as it only enhances the API by adding a proper error message response and making the payment accrued method asynchronous.

- All existing test cases pass.
- A new test case has been added to verify that `process_payment_accrued` is called.


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change