### PR TITLE
Async update_payment_accrued for Imports

### DIFF
--- a/commcare_connect/opportunity/tests/test_visit_import.py
+++ b/commcare_connect/opportunity/tests/test_visit_import.py
@@ -461,6 +461,7 @@ def prepare_opportunity_payment_test_data(opportunity):
             payment_unit=payment_unit,
             status=CompletedWorkStatus.approved.value,
             payment_date=None,
+            status_modified_date=now(),
         )
         completed_works.append(completed_work)
         for deliver_unit in payment_unit.deliver_units.all():
@@ -471,6 +472,7 @@ def prepare_opportunity_payment_test_data(opportunity):
                 status=VisitValidationStatus.approved.value,
                 opportunity_access=access,
                 completed_work=completed_work,
+                status_modified_date=now(),
             )
     return user, access, payment_units, completed_works
 


### PR DESCRIPTION
## Product Description
Added a celery task for the update_payment_accrued function for bulk imports. The update_payment_accrued task times out in a web worker. Doing this task in a celery task will let the import process go without timing out, and the payment accrual can happen asynchronously independent of the upload.

Payment accrual code performance is very bad due to multiple queries made during the `approved_count` and `completed_count` calculations for CompletedWork. A better solution would be to improve those functions but to unblock the users right now, we have to settle for an intermediate solution while we figure out how to improve that calculation.


<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-870)
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story

### Automated test coverage
- This code involves turning a well-tested function into a task.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
