### PR TITLE
Used saved completed count to count visit count.

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -271,8 +271,11 @@ class OpportunityAccess(models.Model):
 
     @property
     def visit_count(self):
-        return sum(
-            [cw.completed for cw in self.completedwork_set.exclude(status=CompletedWorkStatus.over_limit).all()]
+        return (
+            self.completedwork_set.exclude(status=CompletedWorkStatus.over_limit).aggregate(
+                total=Sum("saved_completed_count")
+            )["total"]
+            or 0
         )
 
     @property

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -12,6 +12,7 @@ from commcare_connect.opportunity.tests.factories import (
     PaymentUnitFactory,
     UserVisitFactory,
 )
+from commcare_connect.opportunity.visit_import import update_payment_accrued
 from commcare_connect.users.models import User
 from commcare_connect.users.tests.factories import MobileUserFactory
 
@@ -117,4 +118,5 @@ def test_access_visit_count(opportunity: Opportunity):
     UserVisitFactory(
         completed_work=completed_work, deliver_unit=deliver_unit, user=access.user, opportunity=access.opportunity
     )
+    update_payment_accrued(opportunity, [access.user.id])
     assert access.visit_count == 1


### PR DESCRIPTION
## Technical Summary

We are having an issue with the `completed` count, as it takes too long when the number of visits is large. Instead of calculating it in real-time, using the `saved_completed_count` to track the visits.

[Slack thread](https://dimagi.slack.com/archives/C05UNUNH43X/p1742896758996559)
[Sentry Error](https://dimagi.sentry.io/issues/6456670514/?project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=0)

## Safety Assurance

### Safety story

Updated the test so that saved_completed_count is updated.
Rest all test are passing.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
