### PR TITLE
FCM Analytics Label for Notifications

### DIFF
--- a/commcare_connect/connect_id_client/models.py
+++ b/commcare_connect/connect_id_client/models.py
@@ -1,6 +1,8 @@
 import dataclasses
 from enum import StrEnum
 
+FCM_ANALYTICS_LABEL = "commcare-connect-notification"
+
 
 @dataclasses.dataclass
 class ConnectIdUser:
@@ -74,6 +76,7 @@ class Message:
     title: str = None
     body: str = None
     data: dict = None
+    fcm_options: dict = dataclasses.field(default_factory=lambda: {"analytics_label": FCM_ANALYTICS_LABEL})
 
     def asdict(self):
         return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}


### PR DESCRIPTION
## Product Description

This PR adds the analytics label on the notification sent from Connect to users.
The label for notifications is `commcare-connect-notification`.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-777)


## Safety Assurance

### Safety story


### Automated test coverage

### QA Plan


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
