### PR TITLE
Handle Missing Payment Unit in Deliver Unit

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -237,6 +237,12 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
 def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Opportunity, deliver_unit_block: dict):
     deliver_unit = get_or_create_deliver_unit(app, deliver_unit_block)
     access = OpportunityAccess.objects.get(opportunity=opportunity, user=user)
+    payment_unit = deliver_unit.payment_unit
+    if not payment_unit:
+        raise ProcessingError(
+            f"Payment unit is not configured for the deliver unit: "
+            f"{deliver_unit.name} in opportunity: {opportunity.name}"
+        )
 
     counts = (
         UserVisit.objects.filter(opportunity_access=access, deliver_unit=deliver_unit)
@@ -247,7 +253,6 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
             entity=Count("pk", filter=Q(entity_id=deliver_unit_block.get("entity_id"), deliver_unit=deliver_unit)),
         )
     )
-    payment_unit = deliver_unit.payment_unit
     claim = OpportunityClaim.objects.get(opportunity_access=access)
     claim_limit = OpportunityClaimLimit.objects.get(opportunity_claim=claim, payment_unit=payment_unit)
     entity_id = deliver_unit_block.get("entity_id")

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -816,7 +816,7 @@ class PaymentUnitForm(forms.ModelForm):
                 hx-disabled-elt="this"
                 hx-on:click="this.innerHTML=&quot;<span class=\\
                 'spinner-border spinner-border-sm'></span> Syncing...&quot;;">
-                <span id="sync-text">Sync Delivery Units</span>
+                <span id="sync-text">Sync Deliver Units</span>
                 </button>
                 """
             ),

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -803,6 +803,23 @@ class PaymentUnitForm(forms.ModelForm):
             Row(Column("start_date"), Column("end_date")),
             Row(Field("required_deliver_units")),
             Row(Field("optional_deliver_units")),
+            Row(
+                Column(
+                    HTML(
+                        f"""
+                        <button type="button" class="btn btn-sm btn-outline-info" id="sync-button"
+                            hx-post="{reverse('opportunity:sync_delivery_units', args=('hy-superuser', 2))}"
+                            hx-trigger="click"
+                            hx-swap="outerHTML"
+                            hx-on:click="this.innerHTML=&quot;<span class='spinner-border spinner-border-sm'
+                            role='status' aria-hidden='true'></span> Syncing...&quot;; this.disabled=true;">
+                            <span id="sync-text">Sync Delivery Units</span>
+                        </button>
+                        """
+                    ),
+                    css_class="col-md-3 d-flex align-items-center mb-3",
+                )
+            ),
             Row(Field("payment_units")),
             Field("max_total", wrapper_class="form-group col-md-4 mb-0"),
             Field("max_daily", wrapper_class="form-group col-md-4 mb-0"),

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -793,6 +793,9 @@ class PaymentUnitForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         deliver_units = kwargs.pop("deliver_units", [])
         payment_units = kwargs.pop("payment_units", [])
+        org_slug = kwargs.pop("org_slug")
+        opportunity_id = kwargs.pop("opportunity_id")
+
         super().__init__(*args, **kwargs)
 
         self.helper = FormHelper(self)
@@ -806,7 +809,7 @@ class PaymentUnitForm(forms.ModelForm):
             HTML(
                 f"""
                 <button type="button" class="btn btn-sm btn-outline-info mb-3" id="sync-button"
-                hx-post="{reverse('opportunity:sync_delivery_units', args=('hy-superuser', 2))}"
+                hx-post="{reverse('opportunity:sync_deliver_units', args=(org_slug, opportunity_id))}"
                 hx-trigger="click" hx-swap="none" hx-on::after-request="alert(event?.detail?.xhr?.response);
                 event.detail.successful && location.reload();
                 this.removeAttribute('disabled'); this.innerHTML='Sync Delivery Units';""

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -812,7 +812,7 @@ class PaymentUnitForm(forms.ModelForm):
                 hx-post="{reverse('opportunity:sync_deliver_units', args=(org_slug, opportunity_id))}"
                 hx-trigger="click" hx-swap="none" hx-on::after-request="alert(event?.detail?.xhr?.response);
                 event.detail.successful && location.reload();
-                this.removeAttribute('disabled'); this.innerHTML='Sync Delivery Units';""
+                this.removeAttribute('disabled'); this.innerHTML='Sync Deliver Units';""
                 hx-disabled-elt="this"
                 hx-on:click="this.innerHTML=&quot;<span class=\\
                 'spinner-border spinner-border-sm'></span> Syncing...&quot;;">

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -803,22 +803,19 @@ class PaymentUnitForm(forms.ModelForm):
             Row(Column("start_date"), Column("end_date")),
             Row(Field("required_deliver_units")),
             Row(Field("optional_deliver_units")),
-            Row(
-                Column(
-                    HTML(
-                        f"""
-                        <button type="button" class="btn btn-sm btn-outline-info" id="sync-button"
-                            hx-post="{reverse('opportunity:sync_delivery_units', args=('hy-superuser', 2))}"
-                            hx-trigger="click"
-                            hx-swap="outerHTML"
-                            hx-on:click="this.innerHTML=&quot;<span class='spinner-border spinner-border-sm'
-                            role='status' aria-hidden='true'></span> Syncing...&quot;; this.disabled=true;">
-                            <span id="sync-text">Sync Delivery Units</span>
-                        </button>
-                        """
-                    ),
-                    css_class="col-md-3 d-flex align-items-center mb-3",
-                )
+            HTML(
+                f"""
+                <button type="button" class="btn btn-sm btn-outline-info mb-3" id="sync-button"
+                hx-post="{reverse('opportunity:sync_delivery_units', args=('hy-superuser', 2))}"
+                hx-trigger="click" hx-swap="none" hx-on::after-request="alert(event?.detail?.xhr?.response);
+                event.detail.successful && location.reload();
+                this.removeAttribute('disabled'); this.innerHTML='Sync Delivery Units';""
+                hx-disabled-elt="this"
+                hx-on:click="this.innerHTML=&quot;<span class=\\
+                'spinner-border spinner-border-sm'></span> Syncing...&quot;;">
+                <span id="sync-text">Sync Delivery Units</span>
+                </button>
+                """
             ),
             Row(Field("payment_units")),
             Field("max_total", wrapper_class="form-group col-md-4 mb-0"),

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -46,6 +46,7 @@ from commcare_connect.opportunity.views import (
     send_message_mobile_users,
     suspend_user,
     suspended_users_list,
+    sync_deliver_units,
     update_completed_work_status_import,
     update_visit_status_import,
     user_profile,
@@ -125,4 +126,5 @@ urlpatterns = [
     path("<int:pk>/invoice/approve/", views.invoice_approve, name="invoice_approve"),
     path("<int:opp_id>/user_invite_delete/<int:pk>/", views.user_invite_delete, name="user_invite_delete"),
     path("<int:opp_id>/resend_invite/<int:pk>", resend_user_invite, name="resend_user_invite"),
+    path("<int:opp_id>/sync_delivery_units/", sync_deliver_units, name="sync_delivery_units"),
 ]

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -126,5 +126,5 @@ urlpatterns = [
     path("<int:pk>/invoice/approve/", views.invoice_approve, name="invoice_approve"),
     path("<int:opp_id>/user_invite_delete/<int:pk>/", views.user_invite_delete, name="user_invite_delete"),
     path("<int:opp_id>/resend_invite/<int:pk>", resend_user_invite, name="resend_user_invite"),
-    path("<int:opp_id>/sync_delivery_units/", sync_deliver_units, name="sync_delivery_units"),
+    path("<int:opp_id>/sync_deliver_units/", sync_deliver_units, name="sync_deliver_units"),
 ]

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from functools import reduce
+from http import HTTPStatus
 
 from celery.result import AsyncResult
 from crispy_forms.utils import render_crispy_form
@@ -1363,14 +1364,12 @@ def resend_user_invite(request, org_slug, opp_id, pk):
 
 
 def sync_deliver_units(request, org_slug, opp_id):
-    response_html = ""
+    status = status = HTTPStatus.OK
+    message = "Delivery unit sync completed."
     try:
         create_learn_modules_and_deliver_units.delay(opp_id)
-        response_html = """
-              <i class="bi bi-check-lg text-success" id="sync-button">Sync Completed</i>
-          """
     except AppNoBuildException:
-        response_html = """
-              <i class="bi bi-exclamation text-warning fs-6" id="sync-button">No new updates available.</i>
-          """
-    return HttpResponse(response_html)
+        status = HTTPStatus.BAD_REQUEST
+        message = "No new updates available"
+
+    return HttpResponse(content=message, status=status)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1368,12 +1368,12 @@ def resend_user_invite(request, org_slug, opp_id, pk):
 
 
 def sync_deliver_units(request, org_slug, opp_id):
-    status = status = HTTPStatus.OK
+    status = HTTPStatus.OK
     message = "Delivery unit sync completed."
     try:
-        create_learn_modules_and_deliver_units.apply(args=[opp_id], throw=True)
+        create_learn_modules_and_deliver_units(opp_id)
     except AppNoBuildException:
         status = HTTPStatus.BAD_REQUEST
-        message = "No new updates available"
+        message = "Failed to retrieve updates. No available build at the moment."
 
     return HttpResponse(content=message, status=status)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -613,6 +613,8 @@ def add_payment_unit(request, org_slug=None, pk=None):
         deliver_units=deliver_units,
         data=request.POST or None,
         payment_units=opportunity.paymentunit_set.filter(parent_payment_unit__isnull=True).all(),
+        org_slug=org_slug,
+        opportunity_id=opportunity.pk,
     )
     if form.is_valid():
         form.instance.opportunity = opportunity
@@ -668,6 +670,8 @@ def edit_payment_unit(request, org_slug=None, opp_id=None, pk=None):
         instance=payment_unit,
         data=request.POST or None,
         payment_units=opportunity_payment_units,
+        org_slug=org_slug,
+        opportunity_id=opportunity.pk,
     )
     if form.is_valid():
         form.save()

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1371,7 +1371,7 @@ def sync_deliver_units(request, org_slug, opp_id):
     status = status = HTTPStatus.OK
     message = "Delivery unit sync completed."
     try:
-        create_learn_modules_and_deliver_units.delay(opp_id)
+        create_learn_modules_and_deliver_units.apply(args=[opp_id], throw=True)
     except AppNoBuildException:
         status = HTTPStatus.BAD_REQUEST
         message = "No new updates available"

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -29,6 +29,7 @@ from geopy import distance
 from commcare_connect.connect_id_client import fetch_users
 from commcare_connect.form_receiver.serializers import XFormSerializer
 from commcare_connect.opportunity.api.serializers import remove_opportunity_access_cache
+from commcare_connect.opportunity.app_xml import AppNoBuildException
 from commcare_connect.opportunity.forms import (
     AddBudgetExistingUsersForm,
     AddBudgetNewUsersForm,
@@ -1359,3 +1360,17 @@ def resend_user_invite(request, org_slug, opp_id, pk):
         invite_user.delay(user.id, access.pk)
 
     return HttpResponse("The invitation has been successfully resent to the user.")
+
+
+def sync_deliver_units(request, org_slug, opp_id):
+    response_html = ""
+    try:
+        create_learn_modules_and_deliver_units.delay(opp_id)
+        response_html = """
+              <i class="bi bi-check-lg text-success" id="sync-button">Sync Completed</i>
+          """
+    except AppNoBuildException:
+        response_html = """
+              <i class="bi bi-exclamation text-warning fs-6" id="sync-button">No new updates available.</i>
+          """
+    return HttpResponse(response_html)


### PR DESCRIPTION
## Product Description

This PR prevents a 500 error when the payment unit is null in the delivery unit, which happens when the deliver unit is created later or not configured with a payment unit. Since OpportunityClaimLimit requires a payment unit, this issue needs to be handled properly.

Key Updates:

- Sync Deliver Units from HQ: Added an option in the "Add Payment Unit" form to sync deliver units from HQ, allowing users to assign a payment unit to newly added deliver unit.
- Improved Error Handling: The form processor now returns a clear error message instead of failing with a 500 error.

[CCCT-898](https://dimagi.atlassian.net/browse/CCCT-898)


https://github.com/user-attachments/assets/fd4936e8-8343-47fb-9264-691b434067d8



## Safety Assurance

### Safety story

Most of the code relies on existing functions that have been working correctly. The changes have been tested locally to ensure proper functionality.

### Automated test coverage
All existing tests pass, confirming that the changes do not introduce regressions.


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-898]: https://dimagi.atlassian.net/browse/CCCT-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ