### PR TITLE
IntegrityError: Duplicate Key Violation in Currency Exchange Rates

### DIFF
--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -376,7 +376,8 @@ def get_exchange_rate(currency_code, date=None):
         rate = rates.get(currency_code)
         if not rate:
             raise ImportException("Rate not found for opportunity currency")
-        ExchangeRate.objects.create(currency_code=currency_code, rate=rate, rate_date=rate_date)
+        # get_or_create to avoid race condition.
+        ExchangeRate.objects.get_or_create(currency_code=currency_code, rate=rate, rate_date=rate_date)
 
     return rate
 


### PR DESCRIPTION
## Technical Summary

This PR resolves a race condition that was causing an `IntegrityError` due to duplicate currency exchange rate entries. The issue has been addressed by replacing the `create` method with `get_or_create` to prevent duplicate inserts.

[Sentry Error](https://dimagi.sentry.io/issues/6494300041/?project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=10)

[CCCT-912](https://dimagi.atlassian.net/browse/CCCT-912)


## Safety Assurance

### Safety story
This change is low risk as it only modifies the way exchange rate entries are created, ensuring that duplicates are avoided without altering existing functionality.


### Automated test coverage

A test has been added to confirm that the issue was caused by a race condition. The test now passes successfully after the fix in the get_exchange_rate function.


### QA Plan
NA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-912]: https://dimagi.atlassian.net/browse/CCCT-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ