### PR TITLE
Add payment unit end_date to mobile api

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -60,7 +60,7 @@ class CommCareAppSerializer(serializers.ModelSerializer):
 class PaymentUnitSerializer(serializers.ModelSerializer):
     class Meta:
         model = PaymentUnit
-        fields = ["id", "name", "max_total", "max_daily", "amount"]
+        fields = ["id", "name", "max_total", "max_daily", "amount", "start_date", "end_date"]
 
 
 class OpportunityClaimLimitSerializer(serializers.ModelSerializer):

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -60,7 +60,7 @@ class CommCareAppSerializer(serializers.ModelSerializer):
 class PaymentUnitSerializer(serializers.ModelSerializer):
     class Meta:
         model = PaymentUnit
-        fields = ["id", "name", "max_total", "max_daily", "amount", "start_date", "end_date"]
+        fields = ["id", "name", "max_total", "max_daily", "amount", "end_date"]
 
 
 class OpportunityClaimLimitSerializer(serializers.ModelSerializer):

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -212,7 +212,7 @@ def test_opportunity_list_endpoint(
     assert response.data[0]["verification_flags"]["form_submission_end"] == str(verification_flags.form_submission_end)
     payment_units = response.data[0]["payment_units"]
 
-    payment_unit_fields = ["id", "name", "max_total", "max_daily", "amount", "start_date", "end_date"]
+    payment_unit_fields = ["id", "name", "max_total", "max_daily", "amount", "end_date"]
     assert all(all(field in unit for field in payment_unit_fields) for unit in payment_units)
 
 

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -210,6 +210,10 @@ def test_opportunity_list_endpoint(
         verification_flags.form_submission_start
     )
     assert response.data[0]["verification_flags"]["form_submission_end"] == str(verification_flags.form_submission_end)
+    payment_units = response.data[0]["payment_units"]
+
+    payment_unit_fields = ["id", "name", "max_total", "max_daily", "amount", "start_date", "end_date"]
+    assert all(all(field in unit for field in payment_unit_fields) for unit in payment_units)
 
 
 def test_delivery_progress_endpoint(


### PR DESCRIPTION
## Technical Summary

This PR introduces the end_date field in the Payment Unit serializer to ensure mobile clients receive this information.
[CCCT-910](https://dimagi.atlassian.net/browse/CCCT-910)

## Safety Assurance

### Safety story

This is a low-risk change, as it only involves adding an additional field to the serializer.

### Automated test coverage

Tests have been updated to account for the new field, and all tests pass successfully.

### QA Plan

NA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-910]: https://dimagi.atlassian.net/browse/CCCT-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ