### PR TITLE
Only show program option when flag is set to true

### DIFF
--- a/commcare_connect/templates/base.html
+++ b/commcare_connect/templates/base.html
@@ -56,11 +56,13 @@
         <ul class="navbar-nav">
           {% if request.user.is_authenticated %}
             {% if request.org %}
-              {% if request.user.is_superuser or request.org_membership.is_admin and request.org.program_manager %}
-              <li class="nav-item">
-                <a class="nav-link {% active_link "list || init || edit || opportunity_list || opportunity_init" namespace='program' %}"
-                   href="{% url 'program:list' request.org.slug %}">{% translate "Programs" %}</a>
-              </li>
+              {% if request.org.program_manager %}
+                {% if request.org_membership.is_admin or request.user.is_superuser %}
+                  <li class="nav-item">
+                    <a class="nav-link {% active_link "list || init || edit || opportunity_list || opportunity_init" namespace='program' %}"
+                       href="{% url 'program:list' request.org.slug %}">{% translate "Programs" %}</a>
+                  </li>
+                {% endif %}
               {% endif %}
               <li class="nav-item">
                 <a class="nav-link {% active_link "list || create || edit || detail" namespace='opportunity' %}"


### PR DESCRIPTION
## Product Description

This PR updates the display condition for the Program button on the navbar. Previously, superusers could see the button even if the organization was not marked as a Program Manager. Now, visibility requires the organization to be a Program Manager, regardless of superuser status.

## Safety Assurance

### Safety story

This is a low-risk change. Only a simple condition was updated, and it has been tested locally to confirm correct behavior.


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
