### PR TITLE
Serialize CompletedWork flags in CompletedWorkSerializer

### DIFF
--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -268,8 +268,12 @@ class CompletedWorkSerializer(serializers.ModelSerializer):
         for visit in visits:
             if not visit:
                 continue
+
+            flags_dict = {}
             for slug, reason in visit.get("flags", []):
-                flags.append({slug: reason})
+                flags_dict[slug] = reason
+
+            flags.append(flags_dict)
         return flags
 
 

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -19,6 +19,7 @@ from commcare_connect.opportunity.models import (
     Payment,
     PaymentUnit,
     UserVisit,
+    VisitValidationStatus,
 )
 
 
@@ -245,6 +246,7 @@ class CompletedWorkSerializer(serializers.ModelSerializer):
     deliver_unit_name = serializers.CharField(source="payment_unit.name")
     deliver_unit_slug = serializers.CharField(source="payment_unit.pk")
     visit_date = serializers.DateTimeField(source="completion_date")
+    flags = serializers.SerializerMethodField()
 
     class Meta:
         model = CompletedWork
@@ -257,7 +259,18 @@ class CompletedWorkSerializer(serializers.ModelSerializer):
             "entity_id",
             "entity_name",
             "reason",
+            "flags",
         ]
+
+    def get_flags(self, obj):
+        visits = obj.uservisit_set.exclude(status=VisitValidationStatus.approved).values_list("flag_reason", flat=True)
+        flags = []
+        for visit in visits:
+            if not visit:
+                continue
+            for slug, reason in visit.get("flags", []):
+                flags.append({slug: reason})
+        return flags
 
 
 class PaymentSerializer(serializers.ModelSerializer):

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -264,16 +264,13 @@ class CompletedWorkSerializer(serializers.ModelSerializer):
 
     def get_flags(self, obj):
         visits = obj.uservisit_set.exclude(status=VisitValidationStatus.approved).values_list("flag_reason", flat=True)
-        flags = []
+        flags = {}
         for visit in visits:
             if not visit:
                 continue
 
-            flags_dict = {}
             for slug, reason in visit.get("flags", []):
-                flags_dict[slug] = reason
-
-            flags.append(flags_dict)
+                flags[slug] = reason
         return flags
 
 

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -242,13 +242,11 @@ def test_delivery_progress_endpoint(
     assert len(response.data["deliveries"]) == 1
     assert len(response.data["payments"]) == 0
     assert response.data["deliveries"][0].keys() == CompletedWorkSerializer().get_fields().keys()
-    assert response.data["deliveries"][0]["flags"] == [
-        {
-            "duration": "The form was completed too quickly.",
-            "attachment_missing": "Form was submitted without attachments.",
-        }
-    ]
 
+    assert response.data["deliveries"][0]["flags"] == {
+        "duration": "The form was completed too quickly.",
+        "attachment_missing": "Form was submitted without attachments.",
+    }
     Payment.objects.create(amount=10, date_paid=datetime.date.today(), opportunity_access=access)
     response = api_client.get(f"/api/opportunity/{opportunity.id}/delivery_progress")
     assert response.status_code == 200

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -5,11 +5,11 @@ from rest_framework.test import APIClient
 
 from commcare_connect.opportunity.api.serializers import (
     CommCareAppSerializer,
+    CompletedWorkSerializer,
     DeliveryProgressSerializer,
     OpportunityClaimSerializer,
     OpportunitySerializer,
     PaymentSerializer,
-    UserVisitSerializer,
 )
 from commcare_connect.opportunity.models import (
     CompletedWorkStatus,
@@ -227,6 +227,7 @@ def test_delivery_progress_endpoint(
         status=VisitValidationStatus.pending,
         opportunity_access=access,
         completed_work=completed_work,
+        flag_reason={"flags": [("duration", "The form was completed too quickly.")]},
     )
     api_client.force_authenticate(mobile_user_with_connect_link)
     response = api_client.get(f"/api/opportunity/{opportunity.id}/delivery_progress")
@@ -235,7 +236,7 @@ def test_delivery_progress_endpoint(
     assert response.data.keys() == DeliveryProgressSerializer().get_fields().keys()
     assert len(response.data["deliveries"]) == 1
     assert len(response.data["payments"]) == 0
-    assert response.data["deliveries"][0].keys() == UserVisitSerializer().get_fields().keys()
+    assert response.data["deliveries"][0].keys() == CompletedWorkSerializer().get_fields().keys()
 
     Payment.objects.create(amount=10, date_paid=datetime.date.today(), opportunity_access=access)
     response = api_client.get(f"/api/opportunity/{opportunity.id}/delivery_progress")

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -227,7 +227,12 @@ def test_delivery_progress_endpoint(
         status=VisitValidationStatus.pending,
         opportunity_access=access,
         completed_work=completed_work,
-        flag_reason={"flags": [("duration", "The form was completed too quickly.")]},
+        flag_reason={
+            "flags": [
+                ["duration", "The form was completed too quickly."],
+                ["attachment_missing", "Form was submitted without attachments."],
+            ]
+        },
     )
     api_client.force_authenticate(mobile_user_with_connect_link)
     response = api_client.get(f"/api/opportunity/{opportunity.id}/delivery_progress")
@@ -237,6 +242,10 @@ def test_delivery_progress_endpoint(
     assert len(response.data["deliveries"]) == 1
     assert len(response.data["payments"]) == 0
     assert response.data["deliveries"][0].keys() == CompletedWorkSerializer().get_fields().keys()
+    assert response.data["deliveries"][0]["flags"] == [
+        {"duration": "The form was completed too quickly."},
+        {"attachment_missing": "Form was submitted without attachments."},
+    ]
 
     Payment.objects.create(amount=10, date_paid=datetime.date.today(), opportunity_access=access)
     response = api_client.get(f"/api/opportunity/{opportunity.id}/delivery_progress")

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -243,8 +243,10 @@ def test_delivery_progress_endpoint(
     assert len(response.data["payments"]) == 0
     assert response.data["deliveries"][0].keys() == CompletedWorkSerializer().get_fields().keys()
     assert response.data["deliveries"][0]["flags"] == [
-        {"duration": "The form was completed too quickly."},
-        {"attachment_missing": "Form was submitted without attachments."},
+        {
+            "duration": "The form was completed too quickly.",
+            "attachment_missing": "Form was submitted without attachments.",
+        }
     ]
 
     Payment.objects.create(amount=10, date_paid=datetime.date.today(), opportunity_access=access)


### PR DESCRIPTION
## Product Description
No user-facing changes, only API data update.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/CCCT-654)

This PR makes sure to serialize the CompletedWork records' flags as part of the CompletedWorkSerializer in a dictionary style with slug as key and description as value. For example, the jsonified response would look like this:
```
{
  ...
  "deliveries": [
    {
      ...
      "flags": {
          "duration": "The form was completed too quickly."
        }
    }
  ]
}
```

### Additional (unexpected) update
The `test_delivery_progress_endpoint` test [asserts](https://github.com/dimagi/commcare-connect/blob/f69702d46963576eaf19c020a855e3f2d7996f8d/commcare_connect/opportunity/tests/test_api_views.py#L238) that the serialized delivery keys be similar to the `UserVisitSerializer`, but that's not the correct serializer class that's being used in the [get_deliveries](https://github.com/dimagi/commcare-connect/blob/f69702d46963576eaf19c020a855e3f2d7996f8d/commcare_connect/opportunity/api/serializers.py#L285-L291) method of the `DeliveryProgressSerializer`.

I have updated the test to test against the `CompletedWorkSerializer`, but was just wondering if this was a previous oversight? 

## Safety Assurance

### Safety story
Updated `test_delivery_progress_endpoint` test to reflect new changes.

### Automated test coverage
No new tests, only updated an existing test

### QA Plan
QA not planned

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
