### PR TITLE
Gracefully handle missing form field

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -234,17 +234,17 @@ class OpportunityInitForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        try:
-            if cleaned_data:
+        if cleaned_data:
+            try:
                 cleaned_data["learn_app"] = json.loads(cleaned_data["learn_app"])
                 cleaned_data["deliver_app"] = json.loads(cleaned_data["deliver_app"])
 
                 if cleaned_data["learn_app"]["id"] == cleaned_data["deliver_app"]["id"]:
                     self.add_error("learn_app", "Learn app and Deliver app cannot be same")
                     self.add_error("deliver_app", "Learn app and Deliver app cannot be same")
-                return cleaned_data
-        except KeyError:
-            raise forms.ValidationError("Invalid app data")
+            except KeyError:
+                raise forms.ValidationError("Invalid app data")
+            return cleaned_data
 
     def save(self, commit=True):
         organization = Organization.objects.get(slug=self.org_slug)

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -234,14 +234,17 @@ class OpportunityInitForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        if cleaned_data:
-            cleaned_data["learn_app"] = json.loads(cleaned_data["learn_app"])
-            cleaned_data["deliver_app"] = json.loads(cleaned_data["deliver_app"])
+        try:
+            if cleaned_data:
+                cleaned_data["learn_app"] = json.loads(cleaned_data["learn_app"])
+                cleaned_data["deliver_app"] = json.loads(cleaned_data["deliver_app"])
 
-            if cleaned_data["learn_app"]["id"] == cleaned_data["deliver_app"]["id"]:
-                self.add_error("learn_app", "Learn app and Deliver app cannot be same")
-                self.add_error("deliver_app", "Learn app and Deliver app cannot be same")
-            return cleaned_data
+                if cleaned_data["learn_app"]["id"] == cleaned_data["deliver_app"]["id"]:
+                    self.add_error("learn_app", "Learn app and Deliver app cannot be same")
+                    self.add_error("deliver_app", "Learn app and Deliver app cannot be same")
+                return cleaned_data
+        except KeyError:
+            raise forms.ValidationError("Invalid app data")
 
     def save(self, commit=True):
         organization = Organization.objects.get(slug=self.org_slug)

--- a/commcare_connect/program/tests/test_forms.py
+++ b/commcare_connect/program/tests/test_forms.py
@@ -135,6 +135,14 @@ class TestManagedOpportunityInitForm:
         assert form.errors["learn_app"] == ["Learn app and Deliver app cannot be same"]
         assert form.errors["deliver_app"] == ["Learn app and Deliver app cannot be same"]
 
+    def test_form_validation_missing_data(self):
+        invalid_data = self.form_data.copy()
+        invalid_data.pop("learn_app")
+        form = ManagedOpportunityInitForm(
+            data=invalid_data, program=self.program, domains=self.domains, org_slug=self.organization.slug
+        )
+        assert not form.is_valid()
+
     def test_form_save(self):
         print(self.invited_org)
         form = ManagedOpportunityInitForm(

--- a/commcare_connect/program/tests/test_forms.py
+++ b/commcare_connect/program/tests/test_forms.py
@@ -137,7 +137,7 @@ class TestManagedOpportunityInitForm:
 
     def test_form_validation_missing_data(self):
         invalid_data = self.form_data.copy()
-        invalid_data.pop("learn_app")
+        invalid_data["learn_app"] = None
         form = ManagedOpportunityInitForm(
             data=invalid_data, program=self.program, domains=self.domains, org_slug=self.organization.slug
         )


### PR DESCRIPTION
This PR handles an erroneous situation more gracefully.

## Technical Summary
[Sentry issue](https://dimagi.sentry.io/issues/6536627294/?project=4505635339829248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=5)

An issue was found on sentry where the `learn_app` was not apparently set in the form, despite the field being required.

I'm not 100% sure how to replicate this from the UI as it seems theoretically impossible (as least as a user), but I've managed to replicate it using a unit test.

The solution might work to stop the sentry issue, but I'm curious to know why and how it happened in the first place. Also curious why we have an explicit check for `cleaned_data` in the `clean` method, since data should always be present? 

## Safety Assurance

### Safety story
Added a unit test

### QA Plan
No QA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
