### PR TITLE
added opportunity order

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -178,7 +178,11 @@ def get_opportunity_list_data(organization, program_manager=False):
     today = now().date()
     three_days_ago = now() - timedelta(days=3)
 
-    queryset = Opportunity.objects.filter(organization=organization).annotate(
+    base_filter = Q(organization=organization)
+    if program_manager:
+        base_filter |= Q(managedopportunity__program__organization=organization)
+
+    queryset = Opportunity.objects.filter(base_filter).annotate(
         program=F("managedopportunity__program__name"),
         pending_invites=Count(
             "userinvite",

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -161,13 +161,7 @@ class OrgContextSingleTableView(SingleTableView):
 class OpportunityList(OrganizationUserMixin, SingleTableMixin, TemplateView):
     template_name = "tailwind/pages/opportunities_list.html"
     paginate_by = 15
-    base_columns = ["program", "start_date", "end_date", "status", "opportunity"]
-    pm_columns = ["active_workers", "total_deliveries", "verified_deliveries", "worker_earnings"]
-    nm_columns = ["pending_invites", "inactive_workers", "pending_approvals", "payments_due"]
 
-    def get_allowed_columns(self):
-        extra_columns = self.pm_columns if self.request.org.program_manager else self.nm_columns
-        return self.base_columns + extra_columns
 
     def get_table_class(self):
         if self.request.org.program_manager:
@@ -176,7 +170,9 @@ class OpportunityList(OrganizationUserMixin, SingleTableMixin, TemplateView):
 
     def get_table_data(self):
         org = self.request.org
-        return get_opportunity_list_data(org, self.request.org.program_manager)
+        query_set = get_opportunity_list_data(org, self.request.org.program_manager)
+        query_set = query_set.order_by("status", "start_date", "end_date")
+        return query_set
 
 
 class OpportunityCreate(OrganizationUserMemberRoleMixin, CreateView):


### PR DESCRIPTION
## Product Description

This PR adds a default order to the opportunity list. The list will now be ordered by `status`, `start_date`, and `end_date` by default.

Additionally, it updates the list to include opportunities managed by an organization through a program.