### PR TITLE
make the dashboard stats an API view

### DIFF
--- a/commcare_connect/reports/views.py
+++ b/commcare_connect/reports/views.py
@@ -16,6 +16,8 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.views.decorators.http import require_GET
 from django_filters.views import FilterView
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
@@ -295,7 +297,8 @@ class DeliveryStatsReportView(tables.SingleTableMixin, SuperUserRequiredMixin, N
         return get_table_data_for_year_month(**self.filter_values)
 
 
-@login_required
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
 @user_passes_test(lambda u: u.is_superuser)
 def dashboard_stats_api(request):
     filterset = DashboardFilters(request.GET)


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->

No user facing changes.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

This just converts the stats view for the admin dashboard to a DRF view so that it can be more easily used by external APIs. I'm using this for a proof-of-concept demo of an MCP integration.

## Safety Assurance

### Safety story

There are no user facing changes, I tested this locally, and everything works as expected.
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
