### PR TITLE
Ensure invited user number starts with '+'

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -78,8 +78,13 @@ class OpportunityUserInviteForm(forms.Form):
         if user_data and self.opportunity and not self.opportunity.is_setup_complete:
             raise ValidationError("Please finish setting up the opportunity before inviting users.")
 
-        split_users = [line.strip() for line in user_data.splitlines() if line.strip()]
-        return split_users
+        user_numbers = [line.strip() for line in user_data.splitlines() if line.strip()]
+
+        for user_number in user_numbers:
+            if not user_number.startswith("+"):
+                raise ValidationError("Please ensure all numbers start with '+'.")
+
+        return user_numbers
 
 
 class OpportunityChangeForm(


### PR DESCRIPTION
## Product Description
The user will see the following message whenever a user is invited with a number not starting with "+":
_"Please ensure all numbers start with '+'."_

## Technical Summary
This PR checks that all the users that's invited to opportunities have their numbers specified such that it starts with a '+'. This ensures that a program manager don't get the "ConnectID not found" status only to find out they missed the "+" in front of the number.  

## Safety Assurance

### Safety story
Test have been added

### Automated test coverage
Test have been added

### QA Plan
No QA

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
