### PR TITLE
[New UI] Fixed Opportunity 404 on user_invite

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1146,7 +1146,7 @@ def import_catchment_area(request, org_slug=None, pk=None):
 
 @org_member_required
 def opportunity_user_invite(request, org_slug=None, pk=None):
-    opportunity = get_object_or_404(Opportunity, organization=request.org, id=pk)
+    opportunity = get_opportunity_or_404(org_slug=request.org.slug, pk=pk)
     form = OpportunityUserInviteForm(data=request.POST or None, org_slug=request.org.slug, opportunity=opportunity)
     if form.is_valid():
         users = form.cleaned_data["users"]


### PR DESCRIPTION
## Technical Summary

This change resolve the 404 error when pm invites user in a managed opportunity - `get_opportunity_or_404`
[CCCT-1191](https://dimagi.atlassian.net/browse/CCCT-1191)

## Safety Assurance

### Safety story

Tested Locally

### QA Plan

No QA

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-1191]: https://dimagi.atlassian.net/browse/CCCT-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ