### PR TITLE
Fix Add Worker Forms bug

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -37,7 +37,6 @@ CHECKBOX_CLASS = "simple-toggle"
 
 class OpportunityUserInviteForm(forms.Form):
     def __init__(self, *args, **kwargs):
-        self.org_slug = kwargs.pop("org_slug", None)
         self.opportunity = kwargs.pop("opportunity", None)
         super().__init__(*args, **kwargs)
 
@@ -62,10 +61,7 @@ class OpportunityUserInviteForm(forms.Form):
         return split_users
 
 
-class OpportunityChangeForm(
-    OpportunityUserInviteForm,
-    forms.ModelForm,
-):
+class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
     class Meta:
         model = Opportunity
         fields = [
@@ -80,6 +76,7 @@ class OpportunityChangeForm(
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.opportunity = self.instance
 
         self.helper = FormHelper(self)
         self.helper.layout = Layout(

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -13,7 +13,7 @@ from django.utils.timezone import now
 from django.utils.translation import gettext
 from tablib import Dataset
 
-from commcare_connect.connect_id_client import fetch_users, filter_users, send_message, send_message_bulk
+from commcare_connect.connect_id_client import fetch_users, send_message, send_message_bulk
 from commcare_connect.connect_id_client.models import ConnectIdUser, Message
 from commcare_connect.opportunity.app_xml import get_connect_blocks_for_app, get_deliver_units_for_app
 from commcare_connect.opportunity.export import (
@@ -75,12 +75,8 @@ def create_learn_modules_and_deliver_units(opportunity_id):
 
 
 @celery_app.task()
-def add_connect_users(
-    user_list: list[str], opportunity_id: str, filter_country: str = "", filter_credential: list[str] = ""
-):
+def add_connect_users(user_list: list[str], opportunity_id: str):
     found_users = fetch_users(user_list)
-    if filter_country or filter_credential:
-        found_users += filter_users(country_code=filter_country, credential=filter_credential)
     not_found_users = set(user_list) - {user.phone_number for user in found_users}
     for u in not_found_users:
         UserInvite.objects.get_or_create(

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -122,16 +122,6 @@ class TestOpportunityCreationForm:
 
 @pytest.mark.django_db
 class TestOpportunityChangeForm:
-    @pytest.fixture(autouse=True)
-    def setup_credentials_mock(self, monkeypatch):
-        self.mock_credentials = [
-            type("Credential", (), {"slug": "cert1", "name": "Work for test"}),
-            type("Credential", (), {"slug": "cert2", "name": "Work for test"}),
-        ]
-        monkeypatch.setattr(
-            "commcare_connect.connect_id_client.fetch_credentials", lambda org_slug: self.mock_credentials
-        )
-
     @pytest.fixture
     def valid_opportunity(self, organization):
         opp = OpportunityFactory(
@@ -161,8 +151,6 @@ class TestOpportunityChangeForm:
             "delivery_type": valid_opportunity.delivery_type.id,
             "end_date": (datetime.date.today() + datetime.timedelta(days=60)).isoformat(),
             "users": "+1234567890\n+9876543210",
-            "filter_country": "US",
-            "filter_credential": "cert1",
         }
 
     def test_form_initialization(self, valid_opportunity, organization):
@@ -177,8 +165,6 @@ class TestOpportunityChangeForm:
             "delivery_type",
             "end_date",
             "users",
-            "filter_country",
-            "filter_credential",
         }
         assert all(field in form.fields for field in expected_fields)
 
@@ -191,8 +177,6 @@ class TestOpportunityChangeForm:
             "is_test": valid_opportunity.is_test,
             "delivery_type": valid_opportunity.delivery_type.id,
             "end_date": valid_opportunity.end_date.isoformat(),
-            "filter_country": [""],
-            "filter_credential": [""],
         }
         assert all(form.initial.get(key) == value for key, value in expected_initial.items())
 

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -153,8 +153,8 @@ class TestOpportunityChangeForm:
             "users": "+1234567890\n+9876543210",
         }
 
-    def test_form_initialization(self, valid_opportunity, organization):
-        form = OpportunityChangeForm(instance=valid_opportunity, org_slug=organization.slug)
+    def test_form_initialization(self, valid_opportunity):
+        form = OpportunityChangeForm(instance=valid_opportunity)
         expected_fields = {
             "name",
             "description",
@@ -189,10 +189,10 @@ class TestOpportunityChangeForm:
             "currency",
         ],
     )
-    def test_required_fields(self, valid_opportunity, organization, field, base_form_data):
+    def test_required_fields(self, valid_opportunity, field, base_form_data):
         data = base_form_data.copy()
         data[field] = ""
-        form = OpportunityChangeForm(data=data, instance=valid_opportunity, org_slug=organization.slug)
+        form = OpportunityChangeForm(data=data, instance=valid_opportunity)
         assert not form.is_valid()
         assert field in form.errors
 
@@ -219,10 +219,10 @@ class TestOpportunityChangeForm:
             ),
         ],
     )
-    def test_field_validation(self, valid_opportunity, organization, base_form_data, test_data):
+    def test_field_validation(self, valid_opportunity, base_form_data, test_data):
         data = base_form_data.copy()
         data[test_data["field"]] = test_data["value"]
-        form = OpportunityChangeForm(data=data, instance=valid_opportunity, org_slug=organization.slug)
+        form = OpportunityChangeForm(data=data, instance=valid_opportunity)
         if test_data["error_expected"]:
             assert not form.is_valid()
             assert test_data["error_message"] in str(form.errors[test_data["field"]])
@@ -270,7 +270,7 @@ class TestOpportunityChangeForm:
 
         PaymentUnitFactory(opportunity=inactive_opp)
 
-        form = OpportunityChangeForm(data=base_form_data, instance=inactive_opp, org_slug=organization.slug)
+        form = OpportunityChangeForm(data=base_form_data, instance=inactive_opp)
 
         assert form.is_valid() == app_scenario["expected_valid"]
         if not app_scenario["expected_valid"]:
@@ -285,20 +285,16 @@ class TestOpportunityChangeForm:
             ({"currency": "USD", "additional_users": -5}, True),
         ],
     )
-    def test_valid_combinations(self, valid_opportunity, organization, base_form_data, data_updates, expected_valid):
+    def test_valid_combinations(self, valid_opportunity, base_form_data, data_updates, expected_valid):
         data = base_form_data.copy()
         data.update(data_updates)
-        form = OpportunityChangeForm(data=data, instance=valid_opportunity, org_slug=organization.slug)
+        form = OpportunityChangeForm(data=data, instance=valid_opportunity)
         assert form.is_valid() == expected_valid
 
-    def test_for_incomplete_opp(self, base_form_data, valid_opportunity, organization):
+    def test_for_incomplete_opp(self, base_form_data, valid_opportunity):
         data = data = base_form_data.copy()
         PaymentUnit.objects.filter(opportunity=valid_opportunity).delete()  # making opp incomplete explicitly
-        form = OpportunityChangeForm(
-            data=data,
-            instance=valid_opportunity,
-            org_slug=organization.slug,
-        )
+        form = OpportunityChangeForm(data=data, instance=valid_opportunity)
         assert not form.is_valid()
         assert "users" in form.errors
         assert "Please finish setting up the opportunity before inviting users." in form.errors["users"]

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -104,7 +104,6 @@ from commcare_connect.opportunity.tables import (
     WorkerPaymentsTable,
     WorkerStatusTable,
 )
-from commcare_connect.utils.tables import get_duration_min
 from commcare_connect.opportunity.tasks import (
     add_connect_users,
     bulk_update_payments_task,
@@ -136,6 +135,7 @@ from commcare_connect.users.models import User
 from commcare_connect.utils.celery import CELERY_TASK_SUCCESS, get_task_progress_message
 from commcare_connect.utils.commcarehq_api import get_applications_for_user_by_domain, get_domains_for_user
 from commcare_connect.utils.file import get_file_extension
+from commcare_connect.utils.tables import get_duration_min
 
 
 class OrganizationUserMixin(LoginRequiredMixin, UserPassesTestMixin):
@@ -258,10 +258,8 @@ class OpportunityEdit(OrganizationUserMemberRoleMixin, UpdateView):
         opportunity = form.instance
         opportunity.modified_by = self.request.user.email
         users = form.cleaned_data["users"]
-        filter_country = form.cleaned_data["filter_country"]
-        filter_credential = form.cleaned_data["filter_credential"]
-        if users or filter_country or filter_credential:
-            add_connect_users.delay(users, form.instance.id, filter_country, filter_credential)
+        if users:
+            add_connect_users.delay(users, form.instance.id)
 
         end_date = form.cleaned_data["end_date"]
         if end_date:
@@ -1150,10 +1148,8 @@ def opportunity_user_invite(request, org_slug=None, pk=None):
     form = OpportunityUserInviteForm(data=request.POST or None, org_slug=request.org.slug, opportunity=opportunity)
     if form.is_valid():
         users = form.cleaned_data["users"]
-        filter_country = form.cleaned_data["filter_country"]
-        filter_credential = form.cleaned_data["filter_credential"]
-        if users or filter_country or filter_credential:
-            add_connect_users.delay(users, opportunity.id, filter_country, filter_credential)
+        if users:
+            add_connect_users.delay(users, opportunity.id)
         return redirect("opportunity:detail", request.org.slug, pk)
     return render(
         request,

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -249,11 +249,6 @@ class OpportunityEdit(OrganizationUserMemberRoleMixin, UpdateView):
     def get_success_url(self):
         return reverse("opportunity:detail", args=(self.request.org.slug, self.object.id))
 
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["org_slug"] = self.request.org.slug
-        return kwargs
-
     def form_valid(self, form):
         opportunity = form.instance
         opportunity.modified_by = self.request.user.email


### PR DESCRIPTION
## Product Description
This PR fixes a bug in Add worker form related views. The filter_country and filter_credential fields were removed from the form but not from the views which led to 500 errors. 

This PR also removes all references to credential workflow from add_connect_users since those fields are now removed.

## Safety Assurance

### Safety story
Fixed the test cases, tested locally.


### Automated test coverage
Fixed Test cases.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
