### PR TITLE
[NEW UI] - Minor changes on opp dashboard and worker list

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -227,7 +227,7 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity):
                 incomplete=Coalesce(incomplete_count_sq, Value(0)),
             )
             .annotate(
-                last_active_d=Greatest(
+                last_active=Greatest(
                     F('_last_visit_val'),
                     F('_last_module_val'),
                     F('date_learn_started')
@@ -326,7 +326,7 @@ def get_worker_table_data(opportunity):
     )
 
     queryset = OpportunityAccess.objects.filter(opportunity=opportunity).annotate(
-        last_active_d=OpportunityAnnotations.last_active(),
+        last_active=OpportunityAnnotations.last_active(),
         completed_modules_count=Count(
             "completedmodule__module",
             distinct=True,
@@ -375,7 +375,7 @@ def get_worker_learn_table_data(opportunity):
         .values("total_duration")[:1]
     )
     queryset = OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True).annotate(
-        last_active_d=OpportunityAnnotations.last_active(),
+        last_active=OpportunityAnnotations.last_active(),
         completed_modules_count=Count("completedmodule__module", distinct=True),
         completed_learn=Case(
             When(

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -227,7 +227,7 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity):
                 incomplete=Coalesce(incomplete_count_sq, Value(0)),
             )
             .annotate(
-                last_active=Greatest(
+                last_active_d=Greatest(
                     F('_last_visit_val'),
                     F('_last_module_val'),
                     F('date_learn_started')
@@ -326,7 +326,7 @@ def get_worker_table_data(opportunity):
     )
 
     queryset = OpportunityAccess.objects.filter(opportunity=opportunity).annotate(
-        last_active=OpportunityAnnotations.last_active(),
+        last_active_d=OpportunityAnnotations.last_active(),
         completed_modules_count=Count(
             "completedmodule__module",
             distinct=True,
@@ -375,7 +375,7 @@ def get_worker_learn_table_data(opportunity):
         .values("total_duration")[:1]
     )
     queryset = OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True).annotate(
-        last_active=OpportunityAnnotations.last_active(),
+        last_active_d=OpportunityAnnotations.last_active(),
         completed_modules_count=Count("completedmodule__module", distinct=True),
         completed_learn=Case(
             When(

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -47,10 +47,10 @@ class OpportunityAnnotations:
     @staticmethod
     def inactive_workers(days_ago):
         return Count(
-            "opportunityaccess__id",
-            filter=~Q(opportunityaccess__uservisit__visit_date__gte=days_ago)
-                   & ~Q(opportunityaccess__completedmodule__date__gte=days_ago)
-                   & Q(opportunityaccess__date_learn_started__isnull=False),
+            "opportunityaccess",
+            filter=Q(opportunityaccess__date_learn_started__isnull=False) &
+                   ~Q(opportunityaccess__uservisit__visit_date__gte=days_ago) &
+                   ~Q(opportunityaccess__completedmodule__date__gte=days_ago),
             distinct=True,
         )
 

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -205,14 +205,30 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity):
                 output_field=IntegerField(),
             )
 
+        def completed_work_status_total_subquery(status_value):
+            return Subquery(
+                CompletedWork.objects.filter(
+                    opportunity_access_id=OuterRef("pk"), status=status_value
+                )
+                .values("opportunity_access_id")
+                .annotate(status_count=Count("id", distinct=True))
+                .values("status_count")[:1],
+                output_field=IntegerField(),
+            )
+
         pending_count_sq = completed_work_status_subquery(CompletedWorkStatus.pending)
         approved_count_sq = completed_work_status_subquery(CompletedWorkStatus.approved)
         rejected_count_sq = completed_work_status_subquery(CompletedWorkStatus.rejected)
         over_limit_count_sq = completed_work_status_subquery(CompletedWorkStatus.over_limit)
         incomplete_count_sq = completed_work_status_subquery(CompletedWorkStatus.incomplete)
 
+        total_pending_for_user =completed_work_status_total_subquery(CompletedWorkStatus.pending)
+        total_approved_for_user =completed_work_status_total_subquery(CompletedWorkStatus.approved)
+        total_rejected_for_user =completed_work_status_total_subquery(CompletedWorkStatus.rejected)
+        total_over_limit_for_user =completed_work_status_total_subquery(CompletedWorkStatus.over_limit)
+
         queryset = (
-            OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True)
+            OpportunityAccess.objects.filter(opportunity=opportunity)
             .annotate(
                 payment_unit_id=Value(payment_unit.pk),
                 payment_unit=Value(payment_unit.name, output_field=CharField()),
@@ -225,6 +241,10 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity):
                 duplicate=Coalesce(duplicate_sq, Value(0)),
                 over_limit=Coalesce(over_limit_count_sq, Value(0)),
                 incomplete=Coalesce(incomplete_count_sq, Value(0)),
+                total_pending=Coalesce(total_pending_for_user, Value(0)),
+                total_approved=Coalesce(total_approved_for_user, Value(0)),
+                total_rejected=Coalesce(total_rejected_for_user, Value(0)),
+                total_over_limit=Coalesce(total_over_limit_for_user, Value(0)),
             )
             .annotate(
                 last_active=Greatest(
@@ -234,7 +254,9 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity):
                 ),
                 completed=(
                     F('pending') + F('approved') + F('rejected') + F('over_limit')
-                )
+                ),
+                total_completed=(F('total_pending') + F('total_approved') + F('total_rejected') + F('total_over_limit'))
+
             )
             .select_related('user')
             .order_by('user__name')

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1018,7 +1018,7 @@ class WorkerStatusTable(tables.Table):
     user = UserInfoColumn()
     suspended = SuspendedIndicatorColumn()
     invited_date = DMYTColumn()
-    last_active = DMYTColumn(verbose_name=header_with_tooltip("Last Active", "Submitted a Learn or Deliver form"))
+    last_active = DMYTColumn(verbose_name=header_with_tooltip("Last Active", "Submitted a Learn or Deliver form"), accessor="last_active_d")
     started_learn = DMYTColumn(
         verbose_name=header_with_tooltip("Started Learn", "Submitted the first Learn form"),
         accessor="date_learn_started",
@@ -1042,7 +1042,7 @@ class WorkerPaymentsTable(tables.Table):
     index = IndexColumn()
     user = UserInfoColumn(footer="Total")
     suspended = SuspendedIndicatorColumn()
-    last_active = DMYTColumn()
+    last_active = DMYTColumn(accessor="last_active_d")
     payment_accrued = tables.Column(verbose_name="Accrued",
                                     footer=lambda table: intcomma(
                                         sum(x.payment_accrued or 0 for x in table.data)))
@@ -1098,7 +1098,7 @@ class WorkerLearnTable(OrgContextTable):
     index = IndexColumn()
     user = UserInfoColumn()
     suspended = SuspendedIndicatorColumn()
-    last_active = DMYTColumn()
+    last_active = DMYTColumn(accessor="last_active_d")
     started_learning = DMYTColumn(accessor="date_learn_started", verbose_name="Started Learning")
     modules_completed = tables.TemplateColumn(
         accessor="modules_completed_percentage",
@@ -1219,7 +1219,7 @@ class WorkerDeliveryTable(OrgContextTable):
     index = IndexColumn()
     user = tables.Column(orderable=False, verbose_name="Name", footer="Total")
     suspended = SuspendedIndicatorColumn()
-    last_active = DMYTColumn()
+    last_active = DMYTColumn(accessor="last_active_d")
     payment_unit = tables.Column(orderable=False)
     delivery_progress = tables.Column(accessor="total_visits", empty_values=())
     delivered = TotalDeliveredColumn(

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -558,9 +558,9 @@ def date_with_time_popup(table, date):
 def header_with_tooltip(label, tooltip_text):
     return mark_safe(
         f"""
-        <div x-data x-tooltip.raw="{tooltip_text}">
+        <span x-data x-tooltip.raw="{tooltip_text}">
             {label}
-        </div>
+        </span>
         """
     )
 

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1288,8 +1288,9 @@ class WorkerDeliveryTable(OrgContextTable):
         percentage = round((current / total) * 100, 2)
 
         context = {
+            "current": current,
             "percentage": percentage,
-            "total": current,
+            "total": total,
             "number_style": True,
         }
 

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1274,8 +1274,8 @@ class WorkerDeliveryTable(OrgContextTable):
 
 
     def render_delivery_progress(self, record):
-        current = record.completed
-        total = record.total_visits
+        current = record.completed or 10
+        total = record.total_visits or 100
 
         if not total:
             return "-"
@@ -1283,9 +1283,8 @@ class WorkerDeliveryTable(OrgContextTable):
         percentage = round((current / total) * 100, 2)
 
         context = {
-            "current": current,
             "percentage": percentage,
-            "total": total,
+            "total": current,
             "number_style": True,
         }
 

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -657,7 +657,7 @@ class BaseOpportunityList(OrgContextTable):
     def render_opportunity(self, value, record):
         url = reverse("opportunity:detail", args=(self.org_slug, record.id))
         value = format_html('<a href="{}">{}</a>', url, value)
-        return self._render_div(value, extra_classes="justify-start")
+        return self._render_div(value, extra_classes="justify-start text-wrap")
 
     def render_program(self, value):
         return self._render_div(value if value else "--", extra_classes="justify-start")
@@ -812,7 +812,7 @@ class ProgramManagerOpportunityTable(BaseOpportunityList):
         url = reverse("opportunity:detail", args=(self.org_slug, record.id))
         html = format_html(
             """
-            <a href={} class="flex flex-col items-start w-40">
+            <a href={} class="flex flex-col items-start text-wrap w-50">
                 <p class="text-sm text-slate-900">{}</p>
                 <p class="text-xs text-slate-400">{}</p>
             </a>
@@ -1274,7 +1274,7 @@ class WorkerDeliveryTable(OrgContextTable):
 
 
     def render_delivery_progress(self, record):
-        current = record.completed_visits
+        current = record.completed
         total = record.total_visits
 
         if not total:

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1018,7 +1018,7 @@ class WorkerStatusTable(tables.Table):
     user = UserInfoColumn()
     suspended = SuspendedIndicatorColumn()
     invited_date = DMYTColumn()
-    last_active = DMYTColumn(verbose_name=header_with_tooltip("Last Active", "Submitted a Learn or Deliver form"), accessor="last_active_d")
+    last_active = DMYTColumn(verbose_name=header_with_tooltip("Last Active", "Submitted a Learn or Deliver form"))
     started_learn = DMYTColumn(
         verbose_name=header_with_tooltip("Started Learn", "Submitted the first Learn form"),
         accessor="date_learn_started",
@@ -1042,7 +1042,7 @@ class WorkerPaymentsTable(tables.Table):
     index = IndexColumn()
     user = UserInfoColumn(footer="Total")
     suspended = SuspendedIndicatorColumn()
-    last_active = DMYTColumn(accessor="last_active_d")
+    last_active = DMYTColumn()
     payment_accrued = tables.Column(verbose_name="Accrued",
                                     footer=lambda table: intcomma(
                                         sum(x.payment_accrued or 0 for x in table.data)))
@@ -1098,7 +1098,7 @@ class WorkerLearnTable(OrgContextTable):
     index = IndexColumn()
     user = UserInfoColumn()
     suspended = SuspendedIndicatorColumn()
-    last_active = DMYTColumn(accessor="last_active_d")
+    last_active = DMYTColumn()
     started_learning = DMYTColumn(accessor="date_learn_started", verbose_name="Started Learning")
     modules_completed = tables.TemplateColumn(
         accessor="modules_completed_percentage",
@@ -1219,7 +1219,7 @@ class WorkerDeliveryTable(OrgContextTable):
     index = IndexColumn()
     user = tables.Column(orderable=False, verbose_name="Name", footer="Total")
     suspended = SuspendedIndicatorColumn()
-    last_active = DMYTColumn(accessor="last_active_d")
+    last_active = DMYTColumn()
     payment_unit = tables.Column(orderable=False)
     delivery_progress = tables.Column(accessor="total_visits", empty_values=())
     delivered = TotalDeliveredColumn(

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1087,7 +1087,7 @@ class WorkerPaymentsTable(tables.Table):
             "tailwind/components/worker_page/last_paid.html",
             {
                 "record": record,
-                "value": value.strftime("%d-%b-%Y %H:%M") if value else "--",
+                "value": value.strftime("%d-%b-%Y") if value else "--",
                 "org_slug": self.org_slug,
                 "opp_id": self.opp_id,
             },

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1264,7 +1264,7 @@ class WorkerDeliveryTable(OrgContextTable):
             "rejected",
             "action",
         )
-        order_by = ("-last_active",)
+        orderable = False
 
     def __init__(self, *args, **kwargs):
         self.opp_id = kwargs.pop("opp_id")

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1219,26 +1219,31 @@ class WorkerDeliveryTable(OrgContextTable):
     index = IndexColumn()
     user = tables.Column(orderable=False, verbose_name="Name", footer="Total")
     suspended = SuspendedIndicatorColumn()
-    last_active = DMYTColumn()
+    last_active = DMYTColumn(empty_values=())
     payment_unit = tables.Column(orderable=False)
-    delivery_progress = tables.Column(accessor="total_visits", empty_values=())
+    delivery_progress = tables.Column(accessor="total_visits", empty_values=(), orderable=False)
     delivered = TotalDeliveredColumn(
         verbose_name=header_with_tooltip("Delivered", "Delivered number of payment units"),
-        accessor="completed"
+        accessor="completed",
+        order_by="total_completed",
     )
     pending = TotalFlagCountsColumn(
         verbose_name=header_with_tooltip("Pending", "Payment units with pending approvals with NM or PM"),
-        status=CompletedWorkStatus.pending
+        status=CompletedWorkStatus.pending,
+        order_by="total_pending",
     )
     approved = TotalFlagCountsColumn(
         verbose_name=header_with_tooltip(
             "Approved", "Payment units that are fully approved automatically or manually by NM and PM"
         ),
-        status=CompletedWorkStatus.approved
+        status=CompletedWorkStatus.approved,
+        order_by="total_approved",
     )
     rejected = TotalFlagCountsColumn(
         verbose_name=header_with_tooltip("Rejected", "Payment units that are rejected"),
-        status=CompletedWorkStatus.rejected)
+        status=CompletedWorkStatus.rejected,
+        order_by="total_rejected",
+    )
 
     action = tables.TemplateColumn(
         verbose_name="",
@@ -1264,7 +1269,7 @@ class WorkerDeliveryTable(OrgContextTable):
             "rejected",
             "action",
         )
-        orderable = False
+
 
     def __init__(self, *args, **kwargs):
         self.opp_id = kwargs.pop("opp_id")
@@ -1274,8 +1279,8 @@ class WorkerDeliveryTable(OrgContextTable):
 
 
     def render_delivery_progress(self, record):
-        current = record.completed or 10
-        total = record.total_visits or 100
+        current = record.completed
+        total = record.total_visits
 
         if not total:
             return "-"
@@ -1298,17 +1303,13 @@ class WorkerDeliveryTable(OrgContextTable):
                 <a href="{}"><i class="fa-solid fa-chevron-right text-brand-deep-purple"></i></a>
             </div>
         """
+        self.run_after_every_row(record)
         return format_html(template, url)
 
     def render_user(self, value, record):
-
-        if not record.accepted:
-            return "-"
-
-        if value.id in self._seen_users:
+        if record.id in self._seen_users:
             return ""
 
-        self._seen_users.add(value.id)
 
         url = reverse("opportunity:user_visits_list", args=(self.org_slug, self.opp_id, record.id))
 
@@ -1324,27 +1325,36 @@ class WorkerDeliveryTable(OrgContextTable):
             value.username,
         )
 
+    def render_suspended(self, record, value):
+        if record.id in self._seen_users:
+            return ""
+        return SuspendedIndicatorColumn().render(value)
+
+
+    def run_after_every_row(self, record):
+        self._seen_users.add(record.id)
+
     def render_index(self, value, record):
         page = getattr(self, "page", None)
-        if page:
-            start_index = (page.number - 1) * page.paginator.per_page + 1
-        else:
-            start_index = 1
 
-        if record.user.id in self._seen_users:
+        if not hasattr(self, "_row_counter"):
+            seen_ids = set()
+            unique_before_page = 0
+
+            per_page = page.paginator.per_page
+            page_start_index = (page.number - 1) * per_page
+
+            for d in self.data[:page_start_index]:
+                if d.id not in seen_ids:
+                    seen_ids.add(d.id)
+                    unique_before_page += 1
+
+            self._row_counter = itertools.count(start=unique_before_page + 1)
+
+        if record.id in self._seen_users:
             return ""
 
-        if (
-            not hasattr(self, "_row_counter")
-            or not hasattr(self, "_row_counter_start")
-            or self._row_counter_start != start_index
-        ):
-            self._row_counter = itertools.count(start=start_index)
-            self._row_counter_start = start_index
-
-        display_index = next(self._row_counter)
-
-        return display_index
+        return next(self._row_counter)
 
     def render_delivered(self, record, value):
         rows = [
@@ -1387,6 +1397,12 @@ class WorkerDeliveryTable(OrgContextTable):
 
     def render_rejected(self, record, value):
         return self._render_flag_counts(record, value, status=CompletedWorkStatus.rejected)
+
+    def render_last_active(self, record, value):
+        if record.id in self._seen_users:
+            return ""
+
+        return DMYTColumn().render(value)
 
 
 class WorkerLearnStatusTable(tables.Table):

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1879,7 +1879,7 @@ def worker_payments(request, org_slug=None, opp_id=None):
         "-payment_accrued"
     )
     query_set = query_set.annotate(
-        last_active=Greatest(Max("uservisit__visit_date"), Max("completedmodule__date"), "date_learn_started"),
+        last_active_d=Greatest(Max("uservisit__visit_date"), Max("completedmodule__date"), "date_learn_started"),
         last_paid=Max("payment__date_paid"),
     )
     table = WorkerPaymentsTable(query_set, org_slug=org_slug, opp_id=opp_id)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2184,7 +2184,6 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
                     "status": "Inactive last 3 days",
                     "value": header_with_tooltip(stats["inactive_workers"],
                                                  "Did not submit a Learn or Deliver form in the last 3 days"),
-                    "url": status_url,
                     **panel_type_2,
                 },
             ],

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2023,7 +2023,7 @@ def opportunity_funnel_progress(request, org_slug, opp_id):
         },
         {"stage": "Started Learning",
          "count": header_with_tooltip(aggregates["started_learning_count"],
-                                      "Workers that have submitted the first Learn form"),
+                                      "Workers who started downloading the Learn app"),
          "icon": "book-open-cover"
          },
         {"stage": "Completed Learning", "count": header_with_tooltip(aggregates["completed_learning"],

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2212,7 +2212,7 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
                     "name": "Payments",
                     "status": "Due",
                     "value": header_with_tooltip(intcomma(stats['payments_due']),
-                                                 "Worker payments reported as paid"),
+                                                 "Worker payments reported as due"),
                 },
             ],
         },

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2138,6 +2138,7 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
             "value": header_with_tooltip(stats["total_deliveries"],
                                          "Total delivered so far excluding duplicates"),
             "incr": stats["deliveries_from_yesterday"],
+            "url": delivery_url,
         },
         {
             "icon": "fa-clipboard-list-check",
@@ -2166,9 +2167,9 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
             "title": "Workers",
             "sub_heading": "",
             "value": "",
-            "url": status_url,
             "panels": [
-                {"icon": "fa-user-group", "name": "Workers", "status": "Invited", "value": stats["workers_invited"]},
+                {"icon": "fa-user-group", "name": "Workers", "status": "Invited", "value": stats["workers_invited"],
+                 "url": status_url, },
                 {
                     "icon": "fa-user-check",
                     "name": "Workers",
@@ -2188,7 +2189,6 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
         },
         {
             "title": "Services Delivered",
-            "url": delivery_url,
             "sub_heading": "Last Delivery",
             "value": stats["most_recent_delivery"] or "--",
             "panels": deliveries_panels,
@@ -2196,7 +2196,6 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
         {
             "title": f"Worker Payments ({opportunity.currency})",
             "sub_heading": "Last Payment",
-            "url": payment_url,
             "value": stats["recent_payment"] or "--",
             "panels": [
                 {
@@ -2205,7 +2204,8 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
                     "status": "Earned",
                     "value": header_with_tooltip(intcomma(stats['total_accrued']),
                                                  "Worker payment accrued based on approved service deliveries"),
-                    "incr": stats["accrued_since_yesterday"]
+                    "incr": stats["accrued_since_yesterday"],
+                    "url": payment_url,
                 },
                 {
                     "icon": "fa-hand-holding-droplet",

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2217,7 +2217,7 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
                     "name": "Payments",
                     "status": "Due",
                     "value": header_with_tooltip(intcomma(stats['payments_due']),
-                                                 "Worker payments reported as due"),
+                                                 "Worker payments earned but yet unpaid"),
                 },
             ],
         },

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1882,7 +1882,7 @@ def worker_payments(request, org_slug=None, opp_id=None):
         "-payment_accrued"
     )
     query_set = query_set.annotate(
-        last_active_d=Greatest(Max("uservisit__visit_date"), Max("completedmodule__date"), "date_learn_started"),
+        last_active=Greatest(Max("uservisit__visit_date"), Max("completedmodule__date"), "date_learn_started"),
         last_paid=Max("payment__date_paid"),
     )
     table = WorkerPaymentsTable(query_set, org_slug=org_slug, opp_id=opp_id)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -342,7 +342,7 @@ class OpportunityDashboard(OrganizationUserMixin, DetailView):
 
         context["resources"] = [
             {"name": "Learn App", "count": learn_module_count, "icon": "fa-book-open-cover"},
-            {"name": "Delivery App", "count": deliver_unit_count, "icon": "fa-clipboard-check"},
+            {"name": "Deliver App", "count": deliver_unit_count, "icon": "fa-clipboard-check"},
             {"name": "Payments Units", "count": payment_unit_count, "icon": "fa-hand-holding-dollar"},
         ]
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1251,11 +1251,13 @@ def payment_report(request, org_slug, pk):
     if not opportunity.managed:
         return redirect("opportunity:detail", org_slug, pk)
     total_paid_users = (
-        Payment.objects.filter(opportunity_access__opportunity=opportunity).aggregate(total=Sum("amount"))["total"]
+        Payment.objects.filter(opportunity_access__opportunity=opportunity, organization__isnull=True).aggregate(
+            total=Sum("amount"))["total"]
         or 0
     )
     total_paid_nm = (
-        Payment.objects.filter(organization=opportunity.organization).aggregate(total=Sum("amount"))["total"] or 0
+        Payment.objects.filter(organization=opportunity.organization,
+                               invoice__opportunity=opportunity).aggregate(total=Sum("amount"))["total"] or 0
     )
     data, total_user_payment_accrued, total_nm_payment_accrued = get_payment_report_data(opportunity)
     table = PaymentReportTable(data)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -365,7 +365,7 @@ class OpportunityDashboard(OrganizationUserMixin, DetailView):
             {
                 "name": "Max Workers",
                 "count": header_with_tooltip(safe_display(object.number_of_users),
-                                             "Maximum number of payment units that can be delivered. Each payment unit is a service delivery"),
+                                             "Maximum allowed workers in the Opportunity"),
                 "icon": "fa-users"
             },
             {

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2035,42 +2035,21 @@ def opportunity_worker_progress(request, org_slug, opp_id):
     rejected_percentage = safe_percent(aggregates["rejected_deliveries"], aggregates["total_deliveries"])
     earned_percentage = safe_percent(aggregates["total_accrued"], aggregates["total_budget"])
     paid_percentage = safe_percent(aggregates["total_paid"], aggregates["total_accrued"])
-    visits_since_yesterday_percent = safe_percent(aggregates["visits_since_yesterday"],
-                                                  aggregates["maximum_visit_in_a_day"])
 
     worker_progress = [
-        {
-            "title": "Daily Active Workers",
-            "progress": [
-                {
-                    "title": "Maximum Achieved",
-                    "total": aggregates["maximum_visit_in_a_day"],
-                    "value": aggregates["maximum_visit_in_a_day"],
-                    "badge_type": False,
-                    "percent": 100 if aggregates["maximum_visit_in_a_day"] else 0,
-                },
-                {
-                    "title": "Active Yesterday",
-                    "total": aggregates["visits_since_yesterday"],
-                    "value": aggregates["visits_since_yesterday"],
-                    "badge_type": False,
-                    "percent": visits_since_yesterday_percent,
-                },
-            ],
-        },
         {
             "title": "Verification",
             "progress": [
                 {
                     "title": "Approved",
-                    "total": aggregates["total_deliveries"],
+                    "total": aggregates["approved_deliveries"],
                     "value": f"{verified_percentage:.2f}%",
                     "badge_type": True,
                     "percent": verified_percentage
                 },
                 {
                     "title": "Rejected",
-                    "total": aggregates["total_deliveries"],
+                    "total": aggregates["rejected_deliveries"],
                     "value": f"{rejected_percentage:.2f}%",
                     "badge_type": True,
                     "percent": rejected_percentage,
@@ -2082,14 +2061,14 @@ def opportunity_worker_progress(request, org_slug, opp_id):
             "progress": [
                 {
                     "title": "Earned",
-                    "total": intcomma(aggregates['total_budget']),
+                    "total": "",
                     "value": f"{earned_percentage:.2f}%",
                     "badge_type": True,
                     "percent": earned_percentage,
                 },
                 {
                     "title": "Paid",
-                    "total": intcomma(aggregates['total_accrued']),
+                    "total": aggregates["total_paid"],
                     "value": f"{paid_percentage:.2f}%",
                     "badge_type": True,
                     "percent": paid_percentage,

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1251,11 +1251,16 @@ def payment_report(request, org_slug, pk):
     if not opportunity.managed:
         return redirect("opportunity:detail", org_slug, pk)
     total_paid_users = (
-        Payment.objects.filter(opportunity_access__opportunity=opportunity).aggregate(total=Sum("amount"))["total"]
-        or 0
+        Payment.objects
+        .filter(
+            opportunity_access__opportunity=opportunity,
+            organization__isnull=True
+        )
+        .aggregate(total=Sum("amount"))["total"] or 0
     )
     total_paid_nm = (
-        Payment.objects.filter(organization=opportunity.organization).aggregate(total=Sum("amount"))["total"] or 0
+        Payment.objects.filter(organization=opportunity.organization,
+                               opportunity_access__opportunity=opportunity).aggregate(total=Sum("amount"))["total"] or 0
     )
     data, total_user_payment_accrued, total_nm_payment_accrued = get_payment_report_data(opportunity)
     table = PaymentReportTable(data)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1251,16 +1251,11 @@ def payment_report(request, org_slug, pk):
     if not opportunity.managed:
         return redirect("opportunity:detail", org_slug, pk)
     total_paid_users = (
-        Payment.objects
-        .filter(
-            opportunity_access__opportunity=opportunity,
-            organization__isnull=True
-        )
-        .aggregate(total=Sum("amount"))["total"] or 0
+        Payment.objects.filter(opportunity_access__opportunity=opportunity).aggregate(total=Sum("amount"))["total"]
+        or 0
     )
     total_paid_nm = (
-        Payment.objects.filter(organization=opportunity.organization,
-                               opportunity_access__opportunity=opportunity).aggregate(total=Sum("amount"))["total"] or 0
+        Payment.objects.filter(organization=opportunity.organization).aggregate(total=Sum("amount"))["total"] or 0
     )
     data, total_user_payment_accrued, total_nm_payment_accrued = get_payment_report_data(opportunity)
     table = PaymentReportTable(data)

--- a/commcare_connect/templates/tailwind/base_table.html
+++ b/commcare_connect/templates/tailwind/base_table.html
@@ -4,7 +4,7 @@
 {% load sort_link %}
 <div class="overflow-hidden table-container flex flex-col gap-2 mb-1">
   {% block table %}
-  <div class="w-full max-h-[80vh] overflow-x-auto block">
+  <div class="w-full overflow-x-auto block">
     <table class="base-table" {% render_attrs table.attrs %}>
       {% block table.thead %}
       {% if table.show_header %}

--- a/commcare_connect/templates/tailwind/components/worker_page/profile.html
+++ b/commcare_connect/templates/tailwind/components/worker_page/profile.html
@@ -6,10 +6,10 @@
             <div class="absolute z-10 top-0 left-0 w-full h-full"
                  @click="isStatusModalOpen = true">
               {% if opportunity_access.suspended %}
-                <svg viewBox="-600 -600 1200 1200" xmlns="http://www.w3.org/2000/svg">
+                <svg viewBox="-165 -250 1200 1200" xmlns="http://www.w3.org/2000/svg">
                   <g transform="rotate(45)">
-                    <circle r="500" stroke="red" stroke-width="200" stroke-linecap="round" pathLength="360"
-                            stroke-dasharray="90 270" fill="none"/>
+                    <circle r="120" stroke="red" stroke-width="60" stroke-linecap="round"
+                            pathLength="360" stroke-dasharray="90 270" fill="none"></circle>
                   </g>
                 </svg>
               {% endif %}

--- a/commcare_connect/templates/tailwind/pages/opportunity_dashboard/dashboard.html
+++ b/commcare_connect/templates/tailwind/pages/opportunity_dashboard/dashboard.html
@@ -73,7 +73,7 @@
                       {% endfor %}
 
                       <!-- Modal -->
-                      {% include "tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html" with opp_id=object.id %}
+                      {% include "tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html" with opportunity=object %}
                   </div>
               </div>
           </div>

--- a/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_delivery_stat.html
+++ b/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_delivery_stat.html
@@ -57,8 +57,8 @@
         <h3 class="text-2xl font-medium text-white {{ panel.text_color }}">
           {{ panel.value }}
         </h3>
-        {% if panel.incr %}
-        <span class="badge badge-md positive-dark">{{ panel.incr }} ↑</span>
+        {% if panel.incr %}'
+        <span  x-data x-tooltip.raw="Increment in last 24 hours" class="badge badge-md positive-dark">{{ panel.incr }} ↑</span>
         {% endif %}
         <div>
           <i class="fa-light fa-arrow-up-right text-brand-sky text-lg {{ panel.text_color }}"></i>

--- a/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_delivery_stat.html
+++ b/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_delivery_stat.html
@@ -45,26 +45,34 @@
       </p>
     </div>
     {% for panel in stat.panels %}
-    <a href="{{ stat.url }}">
-      <div class="flex gap-2 rounded-lg p-4 items-center bg-brand-indigo {{ panel.body }}">
-        <div class="w-10 h-10 flex items-center justify-center text-white rounded-md {{ panel.icon_bg }}">
-          <i class="fa-light {{ panel.icon }}"></i>
+    {% if panel.url  %}
+      <a href="{{ panel.url }}">
+    {% endif %}
+        <div class="flex gap-2 rounded-lg p-4 items-center bg-brand-indigo {{ panel.body }}">
+          <div class="w-10 h-10 flex items-center justify-center text-white rounded-md {{ panel.icon_bg }}">
+            <i class="fa-light {{ panel.icon }}"></i>
+          </div>
+          <div class="flex-1">
+            <h3 class="text-xs text-white {{ panel.text_color }}">{{ panel.name }}</h3>
+            <p class="text-sm text-white {{ panel.text_color }}">{{ panel.status }}</p>
+          </div>
+          <h3 class="text-2xl font-medium text-white {{ panel.text_color }}">
+            {{ panel.value }}
+          </h3>
+          {% if panel.incr %}'
+          <span  x-data x-tooltip.raw="Increment in last 24 hours" class="badge badge-md positive-dark">{{ panel.incr }} ↑</span>
+          {% endif %}
+          <div>
+            {% if panel.url %}
+              <i class="fa-light fa-arrow-up-right text-brand-sky text-lg {{ panel.text_color }}"></i>
+            {% else %}
+              <i class="fa-light fa-arrow-up-right text-lg invisible"></i>
+            {% endif %}
+          </div>
         </div>
-        <div class="flex-1">
-          <h3 class="text-xs text-white {{ panel.text_color }}">{{ panel.name }}</h3>
-          <p class="text-sm text-white {{ panel.text_color }}">{{ panel.status }}</p>
-        </div>
-        <h3 class="text-2xl font-medium text-white {{ panel.text_color }}">
-          {{ panel.value }}
-        </h3>
-        {% if panel.incr %}'
-        <span  x-data x-tooltip.raw="Increment in last 24 hours" class="badge badge-md positive-dark">{{ panel.incr }} ↑</span>
-        {% endif %}
-        <div>
-          <i class="fa-light fa-arrow-up-right text-brand-sky text-lg {{ panel.text_color }}"></i>
-        </div>
-      </div>
-    </a>
+    {% if panel.url  %}
+      </a>
+    {% endif %}
     {% endfor %}
   </div>
   {% endfor %}

--- a/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_funnel_progress.html
+++ b/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_funnel_progress.html
@@ -5,6 +5,7 @@
   hx-trigger="load"
   hx-target="#opp-funnel-container"
   hx-swap="innerHTML"
+  class="mt-4"
 >
   <div class="flex flex-col gap-8 w-full p-8 shadow-sm rounded-xl bg-white animate-pulse">
     <h4 class="text-brand-deep-purple font-medium">Worker Progress Funnel</h4>

--- a/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html
+++ b/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html
@@ -24,10 +24,10 @@
                             <div x-show="selectedTab === 'Learn App'"></div>
                         </li>
                         <!-- Delivery App Tab -->
-                        <li @click="selectedTab = 'Delivery App'"
-                            :class="{ 'active': selectedTab === 'Delivery App' }">
-                            <span>Delivery App</span>
-                            <div x-show="selectedTab === 'Delivery App'"></div>
+                        <li @click="selectedTab = 'Deliver App'"
+                            :class="{ 'active': selectedTab === 'Deliver App' }">
+                            <span>Deliver App</span>
+                            <div x-show="selectedTab === 'Deliver App'"></div>
                         </li>
                         <!-- Payment Units Tab -->
                         <li @click="selectedTab = 'Payments Units'"
@@ -56,8 +56,8 @@
                         </div>
                     </div>
 
-                    <!-- Delivery App Content -->
-                    <div x-show="selectedTab === 'Delivery App'"
+                    <!-- Deliver App Content -->
+                    <div x-show="selectedTab === 'Deliver App'"
                             hx-get="{% url 'opportunity:deliver_unit_table' request.org.slug opp_id %}"
                             hx-trigger="tabShown from:body"
                             hx-swap="innerHTML"

--- a/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html
+++ b/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html
@@ -17,14 +17,15 @@
                 <!-- Tabs -->
                 <div class="flex relative mx-auto items-center shadow rounded-lg justify-between w-full px-3 mb-3 bg-slate-50 h-14">
                     <ul class="tabs">
-                        <li
+                        <li x-tooltip.raw.html.interactive.theme.light="<a href='{{ opportunity.learn_app.url }}' target='_blank' class='underline'>{{ opportunity.learn_app.name }}</a>"
                             @click="selectedTab = 'Learn App'"
                             :class="{ 'active': selectedTab === 'Learn App' }">
                             <span>Learn App</span>
                             <div x-show="selectedTab === 'Learn App'"></div>
                         </li>
                         <!-- Delivery App Tab -->
-                        <li @click="selectedTab = 'Deliver App'"
+                        <li x-tooltip.raw.html.interactive.theme.light="<a href='{{ opportunity.deliver_app.url }}' target='_blank' class='underline'>{{ opportunity.deliver_app.name }}</a>"
+                            @click="selectedTab = 'Deliver App'"
                             :class="{ 'active': selectedTab === 'Deliver App' }">
                             <span>Deliver App</span>
                             <div x-show="selectedTab === 'Deliver App'"></div>
@@ -45,9 +46,8 @@
 
                 <!-- Modal body / Tab content -->
                 <div class="z-50 bg-white ">
-                    <!-- Learn App Content -->
                     <div x-show="selectedTab === 'Learn App'"
-                            hx-get="{% url 'opportunity:learn_module_table' request.org.slug opp_id %}"
+                            hx-get="{% url 'opportunity:learn_module_table' request.org.slug opportunity.id %}"
                             hx-trigger="tabShown from:body"
                             hx-swap="innerHTML"
                             class=" rounded-lg h-full w-full">
@@ -58,7 +58,7 @@
 
                     <!-- Deliver App Content -->
                     <div x-show="selectedTab === 'Deliver App'"
-                            hx-get="{% url 'opportunity:deliver_unit_table' request.org.slug opp_id %}"
+                            hx-get="{% url 'opportunity:deliver_unit_table' request.org.slug opportunity.id %}"
                             hx-trigger="tabShown from:body"
                             hx-swap="innerHTML"
                             class="rounded-lg h-full w-full">
@@ -69,7 +69,7 @@
 
                     <!-- Payment Units Content -->
                     <div x-show="selectedTab === 'Payments Units'"
-                            hx-get="{% url 'opportunity:payment_unit_table' request.org.slug opp_id %}"
+                            hx-get="{% url 'opportunity:payment_unit_table' request.org.slug opportunity.id %}"
                            hx-trigger="tabShown from:body"
                             hx-swap="innerHTML"
                             class="rounded-lg h-full w-full">
@@ -77,6 +77,7 @@
                             <div class="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-brand-deep-purple"></div>
                         </div>
                     </div>
+
                 </div>
 
             </div>

--- a/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html
+++ b/commcare_connect/templates/tailwind/pages/opportunity_dashboard/opportunity_resource_modal.html
@@ -17,14 +17,14 @@
                 <!-- Tabs -->
                 <div class="flex relative mx-auto items-center shadow rounded-lg justify-between w-full px-3 mb-3 bg-slate-50 h-14">
                     <ul class="tabs">
-                        <li x-tooltip.raw.html.interactive.theme.light="<a href='{{ opportunity.learn_app.url }}' target='_blank' class='underline'>{{ opportunity.learn_app.name }}</a>"
+                        <li x-tooltip.raw.html.interactive="<a href='{{ opportunity.learn_app.url }}' target='_blank' class='underline'>{{ opportunity.learn_app.name }}</a>"
                             @click="selectedTab = 'Learn App'"
                             :class="{ 'active': selectedTab === 'Learn App' }">
                             <span>Learn App</span>
                             <div x-show="selectedTab === 'Learn App'"></div>
                         </li>
                         <!-- Delivery App Tab -->
-                        <li x-tooltip.raw.html.interactive.theme.light="<a href='{{ opportunity.deliver_app.url }}' target='_blank' class='underline'>{{ opportunity.deliver_app.name }}</a>"
+                        <li x-tooltip.raw.html.interactive="<a href='{{ opportunity.deliver_app.url }}' target='_blank' class='underline'>{{ opportunity.deliver_app.name }}</a>"
                             @click="selectedTab = 'Deliver App'"
                             :class="{ 'active': selectedTab === 'Deliver App' }">
                             <span>Deliver App</span>


### PR DESCRIPTION
## Technical Summary

This pr address following issues:- 
[CCCT-1277](https://dimagi.atlassian.net/browse/CCCT-1277)
https://dimagi.atlassian.net/browse/QA-7760
https://dimagi.atlassian.net/browse/QA-7760
https://dimagi.atlassian.net/browse/QA-7772
https://dimagi.atlassian.net/browse/QA-7774
https://dimagi.atlassian.net/browse/QA-7778
https://dimagi.atlassian.net/browse/CCCT-1178

1. Remove duplicates in Delivery tab progress bar
2. Reconcile Total Services Delivered in Opp Dashboard with Total Row in Delivery Tab
3. Change to Services Delivered Progress Bar. Replace the Total Services Delivered numbers at the end of the progress bars with the actual ‘Approved’ number and ‘Rejected’ number
4. Remove the Max Budget figure from the end of the progress bar
5. Replace 750(earned amount) with actual paid amount
6. Remove the Daily Active Workers progress bar

## Safety Assurance

### Safety story
Tested locally


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-1277]: https://dimagi.atlassian.net/browse/CCCT-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ