### PR TITLE
Export Improvements for User Visit export.

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -17,11 +17,11 @@ from commcare_connect.connect_id_client import fetch_users, send_message, send_m
 from commcare_connect.connect_id_client.models import ConnectIdUser, Message
 from commcare_connect.opportunity.app_xml import get_connect_blocks_for_app, get_deliver_units_for_app
 from commcare_connect.opportunity.export import (
+    UserVisitExporter,
     export_catchment_area_table,
     export_deliver_status_table,
     export_empty_payment_table,
     export_user_status_table,
-    export_user_visit_data,
     export_user_visit_review_data,
     export_work_status_table,
 )
@@ -142,9 +142,8 @@ def invite_user(user_id, opportunity_access_id):
 def generate_visit_export(opportunity_id: int, date_range: str, status: list[str], export_format: str, flatten: bool):
     opportunity = Opportunity.objects.get(id=opportunity_id)
     logger.info(f"Export for {opportunity.name} with date range {date_range} and status {','.join(status)}")
-    dataset = export_user_visit_data(
-        opportunity, DateRanges(date_range), [VisitValidationStatus(s) for s in status], flatten
-    )
+    exporter = UserVisitExporter(opportunity, flatten)
+    dataset = exporter.get_dataset(DateRanges(date_range), [VisitValidationStatus(s) for s in status])
     export_tmp_name = f"{now().isoformat()}_{opportunity.name}_visit_export.{export_format}"
     save_export(dataset, export_tmp_name, export_format)
     return export_tmp_name

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -67,6 +67,48 @@ def test_export_user_visit_data(mobile_user_with_connect_link):
     )
 
 
+def test_export_user_visit_data_no_flatten(mobile_user_with_connect_link):
+    opportunity = OpportunityFactory()
+    deliver_units = DeliverUnitFactory.create_batch(2, app=opportunity.deliver_app)
+    date1 = now()
+    date2 = date1 + timedelta(minutes=10)
+    form_json_1 = {"form": {"name": "test_form1"}}
+    form_json_1_string = '{""form"": {""name"": ""test_form1""}}'
+    form_json_2 = {"form": {"name": "test_form2", "group": {"q": "b"}}}
+    form_json_2_string = '{""form"": {""name"": ""test_form2"", ""group"": {""q"": ""b""}}}'
+    UserVisit.objects.bulk_create(
+        [
+            UserVisit(
+                opportunity=opportunity,
+                user=mobile_user_with_connect_link,
+                visit_date=date1,
+                deliver_unit=deliver_units[0],
+                form_json=form_json_1,
+            ),
+            UserVisit(
+                opportunity=opportunity,
+                user=mobile_user_with_connect_link,
+                visit_date=date2,
+                deliver_unit=deliver_units[1],
+                entity_id="abc",
+                entity_name="A B C",
+                form_json=form_json_2,
+            ),
+        ]
+    )
+    exporter = UserVisitExporter(opportunity, False)
+    dataset = exporter.get_dataset(DateRanges.LAST_30_DAYS, [])
+    username = mobile_user_with_connect_link.username
+    name = mobile_user_with_connect_link.name
+    assert dataset.export("csv") == (
+        "Visit ID,Visit date,Status,Username,Name of User,Unit Name,Rejected Reason,"
+        "Duration,Entity ID,Entity Name,Flags,form_json\r\n"
+        f',{date1.isoformat()},Pending,{username},{name},{deliver_units[0].name},,,,,,"{form_json_1_string}"\r\n'
+        f",{date2.isoformat()},Pending,{username},{name},{deliver_units[1].name},,,abc,A B C,,"
+        f'"{form_json_2_string}"\r\n'
+    )
+
+
 def _get_prepared_dataset_for_user_status_test(data):
     headers = (
         "Name",

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -10,7 +10,6 @@ from commcare_connect.opportunity.export import (
     export_catchment_area_table,
     export_user_status_table,
     export_user_visit_review_data,
-    get_flattened_dataset,
 )
 from commcare_connect.opportunity.forms import DateRanges
 from commcare_connect.opportunity.models import Opportunity, UserInviteStatus, UserVisit, VisitReviewStatus
@@ -66,31 +65,6 @@ def test_export_user_visit_data(mobile_user_with_connect_link):
         f",{date1.isoformat()},Pending,{username},{name},{deliver_units[0].name},,,,,,test_form1,\r\n"
         f",{date2.isoformat()},Pending,{username},{name},{deliver_units[1].name},,,abc,A B C,,test_form2,b\r\n"
     )
-
-
-@pytest.mark.parametrize(
-    "data, expected",
-    [
-        (
-            {"form": {"name": "form1"}},
-            [
-                (
-                    "form.name",
-                    "form1",
-                )
-            ],
-        ),
-        ({"form": [{"name": "form1"}, {"name": "form2"}]}, [("form.0.name", "form1"), ("form.1.name", "form2")]),
-    ],
-)
-def test_get_flattened_dataset(data, expected):
-    headers = ["header1", "header2"]
-    data = [
-        ["value1", "value2", data],
-    ]
-    dataset = get_flattened_dataset(headers, data)
-    assert dataset.headers == ["header1", "header2"] + [x[0] for x in expected]
-    assert dataset[0] == ("value1", "value2") + tuple(x[1] for x in expected)
 
 
 def _get_prepared_dataset_for_user_status_test(data):

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -6,9 +6,9 @@ from django.utils.timezone import now
 from tablib import Dataset
 
 from commcare_connect.opportunity.export import (
+    UserVisitExporter,
     export_catchment_area_table,
     export_user_status_table,
-    export_user_visit_data,
     export_user_visit_review_data,
     get_flattened_dataset,
 )
@@ -55,11 +55,12 @@ def test_export_user_visit_data(mobile_user_with_connect_link):
             ),
         ]
     )
-    exporter = export_user_visit_data(opportunity, DateRanges.LAST_30_DAYS, [], True)
+    exporter = UserVisitExporter(opportunity, True)
+    dataset = exporter.get_dataset(DateRanges.LAST_30_DAYS, [])
     username = mobile_user_with_connect_link.username
     name = mobile_user_with_connect_link.name
 
-    assert exporter.export("csv") == (
+    assert dataset.export("csv") == (
         "Visit ID,Visit date,Status,Username,Name of User,Unit Name,Rejected Reason,"
         "Duration,Entity ID,Entity Name,Flags,form.name,form.group.q\r\n"
         f",{date1.isoformat()},Pending,{username},{name},{deliver_units[0].name},,,,,,test_form1,\r\n"

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -31,8 +31,8 @@ from commcare_connect.users.tests.factories import MobileUserFactory
 
 
 def test_export_user_visit_data(mobile_user_with_connect_link):
-    deliver_unit = DeliverUnitFactory()
     opportunity = OpportunityFactory()
+    deliver_units = DeliverUnitFactory.create_batch(2, app=opportunity.deliver_app)
     date1 = now()
     date2 = date1 + timedelta(minutes=10)
     UserVisit.objects.bulk_create(
@@ -41,14 +41,14 @@ def test_export_user_visit_data(mobile_user_with_connect_link):
                 opportunity=opportunity,
                 user=mobile_user_with_connect_link,
                 visit_date=date1,
-                deliver_unit=deliver_unit,
+                deliver_unit=deliver_units[0],
                 form_json={"form": {"name": "test_form1"}},
             ),
             UserVisit(
                 opportunity=opportunity,
                 user=mobile_user_with_connect_link,
                 visit_date=date2,
-                deliver_unit=deliver_unit,
+                deliver_unit=deliver_units[1],
                 entity_id="abc",
                 entity_name="A B C",
                 form_json={"form": {"name": "test_form2", "group": {"q": "b"}}},
@@ -62,8 +62,8 @@ def test_export_user_visit_data(mobile_user_with_connect_link):
     assert exporter.export("csv") == (
         "Visit ID,Visit date,Status,Username,Name of User,Unit Name,Rejected Reason,"
         "Duration,Entity ID,Entity Name,Flags,form.name,form.group.q\r\n"
-        f",{date1.isoformat()},Pending,{username},{name},{deliver_unit.name},,,,,,test_form1,\r\n"
-        f",{date2.isoformat()},Pending,{username},{name},{deliver_unit.name},,,abc,A B C,,test_form2,b\r\n"
+        f",{date1.isoformat()},Pending,{username},{name},{deliver_units[0].name},,,,,,test_form1,\r\n"
+        f",{date2.isoformat()},Pending,{username},{name},{deliver_units[1].name},,,abc,A B C,,test_form2,b\r\n"
     )
 
 


### PR DESCRIPTION
## Product Description
Refactored the User Visit Export to have pagination on the queryset to reduce the amount of visits that are held in memory at a point of time.
Refactored the code for flattening the json in dataset that also aggregated headers. This code now runs for all deliver units in the current export once at the start and aggregates all the headers including headers generated from flattened json for the dataset. 

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-881)

## Safety Assurance
### Safety story

I have done testing locally for 50000 user visits with a 10x10 form json. 

- Base
	- peak mem 3,207,889.62 KiB (3.05 GiB)
	- final mem 1,950,386.31 KiB 
- Refactored with Pagination, no library changes
	- peak mem 882,964.33 KiB (0.84 GiB) (1/4 usage compared to before)
	- final mem 819,649.30 KiB 

### Automated test coverage
This code has good automated test coverage.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
