### PR TITLE
Flag Reason Column

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -477,6 +477,10 @@ class UserVisitReviewTable(OrgContextTable):
         )
         return mark_safe(f'<a href="{url}">View</a>')
 
+    def render_flag_reason(self, value):
+        short = [flag[1] for flag in value.get("flags")]
+        return ", ".join(short)
+
 
 class PaymentReportTable(tables.Table):
     payment_unit = columns.Column(verbose_name="Payment Unit")

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -465,6 +465,7 @@ class UserVisitReviewTable(OrgContextTable):
             "review_status",
             "created_on",
             "user_visit",
+            "flag_reason",
         )
         empty_text = "No visits submitted for review."
         template_name = "django_tables2/bootstrap5.html"


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
The flag reason column has been added to the PM review sheet export:
![Screenshot from 2025-06-10 15-58-59](https://github.com/user-attachments/assets/186ed348-0827-4102-90fd-5a960a0dbe91)

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CI-94).

This PR simply adds the `flag_reason` field from the `UserVisit` model for export in PM review sheets. Adding this column allows a user to know why the visit was flagged and better understand the corresponding justification without having to match those visits with the User Visits sheet.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Single line change that only adds a single extra column to PM review sheet exports

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
