### PR TITLE
Fixes for status sync issues

### DIFF
--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -30,6 +30,7 @@ from commcare_connect.opportunity.models import (
     OpportunityAccess,
     OpportunityClaimLimit,
     OpportunityVerificationFlags,
+    PaymentUnit,
     UserVisit,
     VisitReviewStatus,
     VisitValidationStatus,
@@ -671,6 +672,28 @@ def test_receiver_visit_review_status(
         assert visit.flagged
     assert visit.status == visit_status
     assert visit.review_status == review_status
+
+
+@pytest.mark.parametrize("opportunity", [{"opp_options": {"managed": True, "org_pay_per_visit": 2}}], indirect=True)
+def test_receiver_duplicate_managed_opportunity(
+    user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
+):
+    form_json = _create_opp_and_form_json(opportunity, user=user_with_connectid_link)
+    make_request(api_client, form_json, user_with_connectid_link)
+    access = OpportunityAccess.objects.get(opportunity=opportunity, user=user_with_connectid_link)
+    payment_unit = PaymentUnit.objects.get(opportunity=opportunity)
+    visit = UserVisit.objects.get(user=user_with_connectid_link)
+    assert visit.status == VisitValidationStatus.approved
+    assert access.payment_accrued == payment_unit.amount
+
+    duplicate_json = deepcopy(form_json)
+    duplicate_json["id"] = str(uuid4())
+    make_request(api_client, duplicate_json, user_with_connectid_link)
+    visit = UserVisit.objects.get(xform_id=duplicate_json["id"])
+    access.refresh_from_db()
+    assert visit.status == VisitValidationStatus.duplicate
+    assert access.payment_accrued == payment_unit.amount
+    assert ["duplicate", "A beneficiary with the same identifier already exists"] in visit.flag_reason.get("flags", [])
 
 
 @pytest.mark.parametrize(

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -38,6 +38,7 @@ from commcare_connect.opportunity.tasks import bulk_approve_completed_work
 from commcare_connect.opportunity.tests.factories import (
     CatchmentAreaFactory,
     CompletedModuleFactory,
+    CompletedWorkFactory,
     DeliverUnitFactory,
     DeliverUnitFlagRulesFactory,
     FormJsonValidationRulesFactory,
@@ -611,6 +612,42 @@ def test_receiver_verification_flags_catchment_areas(
     visit = UserVisit.objects.get(user=user_with_connectid_link)
     assert visit.flagged
     assert ["catchment", "Visit outside worker catchment areas"] in visit.flag_reason.get("flags", [])
+
+
+@pytest.mark.parametrize("opportunity", [{"opp_options": {"managed": True, "org_pay_per_visit": 2}}], indirect=True)
+def test_approve_rejected_visit(mobile_user_with_connect_link: User, api_client: APIClient, opportunity: Opportunity):
+    assert opportunity.managed
+    access = OpportunityAccessFactory(opportunity=opportunity, user=mobile_user_with_connect_link)
+    payment_unit = PaymentUnitFactory(opportunity=opportunity)
+    deliver_unit = DeliverUnitFactory(app=payment_unit.opportunity.deliver_app, payment_unit=payment_unit)
+    completed_work = CompletedWorkFactory(
+        opportunity_access=access, status=CompletedWorkStatus.pending, payment_unit=payment_unit
+    )
+    visit = UserVisitFactory(
+        user=mobile_user_with_connect_link,
+        opportunity_access=access,
+        opportunity=opportunity,
+        completed_work=completed_work,
+        status=VisitValidationStatus.rejected,
+        review_status=VisitReviewStatus.pending,
+        deliver_unit=deliver_unit,
+    )
+
+    update_payment_accrued(opportunity, [mobile_user_with_connect_link.id])
+    completed_work = CompletedWork.objects.get(id=visit.completed_work_id)
+
+    assert visit.status == VisitValidationStatus.rejected
+    assert completed_work.status == CompletedWorkStatus.rejected
+
+    visit.status = VisitValidationStatus.approved
+    visit.review_status = VisitReviewStatus.agree
+    visit.save()
+
+    update_payment_accrued(opportunity, [mobile_user_with_connect_link.id])
+    completed_work.refresh_from_db()
+
+    assert visit.status == VisitValidationStatus.approved
+    assert completed_work.status == CompletedWorkStatus.approved
 
 
 @pytest.mark.parametrize("opportunity", [{"opp_options": {"managed": True, "org_pay_per_visit": 2}}], indirect=True)

--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -34,7 +34,9 @@ def _update_status_set_saved_fields_and_get_payment_accrued(completed_work, oppo
     amount_accrued = 0
     made_changes = False
     if opportunity_access.opportunity.auto_approve_payments:
-        visits = completed_work.uservisit_set.values_list("status", "reason", "review_status")
+        visits = completed_work.uservisit_set.exclude(status__in=[VisitValidationStatus.duplicate]).values_list(
+            "status", "reason", "review_status"
+        )
         if any(status == VisitValidationStatus.rejected for status, *_ in visits):
             completed_work.status = CompletedWorkStatus.rejected
             completed_work.reason = "\n".join(reason for _, reason, _ in visits if reason)

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -192,9 +192,7 @@ def update_payment_accrued(opportunity: Opportunity, users):
     access_objects = OpportunityAccess.objects.filter(user__in=users, opportunity=opportunity, suspended=False)
     for access in access_objects:
         with cache.lock(f"update_payment_accrued_lock_{access.id}", timeout=900):
-            completed_works = access.completedwork_set.exclude(status=CompletedWorkStatus.rejected).select_related(
-                "payment_unit"
-            )
+            completed_works = access.completedwork_set.select_related("payment_unit")
             update_status(completed_works, access, compute_payment=True)
 
 


### PR DESCRIPTION
## Product Description
This PR include fixes for the below issues
- Duplicate Visits were causing auto-approved CompletedWorks to become pending for managed opportunities.
- Rejected completed works cannot be approved automatically as they were excluded from the update_payment_accrued function.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-1267)
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-1266)
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-1287)

## Safety Assurance
### Safety story
Tested on staging.

### Automated test coverage

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
