### PR TITLE
Commcare app to admin seach and linked opp ids

### DIFF
--- a/commcare_connect/opportunity/admin.py
+++ b/commcare_connect/opportunity/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Q
 
 from commcare_connect.opportunity.forms import OpportunityAccessCreationForm
 from commcare_connect.opportunity.models import (
@@ -27,7 +28,6 @@ from commcare_connect.opportunity.tasks import create_learn_modules_and_deliver_
 # Register your models here.
 
 
-admin.site.register(CommCareApp)
 admin.site.register(UserInvite)
 admin.site.register(DeliveryType)
 admin.site.register(DeliverUnitFlagRules)
@@ -171,3 +171,14 @@ class PaymentUnitAdmin(admin.ModelAdmin):
     @admin.display(description="Opportunity Name")
     def get_opp_name(self, obj):
         return obj.opportunity.name
+
+
+@admin.register(CommCareApp)
+class CommCareAppAdmin(admin.ModelAdmin):
+    list_display = ["name", "cc_app_id", "cc_domain", "get_opportunity_ids"]
+    search_fields = ["cc_domain", "name", "cc_app_id"]
+
+    @admin.display(description="Linked Opportunity IDs")
+    def get_opportunity_ids(self, obj):
+        opp_ids = Opportunity.objects.filter(Q(learn_app=obj) | Q(deliver_app=obj)).values_list("id", flat=True)
+        return ", ".join(str(i) for i in opp_ids)


### PR DESCRIPTION
## Technical Summary
This PR enhances the Django admin for CommCareApp by:

- Displaying linked Opportunity IDs in the app list view.
- Enabling search by cc_domain, name, and cc_app_id for easier lookup.

This will help admins quickly identify where an app is used and filter apps by their associated CommCare domain.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
