### PR TITLE
Add Cloudwatch to Ansible Setup

### DIFF
--- a/deploy/roles/connect/handlers/main.yml
+++ b/deploy/roles/connect/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart cloudwatch agent
+  systemd:
+    name: amazon-cloudwatch-agent
+    state: restarted

--- a/deploy/roles/connect/tasks/main.yml
+++ b/deploy/roles/connect/tasks/main.yml
@@ -107,50 +107,46 @@
   tags:
     - django_settings
 
-- name: Download CloudWatch agent
-  get_url:
-    url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
-    dest: /tmp/amazon-cloudwatch-agent.deb
-    mode: '0644'
-  tags:
-    - cloudwatch
+- name: Cloudwatch agent setup
+  block:
+    - name: Download CloudWatch agent
+      get_url:
+        url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+        dest: /tmp/amazon-cloudwatch-agent.deb
+        mode: '0644'
 
-- name: Install CloudWatch agent
-  apt:
-    deb: /tmp/amazon-cloudwatch-agent.deb
-    state: present
-  tags:
-    - cloudwatch
+    - name: Install CloudWatch agent
+      apt:
+        deb: /tmp/amazon-cloudwatch-agent.deb
+        state: present
 
-- name: Remove CloudWatch agent file
-  file:
-    path: /tmp/amazon-cloudwatch-agent.deb
-    state: absent
-  tags:
-    - cloudwatch
+    - name: Remove CloudWatch agent file
+      file:
+        path: /tmp/amazon-cloudwatch-agent.deb
+        state: absent
 
-- name: Create CloudWatch agent config directory
-  file:
-    path: /opt/aws/amazon-cloudwatch-agent/etc
-    state: directory
-    mode: 0755
-  tags:
-    - cloudwatch
+    - name: Create CloudWatch agent config directory
+      file:
+        path: /opt/aws/amazon-cloudwatch-agent/etc
+        state: directory
+        mode: 0755
 
-- name: Configure CloudWatch agent
-  template:
-    src: cloudwatch-config.json.j2
-    dest: /opt/aws/amazon-cloudwatch-agent/etc/config.json
-    mode: 0644
-  notify: restart cloudwatch agent
-  tags:
-    - cloudwatch
+    - name: Configure CloudWatch agent
+      template:
+        src: cloudwatch-config.json.j2
+        dest: /opt/aws/amazon-cloudwatch-agent/etc/config.json
+        mode: 0644
+      notify: restart cloudwatch agent
 
-- name: Start CloudWatch agent
-  systemd:
-    name: amazon-cloudwatch-agent
-    state: started
-    enabled: yes
-    daemon_reload: yes
+    - name: Start CloudWatch agent
+      systemd:
+        name: amazon-cloudwatch-agent
+        state: started
+        enabled: yes
+        daemon_reload: yes
+  rescue:
+    - name: Cloudwatch setup failed
+      debug:
+        msg: 'Cloudwatch agent setup failed, continuing with deployment'
   tags:
     - cloudwatch

--- a/deploy/roles/connect/tasks/main.yml
+++ b/deploy/roles/connect/tasks/main.yml
@@ -27,6 +27,7 @@
       - python3-setuptools
       - gnupg
       - acl
+      - wget
     state: latest
     update_cache: true
   tags:
@@ -105,3 +106,51 @@
     mode: 0644
   tags:
     - django_settings
+
+- name: Download CloudWatch agent
+  get_url:
+    url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+    dest: /tmp/amazon-cloudwatch-agent.deb
+    mode: '0644'
+  tags:
+    - cloudwatch
+
+- name: Install CloudWatch agent
+  apt:
+    deb: /tmp/amazon-cloudwatch-agent.deb
+    state: present
+  tags:
+    - cloudwatch
+
+- name: Remove CloudWatch agent file
+  file:
+    path: /tmp/amazon-cloudwatch-agent.deb
+    state: absent
+  tags:
+    - cloudwatch
+
+- name: Create CloudWatch agent config directory
+  file:
+    path: /opt/aws/amazon-cloudwatch-agent/etc
+    state: directory
+    mode: 0755
+  tags:
+    - cloudwatch
+
+- name: Configure CloudWatch agent
+  template:
+    src: cloudwatch-config.json.j2
+    dest: /opt/aws/amazon-cloudwatch-agent/etc/config.json
+    mode: 0644
+  notify: restart cloudwatch agent
+  tags:
+    - cloudwatch
+
+- name: Start CloudWatch agent
+  systemd:
+    name: amazon-cloudwatch-agent
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  tags:
+    - cloudwatch

--- a/deploy/roles/connect/templates/cloudwatch-config.json.j2
+++ b/deploy/roles/connect/templates/cloudwatch-config.json.j2
@@ -1,0 +1,60 @@
+{
+    "agent": {
+        "metrics_collection_interval": 60,
+        "run_as_user": "cwagent"
+    },
+    "metrics": {
+        "namespace": "PersonalID",
+        "metrics_collected": {
+            "cpu": {
+                "measurement": [
+                    "cpu_usage_idle",
+                    "cpu_usage_iowait",
+                    "cpu_usage_user",
+                    "cpu_usage_system"
+                ],
+                "metrics_collection_interval": 60
+            },
+            "disk": {
+                "measurement": [
+                    "used_percent",
+                    "inodes_free"
+                ],
+                "metrics_collection_interval": 60,
+                "resources": [
+                    "*"
+                ]
+            },
+            "diskio": {
+                "measurement": [
+                    "reads",
+                    "writes",
+                    "read_time",
+                    "write_time",
+                    "io_time"
+                ],
+                "metrics_collection_interval": 60,
+                "resources": [
+                    "*"
+                ]
+            },
+            "mem": {
+                "measurement": [
+                    "mem_used_percent",
+                    "mem_total",
+                    "mem_free",
+                    "mem_cached",
+                    "mem_buffered"
+                ],
+                "metrics_collection_interval": 60
+            },
+            "processes": {
+                "measurement": [
+                    "running",
+                    "sleeping",
+                    "dead"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-1253).
Link to investigation doc [here](https://docs.google.com/document/d/1lR6oJQGpyXtOlBZbxGYnSLq7B0pXfBp97jKEA07uYuM/edit?tab=t.0).

This PR adds the necessary commands in Ansible for setting up and configuring Cloudwatch on an EC2 machine. The config has been set up to track the following items:
- CPU
- Memory
- Disk
- Processes

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The Ansible commands for setting up Cloudwatch do have a block, so if something goes wrong then the deploy won't be blocked.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
