### PR TITLE
add invite views

### DIFF
--- a/commcare_connect/users/urls.py
+++ b/commcare_connect/users/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 
 from commcare_connect.users.views import (
+    CheckInvitedUserView,
+    ResendInvitesView,
     SMSStatusCallbackView,
     accept_invite,
     create_user_link_view,
@@ -19,4 +21,6 @@ urlpatterns = [
     path("accept_invite/<slug:invite_id>/", view=accept_invite, name="accept_invite"),
     path("demo_users/", view=demo_user_tokens, name="demo_users"),
     path("sms_status_callback/", SMSStatusCallbackView.as_view(), name="sms_status_callback"),
+    path("invited_user/", CheckInvitedUserView.as_view(), name="check_invited_user"),
+    path("resend_invites/", ResendInvitesView.as_view(), name="resend_invites"),
 ]

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -182,7 +182,9 @@ class ResendInvitesView(APIView):
 
     def post(request, *args, **kwargs):
         user = ConnectIdUser(request.data)
-        opps = UserInvite.objects.filter(phone_number=user.phone_number).values_list("opportunity_id", flat=True)
+        opps = UserInvite.objects.filter(
+            phone_number=user.phone_number, status=UserInviteStatus.not_found
+        ).values_list("opportunity_id", flat=True)
         for opp_id in opps:
             update_user_and_send_invite(user, opp_id)
         return Response(status=200)


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
Connect part of https://github.com/dimagi/connect-id/pull/131

Adds two views, one to check if a phone number has been invited to a connect opportunity. One to resend invites to a phone number. Only invites that were not previously sent, because the user was not found, are sent.


## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Both views are unused except in new workflows

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
