### PR TITLE
request is a GET not POST

### DIFF
--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -167,7 +167,7 @@ class SMSStatusCallbackView(APIView):
 @method_decorator(csrf_exempt, name="dispatch")
 class CheckInvitedUserView(ClientProtectedResourceMixin, View):
     def get(self, request, *args, **kwargs):
-        phone_number = request.POST.get("phone_number")
+        phone_number = request.GET.get("phone_number")
         invited = False
         if phone_number:
             invited = UserInvite.objects.filter(phone_number=phone_number).exists()


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Title says it all. This request is a GET so must use `request.GET`
