### PR TITLE
Custom get_object logic for OpportunityDashboard

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -313,6 +313,11 @@ class OpportunityDashboard(OrganizationUserMixin, DetailView):
     model = Opportunity
     template_name = "tailwind/pages/opportunity_dashboard/dashboard.html"
 
+    def get_object(self, queryset=None):
+        opp_id = self.kwargs.get("pk")
+        org_slug = self.kwargs.get("org_slug")
+        return get_opportunity_or_404(opp_id, org_slug)
+
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         if not self.object.is_setup_complete:


### PR DESCRIPTION
## Technical Summary
Override get_object in OpportunityDashboard to fetch opportunity using get_opportunity_or_404 with pk and org_slug.
https://dimagi.atlassian.net/browse/CI-124

## Safety Assurance

### Safety story
Tested locally

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
