### PR TITLE
Disable credentials on connect

### DIFF
--- a/commcare_connect/organization/tasks.py
+++ b/commcare_connect/organization/tasks.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.urls import reverse
 
-from commcare_connect import connect_id_client
-from commcare_connect.organization.models import Organization, UserOrganizationMembership
+from commcare_connect.organization.models import UserOrganizationMembership
 from commcare_connect.users.models import User
 from config import celery_app
 
@@ -36,5 +35,7 @@ Commcare Connect"""
 
 @celery_app.task()
 def add_credential_task(org_pk: int, credential: str, users: list[str]):
-    org = Organization.objects.get(pk=org_pk)
-    connect_id_client.add_credential(org, credential, users)
+    # Disable temporarily until the new credentials system is ready
+    # org = Organization.objects.get(pk=org_pk)
+    # connect_id_client.add_credential(org, credential, users)
+    pass

--- a/commcare_connect/templates/organization/organization_home.html
+++ b/commcare_connect/templates/organization/organization_home.html
@@ -45,13 +45,6 @@
           {% crispy form %}
         </form>
       </div>
-       <h2 class="text-xl font-semibold text-brand-deep-purple mb-4">Add Credential</h2>
-      <div class="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-        <form method="post" action="{% url 'organization:add_members' org_slug=organization.slug %}">
-          {% csrf_token %}
-          {% crispy add_credential_form %}
-        </form>
-      </div>
     </div>
 
     <div


### PR DESCRIPTION
## Product Description

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/CCCT-1377)

This PR is for temporarily disabling the ability on Connect for adding credentials to users. This is until the new worker history feature has been rolled out properly. 

## Safety Assurance

### Safety story
Simple change. Tests still pass.

### Automated test coverage
No new tests

### QA Plan
No QA planned

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
