### PR TITLE
reverted get to filter

### DIFF
--- a/commcare_connect/program/utils.py
+++ b/commcare_connect/program/utils.py
@@ -4,7 +4,7 @@ from commcare_connect.program.models import ManagedOpportunity
 
 @quickcache(vary_on=["opp_id"], timeout=60 * 60 * 24)
 def get_managed_opp(opp_id) -> ManagedOpportunity | None:
-    return ManagedOpportunity.objects.select_related("program__organization").get(id=opp_id)
+    return ManagedOpportunity.objects.select_related("program__organization").filter(id=opp_id).first()
 
 
 def is_program_manager(request):


### PR DESCRIPTION
## Technical Summary

Changed get to filter as opp will not be present when normal opps call this function.

## Safety Assurance

### Safety story
tested locally

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
