### PR TITLE
add link back to form in HQ

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -697,6 +697,12 @@ class UserVisit(XFormBaseModel):
             return flags
         return []
 
+    @property
+    def hq_link(self):
+        hq_url = self.deliver_unit.app.hq_server.url
+        domain = self.opportunity.deliver_app.cc_domain
+        return f"https://{hq_url}/a/{domain}/reports/form_data/{self.xform_id}/"
+
     class Meta:
         constraints = [
             models.UniqueConstraint(

--- a/commcare_connect/templates/opportunity/user_visit_details.html
+++ b/commcare_connect/templates/opportunity/user_visit_details.html
@@ -230,6 +230,15 @@
   </div>
   {% endif %}
 
+  {% if request.user.is_superuser %}
+  <hr class="h-px bg-gray-200 border-0">
+
+  <p class="text-sm font-medium text-brand-deep-purple">Further Information</p>
+  <div class="flex">
+    <a class="button button-md button-outline-rounded" href="{{ user_visit.hq_link }}">View Form in CommCareHQ <i class="fa-solid fa-arrow-right"></i></a>
+  </div>
+  {% endif %}
+
   <!-- Popup Modal -->
   <div x-cloak
        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
This adds a link to the form details report in commcarehq for superusers.
https://dimagi.atlassian.net/browse/CCCT-1401

<img width="1277" height="1054" alt="Screenshot from 2025-07-22 18-34-55" src="https://github.com/user-attachments/assets/0eb4a9fd-0373-4dcd-8f4a-426df97363b8" />
## Technical Summary


<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This builds on recent work to tie apps to specific HQ servers, using those as the url base as well as the rest of the info from the form to generate the URL. Open to feedback on the styling/front end code. I was sort of making it up as I went along.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Superuser only, tested locally

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
