### PR TITLE
Ce/cloudwatch fixes

### DIFF
--- a/deploy/roles/connect/tasks/main.yml
+++ b/deploy/roles/connect/tasks/main.yml
@@ -140,7 +140,7 @@
 - name: Configure CloudWatch agent
   template:
     src: cloudwatch-config.json.j2
-    dest: /opt/aws/amazon-cloudwatch-agent/etc/config.json
+    dest: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
     mode: 0644
   notify: restart cloudwatch agent
   tags:

--- a/tasks.py
+++ b/tasks.py
@@ -93,6 +93,7 @@ def restart_django(c: Context, env="staging", verbose=False, diff=False):
     run_ansible(c, play="utils.yml", env=env, tags="restart", verbose=verbose, diff=diff)
 
 
+@task
 def run_ansible(c: Context, play="play.yml", env="staging", tags=None, verbose=False, diff=False):
     ansible_cmd = f"ansible-playbook {play} -i {env}.inventory.yml"
     if tags:


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This moves the cloudwatch config to the default location so that the installed systemd command works out of the box. I also made it easier to run playbooks without a full deploy and with arbitrary tags, since that was the natural way to deploy this

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
no change to application code


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
