### PR TITLE
Append zero-hour time so browser time is ignored

### DIFF
--- a/commcare_connect/templates/opportunity/user_visit_verification_table.html
+++ b/commcare_connect/templates/opportunity/user_visit_verification_table.html
@@ -42,7 +42,7 @@
       {% endfor %}
     </div>
 
-    <div x-data="datePicker('tableDatePicker', {% if request.GET.filter_date %} new Date('{{ request.GET.filter_date }}') {% else %} '' {% endif %})"
+    <div x-data="datePicker('tableDatePicker', {% if request.GET.filter_date %} new Date('{{ request.GET.filter_date }}' + 'T00:00:00') {% else %} '' {% endif %})"
       class="flex gap-x-4 items-center">
       <div class="flex items-center gap-1 bg-slate-100 p-2 text-sm font-normal rounded-sm">
         <i class="fa-solid fa-chevron-left text-brand-deep-purple cursor-pointer" @click="navigateDate(-1)"></i>


### PR DESCRIPTION
## Product Description
A bug is fixed where the selected date "jumps" to the previous day in timezones west of UTC.

The bug is being reproduced in .gif below:
![demo_wrong](https://github.com/user-attachments/assets/22db405a-a177-4b3c-9474-ae24bd3bd96d)

The fixed behaviour can be seen in the .gif below:
![demo_right](https://github.com/user-attachments/assets/2e24f8a4-4caf-4423-a5b8-646245c91188)


## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/CI-152)

This PR fixes an issue where the browser takes the local timezone into account when populating a javascript `Date` object, given a date from the request. The problematic behaviour is that, if the local timezone is west of UTC the date picker jumps back 1 day.

The fix is simple: force the date object that is being populated to use the zero-th hour with the date from the request instead of taking the local timezone into account and potentially jumping back to the previous day.

Example of problem:
I set my timezone to Atlantic Daylight Time (UTC-03) and opened the browser console...
<img width="417" height="62" alt="image" src="https://github.com/user-attachments/assets/ca898e4e-02b3-47de-9283-1fd137d3c3fb" />
 
Observe that the date being represented by the Date object is the previous day, i.e. 23 July.

Now simply append `T00:00:00` to the date...
<img width="417" height="62" alt="image" src="https://github.com/user-attachments/assets/5e2f8b0e-3f9b-4948-9cf1-2c5132cefc68" />

The result is a date object representing the correct date.
 

## Safety Assurance

### Safety story
Tested behaviour with my locally-run app and it works.

### Automated test coverage
No automated test

### QA Plan
QA not planned

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
