### PR TITLE
Ce/remove org credentials

### DIFF
--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -5,7 +5,6 @@ from httpx import BasicAuth, Response
 from commcare_connect.cache import quickcache
 from commcare_connect.connect_id_client.models import (
     ConnectIdUser,
-    Credential,
     DemoUser,
     Message,
     MessagingBulkResponse,
@@ -56,12 +55,16 @@ def add_credential(organization: Organization, credential: str, users: list[str]
 
 
 def fetch_credentials(org_slug=None):
-    params = {}
-    if org_slug:
-        params["org_slug"] = org_slug
-    response = _make_request(GET, "/users/fetch_credentials", params=params)
-    data = response.json()
-    return [Credential(**c) for c in data["credentials"]]
+    # this view no longer exists in it's current form
+    # in connectid. we can add it back once the new design
+    # is finalized. this prevents accidental calls
+    return []
+    # params = {}
+    # if org_slug:
+    #     params["org_slug"] = org_slug
+    # response = _make_request(GET, "/users/fetch_credentials", params=params)
+    # data = response.json()
+    # return [Credential(**c) for c in data["credentials"]]
 
 
 def filter_users(country_code: str, credential: list[str]):

--- a/commcare_connect/organization/views.py
+++ b/commcare_connect/organization/views.py
@@ -51,11 +51,6 @@ def organization_home(request, org_slug):
     if not form:
         form = OrganizationChangeForm(instance=org)
 
-    credentials = connect_id_client.fetch_credentials(org_slug=request.org.slug)
-    credential_name = f"Worked for {org.name}"
-    if not any(c.name == credential_name for c in credentials):
-        credentials.append(Credential(name=credential_name, slug=slugify(credential_name)))
-
     return render(
         request,
         "organization/organization_home.html",
@@ -63,7 +58,6 @@ def organization_home(request, org_slug):
             "organization": org,
             "form": form,
             "membership_form": membership_form,
-            "add_credential_form": AddCredentialForm(credentials=credentials),
         },
     )
 


### PR DESCRIPTION

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This resolves the following [sentry error](https://dimagi.sentry.io/issues/6790196755/?environment=production&project=4505635339829248&query=is%3Aunresolved&referrer=issue-stream), which causes a 500 on loading the organization details view. It is calling a view in connectid that no longer exists, and while the usage of that was removed in https://github.com/dimagi/commcare-connect/pull/674/files, the call itself was not. This also replaces the method that makes the call with an empty list, to prevent accidental calls in the future.

I could be convinced to delete everything rather than the comments and replacements, but it seems like we will want to add them back in the future when the credential API is settled and it will be helpful to leave the framework.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Removes erroring calls


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
