### PR TITLE
currency handling improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Test with pytest
         run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
-          cache-dependency-path: requirements-dev.txt
+          cache-dependency-path: requirements.txt
 
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -r requirements.txt
 
       - name: Test with pytest
         run: pytest


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This task is only supposed to run once per month to get the rates, but when it fails and a rate is missing, it gets called over and over causing us to hit our limits on openexchangerates. This PR does two things to handle failures a bit better

1) limits our requests to once per day (per URL, which changes monthly) by caching the result.
2) reports currencies that aren't found to sentry, but continues processing the rest to prevent a bad code from causing overall failure. 

It also fixes a bug with the loop variables.
 
I had to switch the test runner to use prod requirements in order to avoid an import error for `sentry_sdk`. We could probably also move it to a different file that isn't called during tests, but there doesn't seem to be a huge downside in making our tests closer to the prod environment.
## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This task is already broken and at worst can only affect fetching exchange rates, rather than any core functionality.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
