### PR TITLE
Add "staff" view for manually requesting OTP 

### DIFF
--- a/commcare_connect/connect_id_client/exceptions.py
+++ b/commcare_connect/connect_id_client/exceptions.py
@@ -1,0 +1,2 @@
+class ConnectIDClientError(Exception):
+    pass

--- a/commcare_connect/connect_id_client/exceptions.py
+++ b/commcare_connect/connect_id_client/exceptions.py
@@ -1,2 +1,0 @@
-class ConnectIDClientError(Exception):
-    pass

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -1,10 +1,8 @@
 import httpx
-import sentry_sdk
 from django.conf import settings
 from httpx import BasicAuth, Response
 
 from commcare_connect.cache import quickcache
-from commcare_connect.connect_id_client.exceptions import ConnectIDClientError
 from commcare_connect.connect_id_client.models import (
     ConnectIdUser,
     DemoUser,
@@ -91,9 +89,7 @@ def get_user_otp(phone_number):
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
             return None
-        else:
-            sentry_sdk.capture_message(message=f"ConnectID client error: {str(e)}", level="error")
-            raise ConnectIDClientError(f"Failed to fetch OTP: HTTP {e.response.status_code}")
+        raise
 
 
 def _make_request(method, path, params=None, json=None, timeout=5) -> Response:

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -1,4 +1,5 @@
 import httpx
+import sentry_sdk
 from django.conf import settings
 from httpx import BasicAuth, Response
 
@@ -94,6 +95,7 @@ def get_user_otp(phone_number):
                 "that the user has started their device seating process.",
             )
         else:
+            sentry_sdk.capture_message(message=f"ConnectID client error: {str(e)}", level="error")
             raise ConnectIDClientError(f"Failed to fetch OTP: HTTP {e.response.status_code}")
 
 

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -90,10 +90,7 @@ def get_user_otp(phone_number):
         return data.get("otp")
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
-            raise ConnectIDClientError(
-                "Failed to fetch OTP. Please make sure the number is correct and "
-                "that the user has started their device seating process.",
-            )
+            return None
         else:
             sentry_sdk.capture_message(message=f"ConnectID client error: {str(e)}", level="error")
             raise ConnectIDClientError(f"Failed to fetch OTP: HTTP {e.response.status_code}")

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -1,5 +1,4 @@
 import httpx
-import sentry_sdk
 from django.conf import settings
 from httpx import BasicAuth, Response
 
@@ -90,10 +89,6 @@ def get_user_otp(phone_number):
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
             return None
-        sentry_sdk.capture_exception(e)
-        raise
-    except httpx.HTTPError as e:
-        sentry_sdk.capture_exception(e)
         raise
 
 

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -81,6 +81,15 @@ def fetch_user_counts() -> dict[str, int]:
     return data
 
 
+def fetch_otp(phone_number):
+    try:
+        response = _make_request(GET, "/users/generate_manual_otp", params={"phone_number": phone_number})
+        data = response.json()
+        return data.get("otp")
+    except httpx.HTTPError:
+        return None
+
+
 def _make_request(method, path, params=None, json=None, timeout=5) -> Response:
     if json and not method == "POST":
         raise ValueError("json can only be used with POST requests")

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -81,7 +81,7 @@ def fetch_user_counts() -> dict[str, int]:
     return data
 
 
-def generate_and_fetch_otp(phone_number):
+def get_user_otp(phone_number):
     try:
         response = _make_request(GET, "/users/generate_manual_otp", params={"phone_number": phone_number})
         data = response.json()

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -1,4 +1,5 @@
 import httpx
+import sentry_sdk
 from django.conf import settings
 from httpx import BasicAuth, Response
 
@@ -89,6 +90,10 @@ def get_user_otp(phone_number):
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
             return None
+        sentry_sdk.capture_exception(e)
+        raise
+    except httpx.HTTPError as e:
+        sentry_sdk.capture_exception(e)
         raise
 
 

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -81,7 +81,7 @@ def fetch_user_counts() -> dict[str, int]:
     return data
 
 
-def fetch_otp(phone_number):
+def generate_and_fetch_otp(phone_number):
     try:
         response = _make_request(GET, "/users/generate_manual_otp", params={"phone_number": phone_number})
         data = response.json()

--- a/commcare_connect/templates/pages/connect_user_otp.html
+++ b/commcare_connect/templates/pages/connect_user_otp.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="py-8 px-4 mx-auto max-w-screen-xl text-center lg:py-16">
+    <div class="flex flex-col space-y-4 sm:flex-row sm:justify-center sm:space-y-0">
+        {% crispy form %}
+    </div>
+</div>
+{% endblock %}

--- a/commcare_connect/users/forms.py
+++ b/commcare_connect/users/forms.py
@@ -1,5 +1,7 @@
 from allauth.account.forms import SignupForm
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Field, Layout, Submit
 from django import forms
 from django.contrib.auth import forms as admin_forms
 from django.contrib.auth import get_user_model
@@ -52,3 +54,24 @@ class OrganizationCreationForm(forms.ModelForm):
     class Meta:
         model = Organization
         fields = ["name", "program_manager"]
+
+
+class ManualUserOTPForm(forms.Form):
+    phone_number = forms.CharField(
+        max_length=15,
+        label="Phone Number",
+        help_text="Enter the phone number of the user you which to retreive the OTP for.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.layout = Layout(
+            Field("phone_number"),
+            Submit(
+                name="submit",
+                value="Retrieve OTP",
+                css_class="button button-md primary-dark !inline-flex items-center",
+            ),
+        )

--- a/commcare_connect/users/forms.py
+++ b/commcare_connect/users/forms.py
@@ -58,7 +58,7 @@ class OrganizationCreationForm(forms.ModelForm):
 
 class ManualUserOTPForm(forms.Form):
     phone_number = forms.CharField(
-        max_length=15,
+        max_length=16,
         label="Phone Number",
         help_text="Enter the phone number of the user you which to retreive the OTP for.",
         widget=forms.TextInput(attrs={"placeholder": "e.g. +1234567890"}),
@@ -76,3 +76,16 @@ class ManualUserOTPForm(forms.Form):
                 css_class="button button-md primary-dark !inline-flex items-center",
             ),
         )
+
+    def clean_phone_number(self):
+        phone_number = self.cleaned_data.get("phone_number")
+        phone_number = phone_number.strip().replace(" ", "")
+
+        if not phone_number.startswith("+"):
+            raise forms.ValidationError("Phone number must start with a '+'.")
+        try:
+            int(phone_number[1:])
+        except ValueError:
+            raise forms.ValidationError("Phone number must be numeric.")
+
+        return phone_number

--- a/commcare_connect/users/forms.py
+++ b/commcare_connect/users/forms.py
@@ -60,7 +60,7 @@ class ManualUserOTPForm(forms.Form):
     phone_number = forms.CharField(
         max_length=16,
         label="Phone Number",
-        help_text="Enter the phone number of the user you which to retreive the OTP for.",
+        help_text="Enter the phone number of the user you wish to retreive the OTP for.",
         widget=forms.TextInput(attrs={"placeholder": "e.g. +1234567890"}),
     )
 

--- a/commcare_connect/users/forms.py
+++ b/commcare_connect/users/forms.py
@@ -61,6 +61,7 @@ class ManualUserOTPForm(forms.Form):
         max_length=15,
         label="Phone Number",
         help_text="Enter the phone number of the user you which to retreive the OTP for.",
+        widget=forms.TextInput(attrs={"placeholder": "e.g. +1234567890"}),
     )
 
     def __init__(self, *args, **kwargs):

--- a/commcare_connect/users/tests/test_forms.py
+++ b/commcare_connect/users/tests/test_forms.py
@@ -3,7 +3,7 @@ Module for all Form Tests.
 """
 from django.utils.translation import gettext_lazy as _
 
-from commcare_connect.users.forms import UserAdminCreationForm
+from commcare_connect.users.forms import ManualUserOTPForm, UserAdminCreationForm
 from commcare_connect.users.models import User
 
 
@@ -34,3 +34,19 @@ class TestUserAdminCreationForm:
         assert len(form.errors) == 1
         assert "__all__" in form.errors
         assert form.errors["__all__"][0] == _("Constraint “unique_user_email” is violated.")
+
+
+class TestManualUserOTPForm:
+    def test_valid_phone_number(self):
+        form = ManualUserOTPForm(data={"phone_number": "+1234567890"})
+        assert form.is_valid()
+
+    def test_phone_number_must_start_with_plus(self):
+        form = ManualUserOTPForm(data={"phone_number": "1234567890"})
+        assert not form.is_valid()
+        assert form.errors.get("phone_number") == ["Phone number must start with a '+'."]
+
+    def test_phone_number_must_be_numeric(self):
+        form = ManualUserOTPForm(data={"phone_number": "+1234567abc"})
+        assert not form.is_valid()
+        assert form.errors.get("phone_number") == ["Phone number must be numeric."]

--- a/commcare_connect/users/tests/test_views.py
+++ b/commcare_connect/users/tests/test_views.py
@@ -116,17 +116,17 @@ class TestRetrieveUserOTPView:
 
         assert response.status_code == 403
 
-    @patch("commcare_connect.users.views.generate_and_fetch_otp")
-    def test_superuser_can_generate_and_fetch_otp(self, generate_and_fetch_otp_mock, user, client):
-        generate_and_fetch_otp_mock.return_value = "1234"
+    @patch("commcare_connect.users.views.get_user_otp")
+    def test_superuser_can_get_user_otp(self, get_user_otp_mock, user, client):
+        get_user_otp_mock.return_value = "1234"
         response = self._get_superuser_response(client, user)
 
         messages = list(response.context["messages"])
         assert str(messages[0]) == "The user's OTP is: 1234"
 
-    @patch("commcare_connect.users.views.generate_and_fetch_otp")
-    def test_otp_not_retrieved(self, generate_and_fetch_otp_mock, user, client):
-        generate_and_fetch_otp_mock.return_value = None
+    @patch("commcare_connect.users.views.get_user_otp")
+    def test_otp_not_retrieved(self, get_user_otp_mock, user, client):
+        get_user_otp_mock.return_value = None
         response = self._get_superuser_response(client, user)
 
         expected_failure_message = (

--- a/commcare_connect/users/tests/test_views.py
+++ b/commcare_connect/users/tests/test_views.py
@@ -141,4 +141,4 @@ class TestRetrieveUserOTPView:
         user.is_superuser = True
         user.save()
         client.force_login(user)
-        return client.post(self.url, data={"phone_number": "+1234567890"})
+        return client.post(self.url, data={"phone_number": "+1234567890"}, follow=True)

--- a/commcare_connect/users/tests/test_views.py
+++ b/commcare_connect/users/tests/test_views.py
@@ -9,7 +9,6 @@ from django.http import HttpRequest
 from django.test import RequestFactory
 from django.urls import reverse
 
-from commcare_connect.connect_id_client.exceptions import ConnectIDClientError
 from commcare_connect.organization.models import Organization
 from commcare_connect.users.forms import UserAdminChangeForm
 from commcare_connect.users.models import ConnectIDUserLink, User
@@ -134,16 +133,6 @@ class TestRetrieveUserOTPView:
             "Failed to fetch OTP. Please make sure the number is correct "
             "and that the user has started their device seating process."
         )
-
-        messages = list(response.context["messages"])
-        assert str(messages[0]) == expected_failure_message
-
-    @patch("commcare_connect.users.views.get_user_otp")
-    def test_error_during_otp_retrieval(self, get_user_otp_mock, user, client):
-        get_user_otp_mock.side_effect = ConnectIDClientError("Failed to fetch OTP with some error.")
-        response = self._get_superuser_response(client, user)
-
-        expected_failure_message = "Failed to fetch OTP with some error."
 
         messages = list(response.context["messages"])
         assert str(messages[0]) == expected_failure_message

--- a/commcare_connect/users/tests/test_views.py
+++ b/commcare_connect/users/tests/test_views.py
@@ -126,6 +126,19 @@ class TestRetrieveUserOTPView:
         assert str(messages[0]) == "The user's OTP is: 1234"
 
     @patch("commcare_connect.users.views.get_user_otp")
+    def test_no_otp_returned(self, get_user_otp_mock, user, client):
+        get_user_otp_mock.return_value = None
+        response = self._get_superuser_response(client, user)
+
+        expected_failure_message = (
+            "Failed to fetch OTP. Please make sure the number is correct "
+            "and that the user has started their device seating process."
+        )
+
+        messages = list(response.context["messages"])
+        assert str(messages[0]) == expected_failure_message
+
+    @patch("commcare_connect.users.views.get_user_otp")
     def test_error_during_otp_retrieval(self, get_user_otp_mock, user, client):
         get_user_otp_mock.side_effect = ConnectIDClientError("Failed to fetch OTP with some error.")
         response = self._get_superuser_response(client, user)

--- a/commcare_connect/users/urls.py
+++ b/commcare_connect/users/urls.py
@@ -4,6 +4,7 @@ from commcare_connect.users import views
 from commcare_connect.users.views import (
     CheckInvitedUserView,
     ResendInvitesView,
+    RetrieveUserOTPView,
     SMSStatusCallbackView,
     accept_invite,
     create_user_link_view,
@@ -25,4 +26,5 @@ urlpatterns = [
     path("api_keys/", views.get_api_keys, name="get_api_keys"),
     path("invited_user/", CheckInvitedUserView.as_view(), name="check_invited_user"),
     path("resend_invites/", ResendInvitesView.as_view(), name="resend_invites"),
+    path("connect_user_otp/", RetrieveUserOTPView.as_view(), name="connect_user_otp"),
 ]

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -229,7 +229,8 @@ class RetrieveUserOTPView(TemplateView):
     def post(self, request, *args, **kwargs):
         form = ManualUserOTPForm(request.POST)
         if not form.is_valid():
-            messages.error(request, "Something went wrong.")
+            errors = ", ".join(form.errors["phone_number"])
+            messages.error(request, f"{errors}")
             return self.get(request, *args, **kwargs)
 
         otp = fetch_otp(form.cleaned_data["phone_number"])

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -21,6 +21,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from commcare_connect.connect_id_client.exceptions import ConnectIDClientError
 from commcare_connect.connect_id_client.main import fetch_demo_user_tokens, get_user_otp
 from commcare_connect.connect_id_client.models import ConnectIdUser
 from commcare_connect.opportunity.models import HQApiKey, Opportunity, OpportunityAccess, UserInvite, UserInviteStatus
@@ -225,13 +226,10 @@ class RetrieveUserOTPView(LoginRequiredMixin, UserPassesTestMixin, FormView):
         return self.request.user.is_superuser
 
     def form_valid(self, form):
-        otp = get_user_otp(form.cleaned_data["phone_number"])
-        if otp is None:
-            messages.error(
-                self.request,
-                "Failed to fetch OTP. Please make sure the number is correct and"
-                " that the user has started their device seating process.",
-            )
+        try:
+            otp = get_user_otp(form.cleaned_data["phone_number"])
+        except ConnectIDClientError as e:
+            messages.error(self.request, str(e))
         else:
             messages.success(self.request, f"The user's OTP is: {otp}")
         return super().form_valid(form)

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -21,7 +21,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from commcare_connect.connect_id_client.main import fetch_demo_user_tokens, fetch_otp
+from commcare_connect.connect_id_client.main import fetch_demo_user_tokens, generate_and_fetch_otp
 from commcare_connect.connect_id_client.models import ConnectIdUser
 from commcare_connect.opportunity.models import HQApiKey, Opportunity, OpportunityAccess, UserInvite, UserInviteStatus
 from commcare_connect.opportunity.tasks import update_user_and_send_invite
@@ -231,7 +231,7 @@ class RetrieveUserOTPView(UserPassesTestMixin, TemplateView):
             messages.error(request, f"{errors}")
             return self.get(request, *args, **kwargs)
 
-        otp = fetch_otp(form.cleaned_data["phone_number"])
+        otp = generate_and_fetch_otp(form.cleaned_data["phone_number"])
         if otp is None:
             messages.error(
                 request,

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -231,7 +231,15 @@ class RetrieveUserOTPView(LoginRequiredMixin, UserPassesTestMixin, FormView):
         except ConnectIDClientError as e:
             messages.error(self.request, str(e))
         else:
-            messages.success(self.request, f"The user's OTP is: {otp}")
+            if otp is None:
+                messages.error(
+                    self.request,
+                    "Failed to fetch OTP. Please make sure the number is correct and "
+                    "that the user has started their device seating process.",
+                )
+            else:
+                messages.success(self.request, f"The user's OTP is: {otp}")
+
         return super().form_valid(form)
 
     def form_invalid(self, form):

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -13,7 +13,7 @@ from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
-from django.views.generic import RedirectView, TemplateView, UpdateView, View
+from django.views.generic import FormView, RedirectView, UpdateView, View
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from oauth2_provider.views.mixins import ClientProtectedResourceMixin
 from rest_framework.decorators import api_view, authentication_classes
@@ -213,19 +213,16 @@ class ResendInvitesView(ClientProtectedResourceMixin, View):
         return HttpResponse(status=200)
 
 
-class RetrieveUserOTPView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+class RetrieveUserOTPView(LoginRequiredMixin, UserPassesTestMixin, FormView):
     template_name = "pages/connect_user_otp.html"
+    form_class = ManualUserOTPForm
 
     def test_func(self):
         return self.request.user.is_superuser
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["form"] = ManualUserOTPForm()
-        return context
-
     def post(self, request, *args, **kwargs):
-        form = ManualUserOTPForm(request.POST)
+        form = self.get_form()
+
         if not form.is_valid():
             errors = ", ".join(form.errors["phone_number"])
             messages.error(request, f"{errors}")

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -213,7 +213,7 @@ class ResendInvitesView(ClientProtectedResourceMixin, View):
         return HttpResponse(status=200)
 
 
-class RetrieveUserOTPView(UserPassesTestMixin, TemplateView):
+class RetrieveUserOTPView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     template_name = "pages/connect_user_otp.html"
 
     def test_func(self):

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -2,9 +2,9 @@ from allauth.account.models import transaction
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.messages.views import SuccessMessageMixin
-from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -213,13 +213,11 @@ class ResendInvitesView(ClientProtectedResourceMixin, View):
         return HttpResponse(status=200)
 
 
-class RetrieveUserOTPView(TemplateView):
+class RetrieveUserOTPView(UserPassesTestMixin, TemplateView):
     template_name = "pages/connect_user_otp.html"
 
-    def dispatch(self, request, *args, **kwargs):
-        if self.request.user.is_authenticated and self.request.user.is_staff:
-            return super().dispatch(request, *args, **kwargs)
-        return HttpResponseForbidden()
+    def test_func(self):
+        return self.request.user.is_superuser
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -21,7 +21,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from commcare_connect.connect_id_client.main import fetch_demo_user_tokens
+from commcare_connect.connect_id_client.main import fetch_demo_user_tokens, fetch_otp
 from commcare_connect.connect_id_client.models import ConnectIdUser
 from commcare_connect.opportunity.models import HQApiKey, Opportunity, OpportunityAccess, UserInvite, UserInviteStatus
 from commcare_connect.opportunity.tasks import update_user_and_send_invite
@@ -232,6 +232,14 @@ class RetrieveUserOTPView(TemplateView):
             messages.error(request, "Something went wrong.")
             return self.get(request, *args, **kwargs)
 
-        otp = "12345"
+        otp = fetch_otp(form.cleaned_data["phone_number"])
+        if otp is None:
+            messages.error(
+                request,
+                "Failed to fetch OTP. Please make sure the number is correct and"
+                " that the user has started their device seating process.",
+            )
+            return self.get(request, *args, **kwargs)
+
         messages.success(request, f"The user's OTP is: {otp}")
         return self.get(request, *args, **kwargs)

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -21,7 +21,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from commcare_connect.connect_id_client.main import fetch_demo_user_tokens, generate_and_fetch_otp
+from commcare_connect.connect_id_client.main import fetch_demo_user_tokens, get_user_otp
 from commcare_connect.connect_id_client.models import ConnectIdUser
 from commcare_connect.opportunity.models import HQApiKey, Opportunity, OpportunityAccess, UserInvite, UserInviteStatus
 from commcare_connect.opportunity.tasks import update_user_and_send_invite
@@ -225,7 +225,7 @@ class RetrieveUserOTPView(LoginRequiredMixin, UserPassesTestMixin, FormView):
         return self.request.user.is_superuser
 
     def form_valid(self, form):
-        otp = generate_and_fetch_otp(form.cleaned_data["phone_number"])
+        otp = get_user_otp(form.cleaned_data["phone_number"])
         if otp is None:
             messages.error(
                 self.request,


### PR DESCRIPTION
## Product Description
This PR adds a view at `<base_url>/users/connect_user_otp/` which allows a staff user to request an OTP for a given phone number.

Here's the page:
<img width="1839" height="954" alt="image" src="https://github.com/user-attachments/assets/f7712064-2d36-4c60-bcc0-ed9a0d1b8b88" />

When an OTP is received it will be displayed to the user using django's built-in messaging alerts:
<img width="1839" height="954" alt="image" src="https://github.com/user-attachments/assets/d3ed3200-de68-407c-b5f8-f7886b2d436b" />

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/CCCT-1522)
Also relates to [this PersonalID PR](https://github.com/dimagi/connect-id/pull/163).

## Safety Assurance

### Safety story
Did local testing (except making the call to ConnectID server). Will test on staging as well.

### Automated test coverage
No automated tests added.

### QA Plan
No formal QA planned.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
