### PR TITLE
Bugfix - Add budget

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from django.core.validators import MinValueValidator
 from django.db import models
-from django.db.models import Count, F, Max, Q, Sum
+from django.db.models import Count, F, Q, Sum
 from django.utils.dateparse import parse_datetime
 from django.utils.functional import cached_property
 from django.utils.timezone import now
@@ -189,7 +189,7 @@ class Opportunity(BaseModel):
 
     @property
     def budget_per_visit(self):
-        return self.paymentunit_set.aggregate(amount=Max("amount")).get("amount", 0) or 0
+        return self.paymentunit_set.aggregate(amount=Sum("amount")).get("amount", 0) or 0
 
     @property
     def budget_per_user(self):

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -207,7 +207,7 @@ def test_opportunity_list_endpoint(
     payment_units = opportunity.paymentunit_set.all()
     assert response.data[0]["max_visits_per_user"] == sum([pu.max_total for pu in payment_units])
     assert response.data[0]["daily_max_visits_per_user"] == sum([pu.max_daily for pu in payment_units])
-    assert response.data[0]["budget_per_visit"] == max([pu.amount for pu in payment_units])
+    assert response.data[0]["budget_per_visit"] == sum([pu.amount for pu in payment_units])
     claim_limits = OpportunityClaimLimit.objects.filter(opportunity_claim__opportunity_access__opportunity=opportunity)
     assert response.data[0]["claim"]["max_payments"] == sum([cl.max_visits for cl in claim_limits])
     verification_flags = opportunity.opportunityverificationflags

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -62,7 +62,7 @@ def test_opportunity_stats(opportunity: Opportunity, user: User):
     assert opportunity.allotted_visits == sum([pu.max_total for pu in payment_units]) * opportunity.number_of_users
     assert opportunity.max_visits_per_user == sum([pu.max_total for pu in payment_units])
     assert opportunity.daily_max_visits_per_user == sum([pu.max_daily for pu in payment_units])
-    assert opportunity.budget_per_visit == max([pu.amount for pu in payment_units])
+    assert opportunity.budget_per_visit == sum([pu.amount for pu in payment_units])
 
     access = OpportunityAccessFactory(user=user, opportunity=opportunity)
     claim = OpportunityClaimFactory(opportunity_access=access)

--- a/commcare_connect/templates/opportunity/add_visits_existing_users.html
+++ b/commcare_connect/templates/opportunity/add_visits_existing_users.html
@@ -172,7 +172,7 @@
               <div @click.away="closeModal()" x-transition class="modal">
                 <div class="header flex justify-between items-center">
                   <h2 class="title">Confirm</h2>
-                  <button @click="closeModal()" class="button-icon" aria-label="Close">
+                  <button type="button" @click="closeModal()" class="button-icon" aria-label="Close">
                     <i class="fa-solid fa-xmark"></i>
                   </button>
                 </div>
@@ -186,7 +186,7 @@
                   </div>
                 </div>
                 <div class="footer flex justify-end gap-4">
-                  <button @click="closeModal()" type="button" class="button button-md outline-style">
+                  <button type="button" @click="closeModal()" type="button" class="button button-md outline-style">
                     Close
                   </button>
                   <button type="submit" class="button button-md primary-dark">


### PR DESCRIPTION
## Technical Summary

1. The `budget_per_visit` was using the `max` of the payment unit amount in an opportunity instead of the `sum`. This PR addresses that issue and fixes the incorrect budget calculation displayed when adding budget for an existing user.
2. It also fixes a small UI issue where closing the modal using the cross icon caused the form to be submitted, as the button type was not specified and the default button type is `submit`.

## Safety Assurance

### Safety story
The change only affects the display value on the client side and mobile view, so it’s quite safe. We are not altering the actual calculation, as the calculation is already happening correctly.


### Automated test coverage
All existing test cases pass.

### QA Plan
Tested locally and on staging so no QA for this.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
