### PR TITLE
Incorrect icons in worker visits verification page

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -885,9 +885,12 @@ class UserVisitVerificationTable(tables.Table):
 
         status = []
         if record.opportunity.managed and record.review_status and record.review_created_on:
-            if record.review_status == VisitReviewStatus.pending.value:
+            if (
+                record.review_status == VisitReviewStatus.pending.value
+                and record.status == VisitValidationStatus.approved
+            ):  # Show "pending_review" only if NM approved first
                 status.append("pending_review")
-            else:
+            elif record.review_status in [VisitReviewStatus.agree, VisitReviewStatus.disagree]:
                 status.append(record.review_status)
 
         if record.status in VisitValidationStatus:


### PR DESCRIPTION
## Product Description
if a visit is first approved and then rejected by Nm the review created status (pending review for Pm) icon will not be shown.

## Technical Summary
[CCCT-1344](https://dimagi.atlassian.net/browse/CCCT-1344)

## Safety Assurance

### Safety story
The change is pretty much safe as it touches only the icon part and i have tested it locally.

### QA Plan
No QA

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
