### PR TITLE
Correct URL Parameter Handling for User Visit Export

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -428,7 +428,7 @@ def review_visit_export(request, org_slug, opp_id):
     status = form.cleaned_data["status"]
 
     result = generate_review_visit_export.delay(opp_id, date_range, status, export_format)
-    return redirect(f"{redirect_url}&export_task_id={result.id}")
+    return redirect(f"{redirect_url}?export_task_id={result.id}")
 
 
 @org_member_required


### PR DESCRIPTION
## Product Description
Currently encountering a 404 error when the PM attempts to export user visits. This update resolves the issue.

## Technical Summary
[CI-230](https://dimagi.atlassian.net/browse/CI-230)

## Safety Assurance

### Safety story
Tested locally and verified the export functionality.
Also tried after updating the URL parameter from `&` to `?` on prod. The export works as expected.

### QA Plan
No QA

### Labels & Review
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
