### PR TITLE
Fix - unsupported operand type(s) for /: 'decimal.Decimal' and 'float'

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from decimal import Decimal
 
 import httpx
 import sentry_sdk
@@ -450,5 +451,6 @@ def fetch_exchange_rates(date=None, currency=None):
                 continue
             ExchangeRate.objects.create(currency_code=currency, rate=rate, rate_date=date)
     else:
-        rate = rates[currency]
+        # Parsing it to decimal otherwise the returned object rate will still be in float.
+        rate = Decimal(rates[currency])
         return ExchangeRate.objects.create(currency_code=currency, rate=rate, rate_date=date)


### PR DESCRIPTION
## Product Description
No user facing changes

## Technical Summary
When creating ExchangeRate objects, passing a float value to a DecimalField does not immediately convert it to a Decimal. The in-memory instance retains the original float until it is reloaded from the database.

This behaviour explains why the error: `unsupported operand type(s) for /: 'decimal.Decimal' and 'float'`

occurs in certain cases. It happens only when the exchange rate is not present in our db and is freshly fetched via fetch_exchange_rates(). In such scenarios, the view uses the newly created object directly (where rate is still a float), causing the type mismatch during arithmetic with a Decimal amount.

Verification:
A quick local test confirmed this behaviour:
<img width="1010" height="259" alt="Screenshot 2025-08-29 at 15 22 51" src="https://github.com/user-attachments/assets/ae355e2b-acb3-4705-b147-a5244226baa1" />


## Safety Assurance

### Safety story
The change is pretty safe just explicitly converting value to decimal before saving.

### Automated test coverage
Unlikely

### QA Plan
No QA

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
