### PR TITLE
Update OpportunityClaimLimit end_date

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -628,6 +628,7 @@ class AddBudgetExistingUsersForm(forms.Form):
 
         if end_date:
             OpportunityClaim.objects.filter(pk__in=selected_users).update(end_date=end_date)
+            OpportunityClaimLimit.objects.filter(opportunity_claim__in=selected_users).update(end_date=end_date)
 
 
 class AddBudgetNewUsersForm(forms.Form):

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -46,15 +46,19 @@ def test_add_budget_existing_users(
     ocl = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_units[0], max_visits=10)
     assert opportunity.total_budget == 200
     assert opportunity.claimed_budget == 10
+    end_date = now().date()
 
     url = reverse("opportunity:add_budget_existing_users", args=(organization.slug, opportunity.pk))
     client.force_login(org_user_member)
-    response = client.post(url, data=dict(selected_users=[claim.id], additional_visits=5))
+    response = client.post(url, data=dict(selected_users=[claim.id], additional_visits=5, end_date=end_date))
     assert response.status_code == 302
     opportunity = Opportunity.objects.get(pk=opportunity.pk)
     assert opportunity.total_budget == 205
     assert opportunity.claimed_budget == 15
-    assert OpportunityClaimLimit.objects.get(pk=ocl.pk).max_visits == 15
+    limit = OpportunityClaimLimit.objects.get(pk=ocl.pk)
+    assert limit.max_visits == 15
+    assert limit.opportunity_claim.end_date == end_date
+    assert limit.end_date == end_date
 
 
 def test_add_budget_existing_users_for_managed_opportunity(


### PR DESCRIPTION
## Product Description
No user facing change

## Technical Summary
When the `end_date` of an `OpportunityClaim` is updated, the corresponding end_date in `OpportunityClaimLimit` should also be updated.
[CCCT-915](https://dimagi.atlassian.net/browse/CCCT-915)

## Safety Assurance

### Safety story
Just added a query to update the `end_date` of `OpportunityClaimLimit` so it is pretty much safe.

### Automated test coverage
Updated the tests

### QA Plan
No QA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-915]: https://dimagi.atlassian.net/browse/CCCT-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ