### PR TITLE
Update start_celery

### DIFF
--- a/docker/start_celery
+++ b/docker/start_celery
@@ -4,4 +4,4 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-REMAP_SIGTERM=SIGQUIT celery -A config.celery_app worker -l INFO --concurrency 2 --beat
+REMAP_SIGTERM=SIGQUIT celery -A config.celery_app worker -l INFO --concurrency 2 --max-tasks-per-child 20 --beat


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
We appear to have a memory leak in celery. This [option](https://docs.celeryq.dev/en/stable/reference/cli.html#cmdoption-celery-worker-max-tasks-per-child) restarts celery workers after every 20 tasks to try to reset memory usage.

I am not fully sold this address the root of the problem, but in my testing the most problematic celery tasks took less than 25% of machine memory and we only run two processes, so it feels like something other than bad tasks must be going on. This is generally a recommended first step to deal with celery memory leaks. 20 was chosen somewhat arbitrarily, but I am hoping it is a happy medium between constant restarts, and the memory leaks.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
no code changes

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
