### PR TITLE
Only Show Whole Numbers on Opportunity Dashboard

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -371,14 +371,14 @@ class OpportunityDashboard(OpportunityObjectMixin, OrganizationUserMixin, Detail
             {
                 "name": "Max Connect Workers",
                 "count": header_with_tooltip(
-                    safe_display(object.number_of_users), "Maximum allowed workers in the Opportunity"
+                    safe_display(int(object.number_of_users)), "Maximum allowed workers in the Opportunity"
                 ),
                 "icon": "fa-users",
             },
             {
                 "name": "Max Service Deliveries",
                 "count": header_with_tooltip(
-                    safe_display(object.allotted_visits),
+                    safe_display(int(object.allotted_visits)),
                     "Maximum number of payment units that can be delivered. Each payment unit is a service delivery",
                 ),
                 "icon": "fa-gears",
@@ -2073,7 +2073,7 @@ def opportunity_worker_progress(request, org_slug, opp_id):
                         "Number of Service Deliveries Approved by both PM and NM or Auto-approved",
                     ),
                     "value": header_with_tooltip(
-                        f"{verified_percentage:.2f}%", "Percentage Approved out of Delivered"
+                        f"{verified_percentage:.0f}%", "Percentage Approved out of Delivered"
                     ),
                     "badge_type": True,
                     "percent": verified_percentage,
@@ -2082,7 +2082,7 @@ def opportunity_worker_progress(request, org_slug, opp_id):
                     "title": "Rejected",
                     "total": header_with_tooltip(result.rejected_deliveries, "Number of Service Deliveries Rejected"),
                     "value": header_with_tooltip(
-                        f"{rejected_percentage:.2f}%", "Percentage Rejected out of Delivered"
+                        f"{rejected_percentage:.0f}%", "Percentage Rejected out of Delivered"
                     ),
                     "badge_type": True,
                     "percent": rejected_percentage,
@@ -2096,7 +2096,7 @@ def opportunity_worker_progress(request, org_slug, opp_id):
                     "title": "Earned",
                     "total": header_with_tooltip(amount_with_currency(result.total_accrued), "Earned Amount"),
                     "value": header_with_tooltip(
-                        f"{earned_percentage:.2f}%",
+                        f"{earned_percentage:.0f}%",
                         "Percentage Earned by all workers out of Max Budget in the Opportunity",
                     ),
                     "badge_type": True,
@@ -2108,7 +2108,7 @@ def opportunity_worker_progress(request, org_slug, opp_id):
                         amount_with_currency(result.total_paid), "Paid Amount to All Connect Workers"
                     ),
                     "value": header_with_tooltip(
-                        f"{paid_percentage:.2f}%", "Percentage Paid to all  workers out of Earned amount"
+                        f"{paid_percentage:.0f}%", "Percentage Paid to all  workers out of Earned amount"
                     ),
                     "badge_type": True,
                     "percent": paid_percentage,


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
The following widgets on the opportunity dashboard have been updated to only show whole numbers:
- Max Connect Workers
- Max Service Deliveries
- Approved / Rejected percent values in the "Verification" box
- Earned / Paid percentages in the “Payments to Connect Workers”

**Before:**
<img width="1508" height="89" alt="Screenshot from 2025-09-09 17-37-59" src="https://github.com/user-attachments/assets/3afa62dd-009e-45a4-ae96-ed960c7915d3" />

<img width="1520" height="194" alt="Screenshot from 2025-09-09 17-42-45" src="https://github.com/user-attachments/assets/3a4e933d-d7ff-4c7c-be52-8eca140bf2ad" />

**After:**
<img width="1506" height="85" alt="Screenshot from 2025-09-09 17-37-23" src="https://github.com/user-attachments/assets/a98bf787-a4be-46ee-8c36-4883344390cd" />

<img width="1520" height="194" alt="Screenshot from 2025-09-09 17-43-19" src="https://github.com/user-attachments/assets/d09a2933-a1e4-48a8-bf6d-2c1f4a2155ec" />

The numbers shown on these widgets will always be rounded down.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-1673).

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
