### PR TITLE
update uk sender

### DIFF
--- a/commcare_connect/utils/sms.py
+++ b/commcare_connect/utils/sms.py
@@ -23,7 +23,7 @@ def send_sms(to, body):
 
 
 def get_sms_sender(number):
-    SMS_SENDERS = {"+265": "ConnectID", "+258": "ConnectID"}
+    SMS_SENDERS = {"+265": "ConnectID", "+258": "ConnectID", "+232": "ConnectID", "+44": "ConnectID"}
     for code, sender in SMS_SENDERS.items():
         if number.startswith(code):
             return sender


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Similar connect PR https://github.com/dimagi/connect-id/pull/183

Twilio doesn't support international long codes for SMS to the UK, this changes to use "ConnectID" as the sender.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

We use the same approach for multiple other countries, and SMS are already failing so risk is low.


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
