### PR TITLE
Fix average top paid flws metric to be average instead of sum

### DIFF
--- a/commcare_connect/reports/helpers.py
+++ b/commcare_connect/reports/helpers.py
@@ -198,9 +198,12 @@ def get_table_data_for_year_month(
             sum_total_users[user] += amount
 
         # take atleast 1 top user in cases where this variable is 0
-        top_five_percent_len = len(sum_total_users) // 20 or 1
+        top_five_percent_flw_count = len(sum_total_users) // 20 or 1
         flw_amount_paid = sum(sum_total_users.values())
-        avg_top_paid_flws = sum(sorted(sum_total_users.values(), reverse=True)[:top_five_percent_len])
+        avg_top_paid_flws = (
+            sum(sorted(sum_total_users.values(), reverse=True)[:top_five_percent_flw_count])
+            // top_five_percent_flw_count
+        )
         visit_data_dict[group_key].update(
             {
                 "month_group": datetime.strptime(month_group, "%Y-%m"),


### PR DESCRIPTION
## Product Description
- Fixed average top paid flws metric on Delivery Stats dashboard to be an average instead of a sum.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CI-270)

## Safety Assurance

### Safety story
- Tested Locally

### Automated test coverage
- This code has test coverage.


### QA Plan
- None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
