### PR TITLE
Ce/double save

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -341,7 +341,6 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
 
         if not access.last_active or access.last_active < user_visit.visit_date:
             access.last_active = user_visit.visit_date
-            access.save()
 
         if completed_work is not None:
             if completed_work.completed_count > 0 and completed_work.status == CompletedWorkStatus.incomplete:

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -32,7 +32,7 @@ from commcare_connect.opportunity.models import (
     VisitValidationStatus,
 )
 from commcare_connect.opportunity.tasks import download_user_visit_attachments
-from commcare_connect.opportunity.visit_import import update_payment_accrued
+from commcare_connect.opportunity.visit_import import update_payment_accrued_for_user
 from commcare_connect.users.models import User
 
 LEARN_MODULE_JSONPATH = parse("$..module")
@@ -349,7 +349,7 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
             if completed_work_needs_save:
                 completed_work.save()
 
-    update_payment_accrued(opportunity, [user.id], incremental=True)
+    update_payment_accrued_for_user(access, incremental=True)
     transaction.on_commit(partial(download_user_visit_attachments.delay, user_visit.id))
 
 


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Opportunity access saves are a bottleneck in the form processor which is causing webworker connections to back up and leading to memory problems on those servers, as well as overall slowness. We save the opportunity access twice each time we process a form (and refetch it from the database). This removes one of those saves, while leaving the [later one](https://github.com/dimagi/commcare-connect/blob/main/commcare_connect/opportunity/utils/completed_work.py#L186), called via a [long](https://github.com/dimagi/commcare-connect/blob/main/commcare_connect/form_receiver/processor.py#L353) [chain](https://github.com/dimagi/commcare-connect/blob/main/commcare_connect/opportunity/visit_import.py#L198).

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This does not change the underlying functions, just breaks out a small piece.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
