### PR TITLE
Fix Disabled Invite Buttons

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1068,7 +1068,6 @@ class WorkerStatusTable(tables.Table):
         )
         order_by = ("-last_active",)
         attrs = {
-            "x-data": "connectWorkers()",
             "@change": "updateSelectAll()",
         }
 

--- a/commcare_connect/templates/opportunity/opportunity_worker.html
+++ b/commcare_connect/templates/opportunity/opportunity_worker.html
@@ -11,7 +11,7 @@
     </div>
 </div>
 
-<div class="flex flex-col w-full gap-2">
+<div class="flex flex-col w-full gap-2" x-data="connectWorkers()">
     <!-- Tabs -->
     <div class="flex relative mx-auto items-center justify-between w-full px-4 bg-slate-50 rounded-lg shadow-sm h-14">
     <ul id="tabs" class="tabs">

--- a/commcare_connect/templates/opportunity/workers.html
+++ b/commcare_connect/templates/opportunity/workers.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block tab_options %}
-  <div id="worker-tab-options" x-data="connectWorkers()">
+  <div id="worker-tab-options">
     <button type="button" class="button-icon" @click="showWorkerExportModal = true"
             {% if request.org_membership.is_viewer %} disabled {% endif %}
     >


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
The resend/delete user invite buttons should now correctly become un-disabled when one or more rows are selected.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This PR fixes an issue where the resend/delete user invite buttons on the Connect Workers page would be permanently disabled, even if one or more table rows were selected.

The reason this bug happened is because the table and the buttons each had their own Alpine model instance. So when `selected` got updated from the table it didn't update the `selected` Alpine field for the buttons, leaving them disabled.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA has been done on this feature. This bug was raised as part of QA. Ticket can be found [here](https://dimagi.atlassian.net/browse/QA-8037).

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
