### PR TITLE
Avoid bulk requests on page load.

### DIFF
--- a/commcare_connect/templates/components/worker_page/fetch_flag_counts.html
+++ b/commcare_connect/templates/components/worker_page/fetch_flag_counts.html
@@ -20,7 +20,7 @@
      }"
      x-on:click="isOpen = true; $nextTick(() => { if(isOpen) positionMenu() })"
      hx-get="{{counts_url}}"
-     hx-trigger="load once"
+     hx-trigger="click"
      hx-target="find .flags_counter">
 
     <span class="rounded-lg cursor-pointer hover:bg-slate-200">
@@ -29,9 +29,7 @@
 
     <div x-ref="menu" x-show="isOpen" x-on:click.outside="isOpen = false" x-transition x-cloak
          class="fixed z-40 p-5 text-sm bg-white rounded-lg shadow-md text-brand-deep-purple text-wrap font-normal">
-        <div class="flags_counter"
-             @htmx:after-swap="$refs.menu.style.display = 'initial';
-                               $refs.menu.style.display = 'none';">
+        <div class="flags_counter">
             <p class="text-slate-500">Loading..</p>
         </div>
     </div>


### PR DESCRIPTION
## Product Description
No user facing change

## Technical Summary
This PR addresses an issue on the Deliveries tab where unnecessary bulk requests were being made on page load to fetch flag counts for all delivery rows.

With this update, the UI now lazy-loads flag counts: the API call to fetch a row's flag count is triggered only when the user clicks on the flag count number for that specific cell. This change ensures that only the required data is fetched, significantly reducing the number of API calls and improving performance.

This is what’s happening right now: - [Opp Link prod](https://connect.dimagi.com/a/dimagi-gw-chc-2024-2025/opportunity/411/workers/deliver/?sort=-last_active)
<video width="1719" height="906" src="https://github.com/user-attachments/assets/affa86d2-33cb-4aa9-a609-c59013955a0c" />


After Fix: [Opp Link staging](https://connect-staging.dimagi.com/a/nitins-program/opportunity/180/workers/deliver/?sort=-last_active)
<video width="1719" height="906" src="https://github.com/user-attachments/assets/82ef7977-4b04-41cf-8635-b3441691ce83" />



## Safety Assurance

### Safety story
The change is safe. 
Tested locally and on staging

### Automated test coverage
NA

### QA Plan
No QA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
