### PR TITLE
Models for Connect Credentials

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -9,7 +9,7 @@ from django.db.models import Count, F, Q, Sum
 from django.utils.dateparse import parse_datetime
 from django.utils.functional import cached_property
 from django.utils.timezone import now
-from django.utils.translation import gettext
+from django.utils.translation import gettext, gettext_lazy
 
 from commcare_connect.commcarehq.models import HQServer
 from commcare_connect.organization.models import Organization
@@ -833,3 +833,32 @@ class CatchmentArea(models.Model):
 
     class Meta:
         unique_together = ("site_code", "opportunity")
+
+
+class LearnLevel(models.TextChoices):
+    LEARN_PASSED = "LEARN_PASSED", gettext_lazy("Learning passed")
+
+
+class DeliveryLevel(models.TextChoices):
+    # TODO: Confirm what values should be here
+    pass
+
+
+class CredentialIssuer(models.Model):
+    opportunity = models.ForeignKey(
+        Opportunity,
+        unique=True,
+        on_delete=models.CASCADE,
+    )
+    learn_level = models.CharField(
+        null=True,
+        blank=True,
+        max_length=32,
+        choices=LearnLevel.choices,
+    )
+    delivery_level = models.CharField(
+        null=True,
+        blank=True,
+        max_length=32,
+        choices=DeliveryLevel.choices,
+    )

--- a/commcare_connect/users/models.py
+++ b/commcare_connect/users/models.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from commcare_connect.commcarehq.models import HQServer
+from commcare_connect.opportunity.models import DeliveryLevel, DeliveryType, LearnLevel, Opportunity
 from commcare_connect.users.managers import UserManager
 
 
@@ -71,3 +72,39 @@ class ConnectIDUserLink(models.Model):
 
     class Meta:
         constraints = [models.UniqueConstraint(fields=["user", "commcare_username"], name="connect_user")]
+
+
+# TODO: Confirm what values should be here
+DELIVERY_LEVEL_TO_NUMBER = {}
+
+
+class UserCredential(models.Model):
+    class CredentialType(models.TextChoices):
+        LEARN = "LEARN", _("Learn")
+        DELIVERY = "DELIVERY", _("Deliver")
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    opportunity = models.ForeignKey(Opportunity, on_delete=models.CASCADE)
+    delivery_type = models.ForeignKey(DeliveryType, on_delete=models.CASCADE)
+    created_on = models.DateTimeField(auto_now_add=True)
+    issued_on = models.DateTimeField(null=True, blank=True)
+    credential_type = models.CharField(
+        max_length=32,
+        choices=CredentialType.choices,
+    )
+    level = models.CharField(
+        max_length=32,
+        choices=DeliveryLevel.choices + LearnLevel.choices,
+    )
+
+    class Meta:
+        unique_together = ("user", "opportunity", "credential_type")
+
+    @property
+    def title(self):
+        if self.credential_type == self.CredentialType.LEARN:
+            return _("Passed learning assessment for {delivery_type}").format(delivery_type=self.delivery_type.name)
+        delivery_level_num = DELIVERY_LEVEL_TO_NUMBER.get(self.level)
+        return _("Completed {delivery_level_num} deliveries for {delivery_type}").format(
+            delivery_level_num=delivery_level_num, delivery_type=self.delivery_type.name
+        )


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-1723).

This PR adds two new models which will be used for creating and issuing credentials to workers by an opportunity. Specifically:
- `CredentialIssuer` - The credential issuing settings enabled by a specific opportunity.
- `UserCredential` - A single worker credential that will get submitted to PersonalID.

This PR still has open questions, but opening it in draft so long for any initial review. Please note, that the migration files still needs to be committed, however this will only be done once the open questions are resolved.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Only adds new models.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
