### PR TITLE
Add user name field to OpportunityUserData export API

### DIFF
--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -52,6 +52,7 @@ class ProgramDataExportSerializer(serializers.ModelSerializer):
 
 class OpportunityUserDataSerializer(serializers.Serializer):
     username = serializers.CharField()
+    name = serializers.CharField()
     phone = serializers.CharField()
     date_learn_started = serializers.DateTimeField()
     user_invite_status = serializers.CharField()

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -137,6 +137,7 @@ class OpportunityUserDataView(OpportunityScopedDataView):
     def get_queryset(self, request, opp_id):
         return OpportunityAccess.objects.filter(opportunity=self.opportunity).annotate(
             username=F("user__username"),
+            name=F("user__name"),
             phone=F("user__phone_number"),
             user_invite_status=F("userinvite__status"),
             date_claimed=F("opportunityclaim__date_claimed"),


### PR DESCRIPTION
- Add 'name' field to OpportunityUserDataSerializer
- Annotate queryset with user__name in OpportunityUserDataView
- Provides actual user name alongside username in exports

Adds the user's actual name (from `user.name`) to the OpportunityUserData export API alongside the existing username field.

## Changes
- Added `name` field to `OpportunityUserDataSerializer`
- Annotated queryset with `user__name` in `OpportunityUserDataView`

This provides more complete user information in data exports without requiring additional API calls.