### PR TITLE
Incorrect Accrued Payment Calculation Due to exclude Usage on CompletedWork

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -429,9 +429,7 @@ def bulk_update_payment_accrued(opportunity_id, user_ids: list):
     access_objects = OpportunityAccess.objects.filter(opportunity=opportunity_id, user__in=user_ids, suspended=False)
     for access in access_objects:
         with cache.lock(f"update_payment_accrued_lock_{access.id}", timeout=900):
-            completed_works = access.completedwork_set.exclude(status=CompletedWorkStatus.rejected).select_related(
-                "payment_unit"
-            )
+            completed_works = access.completedwork_set.select_related("payment_unit")
             update_status(completed_works, access, compute_payment=True)
 
 


### PR DESCRIPTION
## Technical Summary

While debugging an interrupt issue, I identified a bug in how accrued payments are calculated.

When a visit is initially marked as rejected, the corresponding CompletedWork record is also marked as rejected. However, if the visit is later approved through the visit import workflow, the CompletedWork record is not updated accordingly. Because the queryset excludes rejected records.

This results in inconsistencies between the visit status and the CompletedWork status, leading to inaccurate payment accruals. The bulk approval/reject UI flow does not apply this exclusion logic, which further introduces inconsistent behavior between the two flows.

To ensure consistency across both flows and to correctly include updated records in the accrual calculation, I have removed the exclusion condition from the queryset.

## Safety Assurance

### Safety story
I’ve removed the exclude filter, as the payment accrual method already handles these scenarios correctly. Given its existing logic and safeguards, I’m confident this change is safe and maintains the intended behaviour.

### Automated test coverage
Already exisit

### QA Plan
No QA

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
