### PR TITLE
feat: Creation APIs for Programs, Opportunities, and related resources

### DIFF
--- a/commcare_connect/opportunity/api/lookups.py
+++ b/commcare_connect/opportunity/api/lookups.py
@@ -1,0 +1,43 @@
+from rest_framework import serializers, viewsets
+from rest_framework.permissions import IsAuthenticated
+
+from commcare_connect.opportunity.models import Country, Currency, DeliveryType
+
+
+class DeliveryTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DeliveryType
+        fields = ["id", "name", "slug", "description"]
+
+
+class CurrencySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Currency
+        fields = ["code", "name"]
+
+
+class CountrySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Country
+        fields = ["code", "name", "currency"]
+
+
+class DeliveryTypeViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = DeliveryType.objects.all()
+    serializer_class = DeliveryTypeSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = None
+
+
+class CurrencyViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Currency.objects.order_by("code")
+    serializer_class = CurrencySerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = None
+
+
+class CountryViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Country.objects.order_by("name")
+    serializer_class = CountrySerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = None

--- a/commcare_connect/opportunity/api/permissions.py
+++ b/commcare_connect/opportunity/api/permissions.py
@@ -1,0 +1,68 @@
+from rest_framework.permissions import IsAuthenticated
+
+from commcare_connect.organization.models import UserOrganizationMembership
+
+
+class IsOrgProgramManagerAdmin(IsAuthenticated):
+    """
+    Allows access only to authenticated users who are admins of a
+    program_manager organization. The organization is determined from:
+    1. URL kwargs ('org_slug')
+    2. Request data ('organization' field as slug)
+    3. Request query params ('organization')
+    """
+
+    def _get_org_slug(self, request, view):
+        org_slug = view.kwargs.get("org_slug")
+        if org_slug:
+            return org_slug
+        return request.data.get("organization") or request.query_params.get("organization")
+
+    def has_permission(self, request, view):
+        if not super().has_permission(request, view):
+            return False
+
+        org_slug = self._get_org_slug(request, view)
+        if not org_slug:
+            return False
+
+        try:
+            membership = UserOrganizationMembership.objects.select_related("organization").get(
+                user=request.user,
+                organization__slug=org_slug,
+            )
+        except UserOrganizationMembership.DoesNotExist:
+            return False
+
+        return membership.is_admin and membership.organization.program_manager
+
+
+class IsOrgAdmin(IsAuthenticated):
+    """
+    Allows access to authenticated users who are admins of the organization
+    identified by 'organization' slug in request data or URL kwargs.
+    """
+
+    def _get_org_slug(self, request, view):
+        org_slug = view.kwargs.get("org_slug")
+        if org_slug:
+            return org_slug
+        return request.data.get("organization") or request.query_params.get("organization")
+
+    def has_permission(self, request, view):
+        if not super().has_permission(request, view):
+            return False
+
+        org_slug = self._get_org_slug(request, view)
+        if not org_slug:
+            return False
+
+        try:
+            membership = UserOrganizationMembership.objects.get(
+                user=request.user,
+                organization__slug=org_slug,
+            )
+        except UserOrganizationMembership.DoesNotExist:
+            return False
+
+        return membership.is_admin

--- a/commcare_connect/opportunity/api/permissions.py
+++ b/commcare_connect/opportunity/api/permissions.py
@@ -35,34 +35,3 @@ class IsOrgProgramManagerAdmin(IsAuthenticated):
             return False
 
         return membership.is_admin and membership.organization.program_manager
-
-
-class IsOrgAdmin(IsAuthenticated):
-    """
-    Allows access to authenticated users who are admins of the organization
-    identified by 'organization' slug in request data or URL kwargs.
-    """
-
-    def _get_org_slug(self, request, view):
-        org_slug = view.kwargs.get("org_slug")
-        if org_slug:
-            return org_slug
-        return request.data.get("organization") or request.query_params.get("organization")
-
-    def has_permission(self, request, view):
-        if not super().has_permission(request, view):
-            return False
-
-        org_slug = self._get_org_slug(request, view)
-        if not org_slug:
-            return False
-
-        try:
-            membership = UserOrganizationMembership.objects.get(
-                user=request.user,
-                organization__slug=org_slug,
-            )
-        except UserOrganizationMembership.DoesNotExist:
-            return False
-
-        return membership.is_admin

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -336,3 +336,15 @@ class DeliveryProgressSerializer(serializers.Serializer):
             .annotate(last_visit_date=Max("uservisit__visit_date"))
         )
         return CompletedWorkSerializer(completed_works, many=True).data
+
+
+class InviteUsersSerializer(serializers.Serializer):
+    phone_numbers = serializers.ListField(child=serializers.CharField())
+
+    def validate_phone_numbers(self, phone_numbers):
+        for number in phone_numbers:
+            if not number.startswith("+") or not number[1:].isdigit():
+                raise serializers.ValidationError(
+                    "Phone numbers must contain only digits and include the country code starting with '+'."
+                )
+        return phone_numbers

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -9,6 +9,7 @@ from commcare_connect.opportunity.models import (
     CompletedModule,
     CompletedWork,
     CompletedWorkStatus,
+    DeliverUnit,
     LearnModule,
     Opportunity,
     OpportunityAccess,
@@ -71,6 +72,12 @@ class PaymentUnitCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         validated_data["opportunity"] = self.context["opportunity"]
         return super().create(validated_data)
+
+
+class DeliverUnitCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DeliverUnit
+        fields = ["slug", "name", "payment_unit", "app", "optional"]
 
 
 class OpportunityClaimLimitSerializer(serializers.ModelSerializer):

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -63,6 +63,16 @@ class PaymentUnitSerializer(serializers.ModelSerializer):
         fields = ["id", "payment_unit_id", "name", "max_total", "max_daily", "amount", "end_date"]
 
 
+class PaymentUnitCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PaymentUnit
+        fields = ["name", "description", "amount", "org_amount", "max_total", "max_daily", "start_date", "end_date"]
+
+    def create(self, validated_data):
+        validated_data["opportunity"] = self.context["opportunity"]
+        return super().create(validated_data)
+
+
 class OpportunityClaimLimitSerializer(serializers.ModelSerializer):
     payment_unit_id = serializers.UUIDField(
         source="payment_unit.payment_unit_id",

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -85,6 +85,12 @@ class DeliverUnitCreateSerializer(serializers.ModelSerializer):
         model = DeliverUnit
         fields = ["slug", "name", "payment_unit", "app", "optional"]
 
+    def validate_payment_unit(self, payment_unit):
+        opportunity = self.context.get("opportunity")
+        if opportunity and payment_unit.opportunity_id != opportunity.id:
+            raise serializers.ValidationError("Payment unit does not belong to this opportunity.")
+        return payment_unit
+
 
 class OpportunityClaimLimitSerializer(serializers.ModelSerializer):
     payment_unit_id = serializers.UUIDField(

--- a/commcare_connect/opportunity/api/serializers.py
+++ b/commcare_connect/opportunity/api/serializers.py
@@ -74,6 +74,12 @@ class PaymentUnitCreateSerializer(serializers.ModelSerializer):
         return super().create(validated_data)
 
 
+class DeliverUnitReadSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DeliverUnit
+        fields = ["id", "slug", "name", "payment_unit", "app", "optional"]
+
+
 class DeliverUnitCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = DeliverUnit

--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -20,6 +20,7 @@ from commcare_connect.opportunity.api.serializers import (
     CompletedWorkSerializer,
     DeliverUnitCreateSerializer,
     DeliveryProgressSerializer,
+    InviteUsersSerializer,
     OpportunitySerializer,
     PaymentUnitCreateSerializer,
     PaymentUnitSerializer,
@@ -35,6 +36,7 @@ from commcare_connect.opportunity.models import (
     Payment,
     PaymentUnit,
 )
+from commcare_connect.opportunity.tasks import add_connect_users
 from commcare_connect.users.helpers import create_hq_user_and_link
 from commcare_connect.users.models import User
 from commcare_connect.utils.db import get_object_or_list_by_uuid_or_int
@@ -237,3 +239,16 @@ class DeliverUnitViewSet(viewsets.ModelViewSet):
         return DeliverUnit.objects.filter(
             payment_unit__opportunity__opportunity_id=self.kwargs["opportunity_id"]
         ).order_by("pk")
+
+
+class InviteUsersView(APIView):
+    permission_classes = [IsAuthenticated, TokenHasScope, IsOrgProgramManagerAdmin]
+    required_scopes = ["create"]
+
+    def post(self, request, opportunity_id):
+        opportunity = get_object_or_404(Opportunity, opportunity_id=opportunity_id)
+        serializer = InviteUsersSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        phone_numbers = serializer.validated_data["phone_numbers"]
+        add_connect_users.delay(phone_numbers, str(opportunity.pk))
+        return Response({"invited": len(phone_numbers)})

--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -18,6 +18,7 @@ from commcare_connect.flags.switch_names import API_UUID
 from commcare_connect.opportunity.api.permissions import IsOrgProgramManagerAdmin
 from commcare_connect.opportunity.api.serializers import (
     CompletedWorkSerializer,
+    DeliverUnitCreateSerializer,
     DeliveryProgressSerializer,
     OpportunitySerializer,
     PaymentUnitCreateSerializer,
@@ -26,6 +27,7 @@ from commcare_connect.opportunity.api.serializers import (
 )
 from commcare_connect.opportunity.models import (
     CompletedWork,
+    DeliverUnit,
     Opportunity,
     OpportunityAccess,
     OpportunityClaim,
@@ -217,3 +219,21 @@ class PaymentUnitViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return PaymentUnit.objects.filter(opportunity__opportunity_id=self.kwargs["opportunity_id"]).order_by("pk")
+
+
+class DeliverUnitViewSet(viewsets.ModelViewSet):
+    serializer_class = DeliverUnitCreateSerializer
+    permission_classes = [IsAuthenticated, TokenHasScope]
+    required_scopes = ["create"]
+    http_method_names = ["get", "post", "patch", "delete", "head", "options"]
+
+    def get_permissions(self):
+        if self.action in ("create", "partial_update", "destroy"):
+            return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
+        return [IsAuthenticated(), TokenHasScope()]
+
+    def get_queryset(self):
+        """Filter deliver units by those linked to payment units of this opportunity."""
+        return DeliverUnit.objects.filter(
+            payment_unit__opportunity__opportunity_id=self.kwargs["opportunity_id"]
+        ).order_by("pk")

--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -221,7 +221,18 @@ class PaymentUnitViewSet(viewsets.ModelViewSet):
         return context
 
     def get_queryset(self):
-        return PaymentUnit.objects.filter(opportunity__opportunity_id=self.kwargs["opportunity_id"]).order_by("pk")
+        user = self.request.user
+        return (
+            PaymentUnit.objects.filter(
+                opportunity__opportunity_id=self.kwargs["opportunity_id"],
+            )
+            .filter(
+                Q(opportunity__organization__memberships__user=user)
+                | Q(opportunity__managedopportunity__program__organization__memberships__user=user)
+            )
+            .distinct()
+            .order_by("pk")
+        )
 
 
 class DeliverUnitViewSet(viewsets.ModelViewSet):
@@ -240,11 +251,29 @@ class DeliverUnitViewSet(viewsets.ModelViewSet):
             return DeliverUnitCreateSerializer
         return DeliverUnitReadSerializer
 
+    def get_opportunity(self):
+        return get_object_or_404(Opportunity, opportunity_id=self.kwargs["opportunity_id"])
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.kwargs.get("opportunity_id"):
+            context["opportunity"] = self.get_opportunity()
+        return context
+
     def get_queryset(self):
         """Filter deliver units by those linked to payment units of this opportunity."""
-        return DeliverUnit.objects.filter(
-            payment_unit__opportunity__opportunity_id=self.kwargs["opportunity_id"]
-        ).order_by("pk")
+        user = self.request.user
+        return (
+            DeliverUnit.objects.filter(
+                payment_unit__opportunity__opportunity_id=self.kwargs["opportunity_id"],
+            )
+            .filter(
+                Q(payment_unit__opportunity__organization__memberships__user=user)
+                | Q(payment_unit__opportunity__managedopportunity__program__organization__memberships__user=user)
+            )
+            .distinct()
+            .order_by("pk")
+        )
 
 
 class InviteUsersView(APIView):
@@ -253,6 +282,11 @@ class InviteUsersView(APIView):
 
     def post(self, request, opportunity_id):
         opportunity = get_object_or_404(Opportunity, opportunity_id=opportunity_id)
+        if opportunity.has_ended:
+            return Response(
+                {"error": "This opportunity has ended. You cannot invite more workers."},
+                status=400,
+            )
         serializer = InviteUsersSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         phone_numbers = serializer.validated_data["phone_numbers"]

--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -8,7 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 from oauth2_provider.contrib.rest_framework.permissions import TokenHasScope
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -195,8 +195,23 @@ class ConfirmPaymentsView(APIView):
         return confirm_payments(request, request.user, request.data.get("payments", []))
 
 
-class PaymentUnitViewSet(viewsets.ModelViewSet):
+class ReadSerializerResponseMixin:
+    """Return the read serializer in create/update responses instead of the write serializer."""
+
+    read_serializer_class = None
+
+    def create(self, request, *args, **kwargs):
+        write_serializer = self.get_serializer(data=request.data)
+        write_serializer.is_valid(raise_exception=True)
+        self.perform_create(write_serializer)
+        read_serializer = self.read_serializer_class(write_serializer.instance, context=self.get_serializer_context())
+        headers = self.get_success_headers(read_serializer.data)
+        return Response(read_serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class PaymentUnitViewSet(ReadSerializerResponseMixin, viewsets.ModelViewSet):
     serializer_class = PaymentUnitSerializer
+    read_serializer_class = PaymentUnitSerializer
     permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]
@@ -235,8 +250,9 @@ class PaymentUnitViewSet(viewsets.ModelViewSet):
         )
 
 
-class DeliverUnitViewSet(viewsets.ModelViewSet):
+class DeliverUnitViewSet(ReadSerializerResponseMixin, viewsets.ModelViewSet):
     serializer_class = DeliverUnitReadSerializer
+    read_serializer_class = DeliverUnitReadSerializer
     permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]

--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -19,6 +19,7 @@ from commcare_connect.opportunity.api.permissions import IsOrgProgramManagerAdmi
 from commcare_connect.opportunity.api.serializers import (
     CompletedWorkSerializer,
     DeliverUnitCreateSerializer,
+    DeliverUnitReadSerializer,
     DeliveryProgressSerializer,
     InviteUsersSerializer,
     OpportunitySerializer,
@@ -196,14 +197,14 @@ class ConfirmPaymentsView(APIView):
 
 class PaymentUnitViewSet(viewsets.ModelViewSet):
     serializer_class = PaymentUnitSerializer
-    permission_classes = [IsAuthenticated, TokenHasScope]
+    permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]
 
     def get_permissions(self):
         if self.action in ("create", "partial_update", "destroy"):
             return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
-        return [IsAuthenticated(), TokenHasScope()]
+        return [IsAuthenticated()]
 
     def get_serializer_class(self):
         if self.action in ("create", "partial_update"):
@@ -224,15 +225,20 @@ class PaymentUnitViewSet(viewsets.ModelViewSet):
 
 
 class DeliverUnitViewSet(viewsets.ModelViewSet):
-    serializer_class = DeliverUnitCreateSerializer
-    permission_classes = [IsAuthenticated, TokenHasScope]
+    serializer_class = DeliverUnitReadSerializer
+    permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]
 
     def get_permissions(self):
         if self.action in ("create", "partial_update", "destroy"):
             return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
-        return [IsAuthenticated(), TokenHasScope()]
+        return [IsAuthenticated()]
+
+    def get_serializer_class(self):
+        if self.action in ("create", "partial_update"):
+            return DeliverUnitCreateSerializer
+        return DeliverUnitReadSerializer
 
     def get_queryset(self):
         """Filter deliver units by those linked to payment units of this opportunity."""
@@ -243,7 +249,7 @@ class DeliverUnitViewSet(viewsets.ModelViewSet):
 
 class InviteUsersView(APIView):
     permission_classes = [IsAuthenticated, TokenHasScope, IsOrgProgramManagerAdmin]
-    required_scopes = ["create"]
+    required_scopes = ["create"]  # POST-only view, always requires create scope
 
     def post(self, request, opportunity_id):
         opportunity = get_object_or_404(Opportunity, opportunity_id=opportunity_id)

--- a/commcare_connect/opportunity/api/views.py
+++ b/commcare_connect/opportunity/api/views.py
@@ -5,7 +5,9 @@ import waffle
 from django.db import transaction
 from django.db.models import Q
 from django.http import Http404
+from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
+from oauth2_provider.contrib.rest_framework.permissions import TokenHasScope
 from rest_framework import viewsets
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -13,10 +15,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from commcare_connect.flags.switch_names import API_UUID
+from commcare_connect.opportunity.api.permissions import IsOrgProgramManagerAdmin
 from commcare_connect.opportunity.api.serializers import (
     CompletedWorkSerializer,
     DeliveryProgressSerializer,
     OpportunitySerializer,
+    PaymentUnitCreateSerializer,
+    PaymentUnitSerializer,
     UserLearnProgressSerializer,
 )
 from commcare_connect.opportunity.models import (
@@ -26,6 +31,7 @@ from commcare_connect.opportunity.models import (
     OpportunityClaim,
     OpportunityClaimLimit,
     Payment,
+    PaymentUnit,
 )
 from commcare_connect.users.helpers import create_hq_user_and_link
 from commcare_connect.users.models import User
@@ -182,3 +188,32 @@ class ConfirmPaymentsView(APIView):
 
     def post(self, request, *args, **kwargs):
         return confirm_payments(request, request.user, request.data.get("payments", []))
+
+
+class PaymentUnitViewSet(viewsets.ModelViewSet):
+    serializer_class = PaymentUnitSerializer
+    permission_classes = [IsAuthenticated, TokenHasScope]
+    required_scopes = ["create"]
+    http_method_names = ["get", "post", "patch", "delete", "head", "options"]
+
+    def get_permissions(self):
+        if self.action in ("create", "partial_update", "destroy"):
+            return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
+        return [IsAuthenticated(), TokenHasScope()]
+
+    def get_serializer_class(self):
+        if self.action in ("create", "partial_update"):
+            return PaymentUnitCreateSerializer
+        return PaymentUnitSerializer
+
+    def get_opportunity(self):
+        return get_object_or_404(Opportunity, opportunity_id=self.kwargs["opportunity_id"])
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.kwargs.get("opportunity_id"):
+            context["opportunity"] = self.get_opportunity()
+        return context
+
+    def get_queryset(self):
+        return PaymentUnit.objects.filter(opportunity__opportunity_id=self.kwargs["opportunity_id"]).order_by("pk")

--- a/commcare_connect/opportunity/tests/test_creation_api.py
+++ b/commcare_connect/opportunity/tests/test_creation_api.py
@@ -4,6 +4,7 @@ import pytest
 from django.utils.timezone import now
 from rest_framework.test import APIClient
 
+from commcare_connect.opportunity.models import DeliveryType
 from commcare_connect.organization.models import Organization
 from commcare_connect.users.models import User
 
@@ -87,3 +88,37 @@ class TestOrgPermissions:
             format="json",
         )
         assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestLookupEndpoints:
+    def test_list_delivery_types(self, api_client: APIClient, program_manager_org_user_admin: User):
+        DeliveryType.objects.create(name="Direct Delivery", slug="direct-delivery", description="Direct")
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.get("/api/lookups/delivery_types/")
+        assert response.status_code == 200
+        assert len(response.data) >= 1
+        assert "id" in response.data[0]
+        assert "name" in response.data[0]
+        assert "slug" in response.data[0]
+
+    def test_list_currencies(self, api_client: APIClient, program_manager_org_user_admin: User):
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.get("/api/lookups/currencies/")
+        assert response.status_code == 200
+        assert len(response.data) >= 1
+        assert "code" in response.data[0]
+        assert "name" in response.data[0]
+
+    def test_list_countries(self, api_client: APIClient, program_manager_org_user_admin: User):
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.get("/api/lookups/countries/")
+        assert response.status_code == 200
+        assert len(response.data) >= 1
+        assert "code" in response.data[0]
+        assert "name" in response.data[0]
+        assert "currency" in response.data[0]
+
+    def test_lookups_unauthenticated(self, api_client: APIClient):
+        response = api_client.get("/api/lookups/delivery_types/")
+        assert response.status_code == 401

--- a/commcare_connect/opportunity/tests/test_creation_api.py
+++ b/commcare_connect/opportunity/tests/test_creation_api.py
@@ -170,9 +170,7 @@ def managed_opp_setup(program_manager_org, program_manager_org_user_admin):
 
 @pytest.mark.django_db
 class TestPaymentUnitAPI:
-    def test_create_payment_unit(
-        self, api_client: APIClient, program_manager_org_user_admin: User, managed_opp_setup
-    ):
+    def test_create_payment_unit(self, api_client: APIClient, program_manager_org_user_admin: User, managed_opp_setup):
         opp = managed_opp_setup
         _add_create_credentials(api_client, program_manager_org_user_admin)
         response = api_client.post(
@@ -191,9 +189,7 @@ class TestPaymentUnitAPI:
         assert response.status_code == 201, response.data
         assert PaymentUnit.objects.filter(opportunity=opp, name="Per Visit").exists()
 
-    def test_list_payment_units(
-        self, api_client: APIClient, program_manager_org_user_admin: User, managed_opp_setup
-    ):
+    def test_list_payment_units(self, api_client: APIClient, program_manager_org_user_admin: User, managed_opp_setup):
         opp = managed_opp_setup
         PaymentUnit.objects.create(
             opportunity=opp, name="Unit 1", description="test", amount=10, max_total=10, max_daily=5
@@ -201,6 +197,49 @@ class TestPaymentUnitAPI:
         _add_create_credentials(api_client, program_manager_org_user_admin)
         response = api_client.get(
             f"/api/opportunity/{opp.opportunity_id}/payment_units/?organization={opp.program.organization.slug}"
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+
+@pytest.mark.django_db
+class TestDeliverUnitAPI:
+    @pytest.fixture
+    def opp_with_payment_unit(self, managed_opp_setup):
+        opp = managed_opp_setup
+        pu = PaymentUnit.objects.create(
+            opportunity=opp, name="Per Visit", description="test", amount=10, max_total=10, max_daily=5
+        )
+        return opp, pu
+
+    def test_create_deliver_unit(
+        self, api_client: APIClient, program_manager_org_user_admin: User, opp_with_payment_unit
+    ):
+        opp, pu = opp_with_payment_unit
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/opportunity/{opp.opportunity_id}/deliver_units/",
+            {
+                "slug": "form_1",
+                "name": "Home Visit Form",
+                "payment_unit": pu.id,
+                "app": opp.deliver_app.id,
+                "optional": False,
+                "organization": opp.program.organization.slug,
+            },
+            format="json",
+        )
+        assert response.status_code == 201, response.data
+        assert DeliverUnit.objects.filter(slug="form_1", payment_unit=pu).exists()
+
+    def test_list_deliver_units(
+        self, api_client: APIClient, program_manager_org_user_admin: User, opp_with_payment_unit
+    ):
+        opp, pu = opp_with_payment_unit
+        DeliverUnit.objects.create(app=opp.deliver_app, slug="form_1", name="Form 1", payment_unit=pu)
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.get(
+            f"/api/opportunity/{opp.opportunity_id}/deliver_units/?organization={opp.program.organization.slug}"
         )
         assert response.status_code == 200
         assert len(response.data) == 1

--- a/commcare_connect/opportunity/tests/test_creation_api.py
+++ b/commcare_connect/opportunity/tests/test_creation_api.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 import pytest
 from django.utils.timezone import now
@@ -243,3 +244,50 @@ class TestDeliverUnitAPI:
         )
         assert response.status_code == 200
         assert len(response.data) == 1
+
+
+@pytest.mark.django_db
+class TestInviteUsersAPI:
+    @pytest.fixture
+    def active_opp(self, managed_opp_setup):
+        """Set up a fully configured opportunity with payment units."""
+        opp = managed_opp_setup
+        PaymentUnit.objects.create(
+            opportunity=opp, name="Per Visit", description="test", amount=10, max_total=10, max_daily=5
+        )
+        opp.active = True
+        opp.save()
+        return opp
+
+    @patch("commcare_connect.opportunity.api.views.add_connect_users")
+    def test_invite_users_success(
+        self, mock_add_users, api_client: APIClient, program_manager_org_user_admin: User, active_opp
+    ):
+        opp = active_opp
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/opportunity/{opp.opportunity_id}/invite/",
+            {
+                "phone_numbers": ["+1234567890", "+0987654321"],
+                "organization": opp.program.organization.slug,
+            },
+            format="json",
+        )
+        assert response.status_code == 200, response.data
+        assert response.data["invited"] == 2
+        mock_add_users.delay.assert_called_once_with(["+1234567890", "+0987654321"], str(opp.pk))
+
+    def test_invite_invalid_phone_number(
+        self, api_client: APIClient, program_manager_org_user_admin: User, active_opp
+    ):
+        opp = active_opp
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/opportunity/{opp.opportunity_id}/invite/",
+            {
+                "phone_numbers": ["not-a-number"],
+                "organization": opp.program.organization.slug,
+            },
+            format="json",
+        )
+        assert response.status_code == 400

--- a/commcare_connect/opportunity/tests/test_creation_api.py
+++ b/commcare_connect/opportunity/tests/test_creation_api.py
@@ -1,0 +1,89 @@
+import datetime
+
+import pytest
+from django.utils.timezone import now
+from rest_framework.test import APIClient
+
+from commcare_connect.organization.models import Organization
+from commcare_connect.users.models import User
+
+
+def _add_create_credentials(api_client, user):
+    """Add OAuth token with 'create' scope to the API client. Mirrors _add_export_credentials pattern."""
+    token, _ = user.oauth2_provider_accesstoken.get_or_create(
+        token=f"create-token-{user.pk}",
+        scope="read write create",
+        defaults={"expires": now() + datetime.timedelta(hours=1)},
+    )
+    api_client.credentials(Authorization=f"Bearer {token}")
+
+
+@pytest.mark.django_db
+class TestOrgPermissions:
+    def test_unauthenticated_rejected(self, api_client: APIClient):
+        response = api_client.get("/api/lookups/delivery_types/")
+        assert response.status_code == 401
+
+    def test_no_create_scope_rejected(
+        self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
+    ):
+        """Token without 'create' scope cannot access creation endpoints."""
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.post(
+            "/api/program/",
+            {
+                "name": "Test",
+                "description": "Test",
+                "delivery_type": 1,
+                "budget": 1000,
+                "currency": "USD",
+                "country": "USA",
+                "start_date": "2026-01-01",
+                "end_date": "2026-12-31",
+                "organization": program_manager_org.slug,
+            },
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_non_pm_org_rejected(self, api_client: APIClient, org_user_admin: User, organization: Organization):
+        """Non-program-manager org admin cannot access creation endpoints."""
+        _add_create_credentials(api_client, org_user_admin)
+        response = api_client.post(
+            "/api/program/",
+            {
+                "name": "Test",
+                "description": "Test",
+                "delivery_type": 1,
+                "budget": 1000,
+                "currency": "USD",
+                "country": "USA",
+                "start_date": "2026-01-01",
+                "end_date": "2026-12-31",
+                "organization": organization.slug,
+            },
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_member_role_rejected(
+        self, api_client: APIClient, program_manager_org_user_member: User, program_manager_org: Organization
+    ):
+        """Member (not admin) of PM org cannot access creation endpoints."""
+        _add_create_credentials(api_client, program_manager_org_user_member)
+        response = api_client.post(
+            "/api/program/",
+            {
+                "name": "Test",
+                "description": "Test",
+                "delivery_type": 1,
+                "budget": 1000,
+                "currency": "USD",
+                "country": "USA",
+                "start_date": "2026-01-01",
+                "end_date": "2026-12-31",
+                "organization": program_manager_org.slug,
+            },
+            format="json",
+        )
+        assert response.status_code == 403

--- a/commcare_connect/opportunity/tests/test_creation_api.py
+++ b/commcare_connect/opportunity/tests/test_creation_api.py
@@ -4,9 +4,14 @@ import pytest
 from django.utils.timezone import now
 from rest_framework.test import APIClient
 
-from commcare_connect.opportunity.models import DeliveryType
+from commcare_connect.commcarehq.tests.factories import HQServerFactory
+from commcare_connect.opportunity.models import DeliverUnit, DeliveryType, PaymentUnit
+from commcare_connect.opportunity.tests.factories import CommCareAppFactory
 from commcare_connect.organization.models import Organization
+from commcare_connect.program.models import ManagedOpportunity, ProgramApplication, ProgramApplicationStatus
+from commcare_connect.program.tests.factories import ProgramFactory
 from commcare_connect.users.models import User
+from commcare_connect.users.tests.factories import OrganizationFactory
 
 
 def _add_create_credentials(api_client, user):
@@ -122,3 +127,80 @@ class TestLookupEndpoints:
     def test_lookups_unauthenticated(self, api_client: APIClient):
         response = api_client.get("/api/lookups/delivery_types/")
         assert response.status_code == 401
+
+
+@pytest.fixture
+def managed_opp_setup(program_manager_org, program_manager_org_user_admin):
+    """Module-level fixture: creates a fully configured ManagedOpportunity for testing."""
+    from commcare_connect.opportunity.models import Country, Currency
+
+    dt = DeliveryType.objects.create(name="Direct PU", slug="direct-pu", description="Direct")
+    currency = Currency.objects.get_or_create(code="USD", defaults={"name": "US Dollar"})[0]
+    country = Country.objects.get_or_create(code="USA", defaults={"name": "USA", "currency": currency})[0]
+    program = ProgramFactory(organization=program_manager_org, delivery_type=dt, currency=currency, country=country)
+    nm_org = OrganizationFactory()
+    ProgramApplication.objects.create(
+        program=program,
+        organization=nm_org,
+        status=ProgramApplicationStatus.ACCEPTED,
+        created_by="test@test.com",
+        modified_by="test@test.com",
+    )
+    hq_server = HQServerFactory()
+    opp = ManagedOpportunity.objects.create(
+        name="Test Opp",
+        description="test",
+        program=program,
+        organization=nm_org,
+        currency=currency,
+        country=country,
+        delivery_type=dt,
+        managed=True,
+        start_date="2026-01-01",
+        end_date="2026-12-31",
+        total_budget=50000,
+        created_by="test@test.com",
+        modified_by="test@test.com",
+        learn_app=CommCareAppFactory(organization=nm_org, hq_server=hq_server),
+        deliver_app=CommCareAppFactory(organization=nm_org, hq_server=hq_server),
+        hq_server=hq_server,
+    )
+    return opp
+
+
+@pytest.mark.django_db
+class TestPaymentUnitAPI:
+    def test_create_payment_unit(
+        self, api_client: APIClient, program_manager_org_user_admin: User, managed_opp_setup
+    ):
+        opp = managed_opp_setup
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/opportunity/{opp.opportunity_id}/payment_units/",
+            {
+                "name": "Per Visit",
+                "description": "Payment per visit",
+                "amount": 100,
+                "org_amount": 20,
+                "max_total": 50,
+                "max_daily": 5,
+                "organization": opp.program.organization.slug,
+            },
+            format="json",
+        )
+        assert response.status_code == 201, response.data
+        assert PaymentUnit.objects.filter(opportunity=opp, name="Per Visit").exists()
+
+    def test_list_payment_units(
+        self, api_client: APIClient, program_manager_org_user_admin: User, managed_opp_setup
+    ):
+        opp = managed_opp_setup
+        PaymentUnit.objects.create(
+            opportunity=opp, name="Unit 1", description="test", amount=10, max_total=10, max_daily=5
+        )
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.get(
+            f"/api/opportunity/{opp.opportunity_id}/payment_units/?organization={opp.program.organization.slug}"
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1

--- a/commcare_connect/opportunity/tests/test_creation_api.py
+++ b/commcare_connect/opportunity/tests/test_creation_api.py
@@ -195,10 +195,8 @@ class TestPaymentUnitAPI:
         PaymentUnit.objects.create(
             opportunity=opp, name="Unit 1", description="test", amount=10, max_total=10, max_daily=5
         )
-        _add_create_credentials(api_client, program_manager_org_user_admin)
-        response = api_client.get(
-            f"/api/opportunity/{opp.opportunity_id}/payment_units/?organization={opp.program.organization.slug}"
-        )
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.get(f"/api/opportunity/{opp.opportunity_id}/payment_units/")
         assert response.status_code == 200
         assert len(response.data) == 1
 
@@ -238,12 +236,12 @@ class TestDeliverUnitAPI:
     ):
         opp, pu = opp_with_payment_unit
         DeliverUnit.objects.create(app=opp.deliver_app, slug="form_1", name="Form 1", payment_unit=pu)
-        _add_create_credentials(api_client, program_manager_org_user_admin)
-        response = api_client.get(
-            f"/api/opportunity/{opp.opportunity_id}/deliver_units/?organization={opp.program.organization.slug}"
-        )
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.get(f"/api/opportunity/{opp.opportunity_id}/deliver_units/")
         assert response.status_code == 200
         assert len(response.data) == 1
+        assert "id" in response.data[0]
+        assert "slug" in response.data[0]
 
 
 @pytest.mark.django_db

--- a/commcare_connect/program/api/serializers.py
+++ b/commcare_connect/program/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from commcare_connect.organization.models import Organization
-from commcare_connect.program.models import Program
+from commcare_connect.program.models import ManagedOpportunity, Program, ProgramApplication, ProgramApplicationStatus
 
 
 class ProgramCreateSerializer(serializers.ModelSerializer):
@@ -51,6 +51,78 @@ class ProgramReadSerializer(serializers.ModelSerializer):
             "start_date",
             "end_date",
             "organization",
+            "date_created",
+            "date_modified",
+        ]
+
+
+class ManagedOpportunityCreateSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="slug", queryset=Organization.objects.all())
+
+    class Meta:
+        model = ManagedOpportunity
+        fields = [
+            "name",
+            "description",
+            "short_description",
+            "organization",
+            "learn_app",
+            "deliver_app",
+            "start_date",
+            "end_date",
+            "total_budget",
+            "api_key",
+        ]
+
+    def validate_organization(self, org):
+        program = self.context["program"]
+        accepted = ProgramApplication.objects.filter(
+            program=program, organization=org, status=ProgramApplicationStatus.ACCEPTED
+        ).exists()
+        if not accepted:
+            raise serializers.ValidationError("Organization must be an accepted member of the program.")
+        return org
+
+    def validate(self, data):
+        if data.get("end_date") and data.get("start_date") and data["end_date"] <= data["start_date"]:
+            raise serializers.ValidationError({"end_date": "End date must be after the start date."})
+        return data
+
+    def create(self, validated_data):
+        program = self.context["program"]
+        user = self.context["request"].user
+        validated_data["program"] = program
+        validated_data["currency"] = program.currency
+        validated_data["country"] = program.country
+        validated_data["delivery_type"] = program.delivery_type
+        validated_data["managed"] = True
+        validated_data["created_by"] = user.email
+        validated_data["modified_by"] = user.email
+        return super().create(validated_data)
+
+
+class ManagedOpportunityReadSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="slug", read_only=True)
+
+    class Meta:
+        model = ManagedOpportunity
+        fields = [
+            "id",
+            "opportunity_id",
+            "name",
+            "description",
+            "short_description",
+            "organization",
+            "learn_app",
+            "deliver_app",
+            "start_date",
+            "end_date",
+            "total_budget",
+            "currency",
+            "country",
+            "delivery_type",
+            "active",
+            "managed",
             "date_created",
             "date_modified",
         ]

--- a/commcare_connect/program/api/serializers.py
+++ b/commcare_connect/program/api/serializers.py
@@ -126,3 +126,43 @@ class ManagedOpportunityReadSerializer(serializers.ModelSerializer):
             "date_created",
             "date_modified",
         ]
+
+
+class ProgramApplicationCreateSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="slug", queryset=Organization.objects.all())
+
+    class Meta:
+        model = ProgramApplication
+        fields = ["organization"]
+
+    def validate_organization(self, org):
+        program = self.context["program"]
+        if org == program.organization:
+            raise serializers.ValidationError("Cannot invite the program manager's own organization.")
+        if ProgramApplication.objects.filter(program=program, organization=org).exists():
+            raise serializers.ValidationError("This organization has already been invited to this program.")
+        return org
+
+    def create(self, validated_data):
+        program = self.context["program"]
+        user = self.context["request"].user
+        validated_data["program"] = program
+        validated_data["status"] = ProgramApplicationStatus.INVITED
+        validated_data["created_by"] = user.email
+        validated_data["modified_by"] = user.email
+        return super().create(validated_data)
+
+
+class ProgramApplicationReadSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="slug", read_only=True)
+
+    class Meta:
+        model = ProgramApplication
+        fields = [
+            "id",
+            "program_application_id",
+            "organization",
+            "status",
+            "date_created",
+            "date_modified",
+        ]

--- a/commcare_connect/program/api/serializers.py
+++ b/commcare_connect/program/api/serializers.py
@@ -1,0 +1,56 @@
+from rest_framework import serializers
+
+from commcare_connect.organization.models import Organization
+from commcare_connect.program.models import Program
+
+
+class ProgramCreateSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="slug", queryset=Organization.objects.all())
+
+    class Meta:
+        model = Program
+        fields = [
+            "name",
+            "description",
+            "delivery_type",
+            "budget",
+            "currency",
+            "country",
+            "start_date",
+            "end_date",
+            "organization",
+        ]
+
+    def validate(self, data):
+        if data.get("end_date") and data.get("start_date") and data["end_date"] <= data["start_date"]:
+            raise serializers.ValidationError({"end_date": "End date must be after the start date."})
+        return data
+
+    def create(self, validated_data):
+        user = self.context["request"].user
+        validated_data["created_by"] = user.email
+        validated_data["modified_by"] = user.email
+        return super().create(validated_data)
+
+
+class ProgramReadSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="slug", read_only=True)
+
+    class Meta:
+        model = Program
+        fields = [
+            "id",
+            "program_id",
+            "name",
+            "slug",
+            "description",
+            "delivery_type",
+            "budget",
+            "currency",
+            "country",
+            "start_date",
+            "end_date",
+            "organization",
+            "date_created",
+            "date_modified",
+        ]

--- a/commcare_connect/program/api/views.py
+++ b/commcare_connect/program/api/views.py
@@ -17,14 +17,14 @@ from commcare_connect.program.models import ManagedOpportunity, Program, Program
 
 class ProgramViewSet(viewsets.ModelViewSet):
     serializer_class = ProgramReadSerializer
-    permission_classes = [IsAuthenticated, TokenHasScope]
+    permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "head", "options"]
 
     def get_permissions(self):
         if self.action in ("create", "partial_update"):
             return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
-        return [IsAuthenticated(), TokenHasScope()]
+        return [IsAuthenticated()]
 
     def get_serializer_class(self):
         if self.action in ("create", "partial_update"):
@@ -32,16 +32,16 @@ class ProgramViewSet(viewsets.ModelViewSet):
         return ProgramReadSerializer
 
     def get_queryset(self):
-        qs = Program.objects.all()
+        qs = Program.objects.filter(organization__memberships__user=self.request.user)
         org_slug = self.request.query_params.get("organization")
         if org_slug:
             qs = qs.filter(organization__slug=org_slug)
-        return qs.order_by("-start_date")
+        return qs.distinct().order_by("-start_date")
 
 
 class ManagedOpportunityViewSet(viewsets.ModelViewSet):
     serializer_class = ManagedOpportunityReadSerializer
-    permission_classes = [IsAuthenticated, TokenHasScope]
+    permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "head", "options"]
 
@@ -58,7 +58,7 @@ class ManagedOpportunityViewSet(viewsets.ModelViewSet):
     def get_permissions(self):
         if self.action in ("create", "partial_update"):
             return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
-        return [IsAuthenticated(), TokenHasScope()]
+        return [IsAuthenticated()]
 
     def get_serializer_class(self):
         if self.action in ("create", "partial_update"):
@@ -82,7 +82,7 @@ class ManagedOpportunityViewSet(viewsets.ModelViewSet):
 
 class ProgramApplicationViewSet(viewsets.ModelViewSet):
     serializer_class = ProgramApplicationReadSerializer
-    permission_classes = [IsAuthenticated, TokenHasScope]
+    permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "head", "options"]
 
@@ -99,7 +99,7 @@ class ProgramApplicationViewSet(viewsets.ModelViewSet):
     def get_permissions(self):
         if self.action == "create":
             return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
-        return [IsAuthenticated(), TokenHasScope()]
+        return [IsAuthenticated()]
 
     def get_serializer_class(self):
         if self.action == "create":

--- a/commcare_connect/program/api/views.py
+++ b/commcare_connect/program/api/views.py
@@ -4,6 +4,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from commcare_connect.opportunity.api.permissions import IsOrgProgramManagerAdmin
+from commcare_connect.opportunity.api.views import ReadSerializerResponseMixin
 from commcare_connect.program.api.serializers import (
     ManagedOpportunityCreateSerializer,
     ManagedOpportunityReadSerializer,
@@ -15,8 +16,9 @@ from commcare_connect.program.api.serializers import (
 from commcare_connect.program.models import ManagedOpportunity, Program, ProgramApplication
 
 
-class ProgramViewSet(viewsets.ModelViewSet):
+class ProgramViewSet(ReadSerializerResponseMixin, viewsets.ModelViewSet):
     serializer_class = ProgramReadSerializer
+    read_serializer_class = ProgramReadSerializer
     permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "head", "options"]
@@ -59,8 +61,9 @@ class ProgramNestedViewMixin:
         return context
 
 
-class ManagedOpportunityViewSet(ProgramNestedViewMixin, viewsets.ModelViewSet):
+class ManagedOpportunityViewSet(ReadSerializerResponseMixin, ProgramNestedViewMixin, viewsets.ModelViewSet):
     serializer_class = ManagedOpportunityReadSerializer
+    read_serializer_class = ManagedOpportunityReadSerializer
     permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "patch", "head", "options"]
@@ -82,8 +85,9 @@ class ManagedOpportunityViewSet(ProgramNestedViewMixin, viewsets.ModelViewSet):
         ).order_by("-date_created")
 
 
-class ProgramApplicationViewSet(ProgramNestedViewMixin, viewsets.ModelViewSet):
+class ProgramApplicationViewSet(ReadSerializerResponseMixin, ProgramNestedViewMixin, viewsets.ModelViewSet):
     serializer_class = ProgramApplicationReadSerializer
+    read_serializer_class = ProgramApplicationReadSerializer
     permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "head", "options"]

--- a/commcare_connect/program/api/views.py
+++ b/commcare_connect/program/api/views.py
@@ -7,10 +7,12 @@ from commcare_connect.opportunity.api.permissions import IsOrgProgramManagerAdmi
 from commcare_connect.program.api.serializers import (
     ManagedOpportunityCreateSerializer,
     ManagedOpportunityReadSerializer,
+    ProgramApplicationCreateSerializer,
+    ProgramApplicationReadSerializer,
     ProgramCreateSerializer,
     ProgramReadSerializer,
 )
-from commcare_connect.program.models import ManagedOpportunity, Program
+from commcare_connect.program.models import ManagedOpportunity, Program, ProgramApplication
 
 
 class ProgramViewSet(viewsets.ModelViewSet):
@@ -74,5 +76,46 @@ class ManagedOpportunityViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return ManagedOpportunity.objects.filter(program__program_id=self.kwargs["program_id"]).order_by(
+            "-date_created"
+        )
+
+
+class ProgramApplicationViewSet(viewsets.ModelViewSet):
+    serializer_class = ProgramApplicationReadSerializer
+    permission_classes = [IsAuthenticated, TokenHasScope]
+    required_scopes = ["create"]
+    http_method_names = ["get", "post", "head", "options"]
+
+    def initial(self, request, *args, **kwargs):
+        """Inject PM org slug for permission checking."""
+        if self.kwargs.get("program_id"):
+            try:
+                program = Program.objects.get(program_id=self.kwargs["program_id"])
+                self.kwargs["org_slug"] = program.organization.slug
+            except Program.DoesNotExist:
+                pass
+        super().initial(request, *args, **kwargs)
+
+    def get_permissions(self):
+        if self.action == "create":
+            return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
+        return [IsAuthenticated(), TokenHasScope()]
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return ProgramApplicationCreateSerializer
+        return ProgramApplicationReadSerializer
+
+    def get_program(self):
+        return get_object_or_404(Program, program_id=self.kwargs["program_id"])
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.kwargs.get("program_id"):
+            context["program"] = self.get_program()
+        return context
+
+    def get_queryset(self):
+        return ProgramApplication.objects.filter(program__program_id=self.kwargs["program_id"]).order_by(
             "-date_created"
         )

--- a/commcare_connect/program/api/views.py
+++ b/commcare_connect/program/api/views.py
@@ -1,0 +1,31 @@
+from oauth2_provider.contrib.rest_framework.permissions import TokenHasScope
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+
+from commcare_connect.opportunity.api.permissions import IsOrgProgramManagerAdmin
+from commcare_connect.program.api.serializers import ProgramCreateSerializer, ProgramReadSerializer
+from commcare_connect.program.models import Program
+
+
+class ProgramViewSet(viewsets.ModelViewSet):
+    serializer_class = ProgramReadSerializer
+    permission_classes = [IsAuthenticated, TokenHasScope]
+    required_scopes = ["create"]
+    http_method_names = ["get", "post", "patch", "head", "options"]
+
+    def get_permissions(self):
+        if self.action in ("create", "partial_update"):
+            return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
+        return [IsAuthenticated(), TokenHasScope()]
+
+    def get_serializer_class(self):
+        if self.action in ("create", "partial_update"):
+            return ProgramCreateSerializer
+        return ProgramReadSerializer
+
+    def get_queryset(self):
+        qs = Program.objects.all()
+        org_slug = self.request.query_params.get("organization")
+        if org_slug:
+            qs = qs.filter(organization__slug=org_slug)
+        return qs.order_by("-start_date")

--- a/commcare_connect/program/api/views.py
+++ b/commcare_connect/program/api/views.py
@@ -39,21 +39,31 @@ class ProgramViewSet(viewsets.ModelViewSet):
         return qs.distinct().order_by("-start_date")
 
 
-class ManagedOpportunityViewSet(viewsets.ModelViewSet):
-    serializer_class = ManagedOpportunityReadSerializer
-    permission_classes = [IsAuthenticated]
-    required_scopes = ["create"]
-    http_method_names = ["get", "post", "patch", "head", "options"]
+class ProgramNestedViewMixin:
+    """Shared logic for viewsets nested under a Program."""
 
     def initial(self, request, *args, **kwargs):
         """Inject PM org slug for permission checking on nested program routes."""
         if self.kwargs.get("program_id"):
-            try:
-                program = Program.objects.get(program_id=self.kwargs["program_id"])
-                self.kwargs["org_slug"] = program.organization.slug
-            except Program.DoesNotExist:
-                pass
+            program = get_object_or_404(Program, program_id=self.kwargs["program_id"])
+            self.kwargs["org_slug"] = program.organization.slug
         super().initial(request, *args, **kwargs)
+
+    def get_program(self):
+        return get_object_or_404(Program, program_id=self.kwargs["program_id"])
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.kwargs.get("program_id"):
+            context["program"] = self.get_program()
+        return context
+
+
+class ManagedOpportunityViewSet(ProgramNestedViewMixin, viewsets.ModelViewSet):
+    serializer_class = ManagedOpportunityReadSerializer
+    permission_classes = [IsAuthenticated]
+    required_scopes = ["create"]
+    http_method_names = ["get", "post", "patch", "head", "options"]
 
     def get_permissions(self):
         if self.action in ("create", "partial_update"):
@@ -65,36 +75,18 @@ class ManagedOpportunityViewSet(viewsets.ModelViewSet):
             return ManagedOpportunityCreateSerializer
         return ManagedOpportunityReadSerializer
 
-    def get_program(self):
-        return get_object_or_404(Program, program_id=self.kwargs["program_id"])
-
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        if self.kwargs.get("program_id"):
-            context["program"] = self.get_program()
-        return context
-
     def get_queryset(self):
-        return ManagedOpportunity.objects.filter(program__program_id=self.kwargs["program_id"]).order_by(
-            "-date_created"
-        )
+        return ManagedOpportunity.objects.filter(
+            program__program_id=self.kwargs["program_id"],
+            program__organization__memberships__user=self.request.user,
+        ).order_by("-date_created")
 
 
-class ProgramApplicationViewSet(viewsets.ModelViewSet):
+class ProgramApplicationViewSet(ProgramNestedViewMixin, viewsets.ModelViewSet):
     serializer_class = ProgramApplicationReadSerializer
     permission_classes = [IsAuthenticated]
     required_scopes = ["create"]
     http_method_names = ["get", "post", "head", "options"]
-
-    def initial(self, request, *args, **kwargs):
-        """Inject PM org slug for permission checking."""
-        if self.kwargs.get("program_id"):
-            try:
-                program = Program.objects.get(program_id=self.kwargs["program_id"])
-                self.kwargs["org_slug"] = program.organization.slug
-            except Program.DoesNotExist:
-                pass
-        super().initial(request, *args, **kwargs)
 
     def get_permissions(self):
         if self.action == "create":
@@ -106,16 +98,8 @@ class ProgramApplicationViewSet(viewsets.ModelViewSet):
             return ProgramApplicationCreateSerializer
         return ProgramApplicationReadSerializer
 
-    def get_program(self):
-        return get_object_or_404(Program, program_id=self.kwargs["program_id"])
-
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        if self.kwargs.get("program_id"):
-            context["program"] = self.get_program()
-        return context
-
     def get_queryset(self):
-        return ProgramApplication.objects.filter(program__program_id=self.kwargs["program_id"]).order_by(
-            "-date_created"
-        )
+        return ProgramApplication.objects.filter(
+            program__program_id=self.kwargs["program_id"],
+            program__organization__memberships__user=self.request.user,
+        ).order_by("-date_created")

--- a/commcare_connect/program/api/views.py
+++ b/commcare_connect/program/api/views.py
@@ -1,10 +1,16 @@
+from django.shortcuts import get_object_or_404
 from oauth2_provider.contrib.rest_framework.permissions import TokenHasScope
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from commcare_connect.opportunity.api.permissions import IsOrgProgramManagerAdmin
-from commcare_connect.program.api.serializers import ProgramCreateSerializer, ProgramReadSerializer
-from commcare_connect.program.models import Program
+from commcare_connect.program.api.serializers import (
+    ManagedOpportunityCreateSerializer,
+    ManagedOpportunityReadSerializer,
+    ProgramCreateSerializer,
+    ProgramReadSerializer,
+)
+from commcare_connect.program.models import ManagedOpportunity, Program
 
 
 class ProgramViewSet(viewsets.ModelViewSet):
@@ -29,3 +35,44 @@ class ProgramViewSet(viewsets.ModelViewSet):
         if org_slug:
             qs = qs.filter(organization__slug=org_slug)
         return qs.order_by("-start_date")
+
+
+class ManagedOpportunityViewSet(viewsets.ModelViewSet):
+    serializer_class = ManagedOpportunityReadSerializer
+    permission_classes = [IsAuthenticated, TokenHasScope]
+    required_scopes = ["create"]
+    http_method_names = ["get", "post", "patch", "head", "options"]
+
+    def initial(self, request, *args, **kwargs):
+        """Inject PM org slug for permission checking on nested program routes."""
+        if self.kwargs.get("program_id"):
+            try:
+                program = Program.objects.get(program_id=self.kwargs["program_id"])
+                self.kwargs["org_slug"] = program.organization.slug
+            except Program.DoesNotExist:
+                pass
+        super().initial(request, *args, **kwargs)
+
+    def get_permissions(self):
+        if self.action in ("create", "partial_update"):
+            return [IsAuthenticated(), TokenHasScope(), IsOrgProgramManagerAdmin()]
+        return [IsAuthenticated(), TokenHasScope()]
+
+    def get_serializer_class(self):
+        if self.action in ("create", "partial_update"):
+            return ManagedOpportunityCreateSerializer
+        return ManagedOpportunityReadSerializer
+
+    def get_program(self):
+        return get_object_or_404(Program, program_id=self.kwargs["program_id"])
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.kwargs.get("program_id"):
+            context["program"] = self.get_program()
+        return context
+
+    def get_queryset(self):
+        return ManagedOpportunity.objects.filter(program__program_id=self.kwargs["program_id"]).order_by(
+            "-date_created"
+        )

--- a/commcare_connect/program/tests/test_creation_api.py
+++ b/commcare_connect/program/tests/test_creation_api.py
@@ -4,11 +4,14 @@ import pytest
 from django.utils.timezone import now
 from rest_framework.test import APIClient
 
-from commcare_connect.opportunity.models import DeliveryType
+from commcare_connect.commcarehq.tests.factories import HQServerFactory
+from commcare_connect.opportunity.models import Country, Currency, DeliveryType
+from commcare_connect.opportunity.tests.factories import CommCareAppFactory, HQApiKeyFactory
 from commcare_connect.organization.models import Organization
-from commcare_connect.program.models import Program
+from commcare_connect.program.models import ManagedOpportunity, Program, ProgramApplication, ProgramApplicationStatus
 from commcare_connect.program.tests.factories import ProgramFactory
 from commcare_connect.users.models import User
+from commcare_connect.users.tests.factories import OrganizationFactory
 
 
 def _add_create_credentials(api_client, user):
@@ -88,3 +91,104 @@ class TestListPrograms:
         response = api_client.get(f"/api/program/?organization={program_manager_org.slug}")
         assert response.status_code == 200
         assert len(response.data) == 1
+
+
+@pytest.mark.django_db
+class TestCreateManagedOpportunity:
+    @pytest.fixture
+    def setup_program_with_nm(self, program_manager_org, program_manager_org_user_admin):
+        dt = DeliveryType.objects.create(name="Direct", slug="direct-mo", description="Direct")
+        currency = Currency.objects.get_or_create(code="USD", defaults={"name": "US Dollar"})[0]
+        country = Country.objects.get_or_create(code="USA", defaults={"name": "USA", "currency": currency})[0]
+        program = Program.objects.create(
+            name="Test Program",
+            description="Test",
+            delivery_type=dt,
+            budget=100000,
+            currency=currency,
+            country=country,
+            start_date="2026-01-01",
+            end_date="2026-12-31",
+            organization=program_manager_org,
+            created_by=program_manager_org_user_admin.email,
+            modified_by=program_manager_org_user_admin.email,
+        )
+        nm_org = OrganizationFactory()
+        ProgramApplication.objects.create(
+            program=program,
+            organization=nm_org,
+            status=ProgramApplicationStatus.ACCEPTED,
+            created_by="test@test.com",
+            modified_by="test@test.com",
+        )
+        return program, nm_org
+
+    def test_create_managed_opportunity_success(
+        self,
+        api_client: APIClient,
+        program_manager_org_user_admin: User,
+        program_manager_org: Organization,
+        setup_program_with_nm,
+    ):
+        program, nm_org = setup_program_with_nm
+        hq_server = HQServerFactory()
+        api_key = HQApiKeyFactory(hq_server=hq_server, user=program_manager_org_user_admin)
+        learn_app = CommCareAppFactory(organization=nm_org, hq_server=hq_server)
+        deliver_app = CommCareAppFactory(organization=nm_org, hq_server=hq_server)
+
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/program/{program.program_id}/opportunity/",
+            {
+                "name": "Test Opp",
+                "description": "A test opportunity",
+                "short_description": "Test",
+                "organization": nm_org.slug,
+                "learn_app": learn_app.id,
+                "deliver_app": deliver_app.id,
+                "start_date": "2026-04-01",
+                "end_date": "2026-12-31",
+                "total_budget": 50000,
+                "api_key": api_key.id,
+            },
+            format="json",
+        )
+        assert response.status_code == 201, response.data
+        opp = ManagedOpportunity.objects.get(name="Test Opp")
+        assert opp.program == program
+        assert opp.organization == nm_org
+        assert opp.currency == program.currency
+        assert opp.delivery_type == program.delivery_type
+        assert opp.managed is True
+
+    def test_create_managed_opportunity_non_accepted_org_fails(
+        self,
+        api_client: APIClient,
+        program_manager_org_user_admin: User,
+        program_manager_org: Organization,
+        setup_program_with_nm,
+    ):
+        program, nm_org = setup_program_with_nm
+        other_org = OrganizationFactory()
+        hq_server = HQServerFactory()
+        api_key = HQApiKeyFactory(hq_server=hq_server, user=program_manager_org_user_admin)
+        learn_app = CommCareAppFactory(organization=other_org, hq_server=hq_server)
+        deliver_app = CommCareAppFactory(organization=other_org, hq_server=hq_server)
+
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/program/{program.program_id}/opportunity/",
+            {
+                "name": "Test Opp",
+                "description": "A test opportunity",
+                "organization": other_org.slug,
+                "learn_app": learn_app.id,
+                "deliver_app": deliver_app.id,
+                "start_date": "2026-04-01",
+                "end_date": "2026-12-31",
+                "total_budget": 50000,
+                "api_key": api_key.id,
+            },
+            format="json",
+        )
+        assert response.status_code == 400

--- a/commcare_connect/program/tests/test_creation_api.py
+++ b/commcare_connect/program/tests/test_creation_api.py
@@ -192,3 +192,68 @@ class TestCreateManagedOpportunity:
             format="json",
         )
         assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestProgramApplicationAPI:
+    @pytest.fixture
+    def program_setup(self, program_manager_org, program_manager_org_user_admin):
+        program = ProgramFactory(organization=program_manager_org)
+        return program
+
+    def test_invite_org_to_program(
+        self,
+        api_client: APIClient,
+        program_manager_org_user_admin: User,
+        program_manager_org: Organization,
+        program_setup,
+    ):
+        program = program_setup
+        target_org = OrganizationFactory()
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/program/{program.program_id}/applications/",
+            {"organization": target_org.slug},
+            format="json",
+        )
+        assert response.status_code == 201, response.data
+        assert ProgramApplication.objects.filter(
+            program=program, organization=target_org, status=ProgramApplicationStatus.INVITED
+        ).exists()
+
+    def test_cannot_invite_own_org(
+        self,
+        api_client: APIClient,
+        program_manager_org_user_admin: User,
+        program_manager_org: Organization,
+        program_setup,
+    ):
+        program = program_setup
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/program/{program.program_id}/applications/",
+            {"organization": program_manager_org.slug},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    def test_list_applications(
+        self,
+        api_client: APIClient,
+        program_manager_org_user_admin: User,
+        program_manager_org: Organization,
+        program_setup,
+    ):
+        program = program_setup
+        target_org = OrganizationFactory()
+        ProgramApplication.objects.create(
+            program=program,
+            organization=target_org,
+            status=ProgramApplicationStatus.INVITED,
+            created_by="test@test.com",
+            modified_by="test@test.com",
+        )
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.get(f"/api/program/{program.program_id}/applications/")
+        assert response.status_code == 200
+        assert len(response.data) == 1

--- a/commcare_connect/program/tests/test_creation_api.py
+++ b/commcare_connect/program/tests/test_creation_api.py
@@ -1,0 +1,90 @@
+import datetime
+
+import pytest
+from django.utils.timezone import now
+from rest_framework.test import APIClient
+
+from commcare_connect.opportunity.models import DeliveryType
+from commcare_connect.organization.models import Organization
+from commcare_connect.program.models import Program
+from commcare_connect.program.tests.factories import ProgramFactory
+from commcare_connect.users.models import User
+
+
+def _add_create_credentials(api_client, user):
+    """Add OAuth token with 'create' scope to the API client."""
+    token, _ = user.oauth2_provider_accesstoken.get_or_create(
+        token=f"create-token-{user.pk}",
+        scope="read write create",
+        defaults={"expires": now() + datetime.timedelta(hours=1)},
+    )
+    api_client.credentials(Authorization=f"Bearer {token}")
+
+
+@pytest.mark.django_db
+class TestCreateProgram:
+    def _payload(self, org, delivery_type_id):
+        return {
+            "name": "Test Program",
+            "description": "A test program",
+            "delivery_type": delivery_type_id,
+            "budget": 50000,
+            "currency": "USD",
+            "country": "USA",
+            "start_date": "2026-04-01",
+            "end_date": "2026-12-31",
+            "organization": org.slug,
+        }
+
+    def test_create_program_success(
+        self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
+    ):
+        dt = DeliveryType.objects.create(name="Direct", slug="direct", description="Direct delivery")
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post("/api/program/", self._payload(program_manager_org, dt.id), format="json")
+        assert response.status_code == 201
+        assert Program.objects.filter(name="Test Program").exists()
+        program = Program.objects.get(name="Test Program")
+        assert program.organization == program_manager_org
+        assert program.slug
+
+    def test_create_program_non_pm_org_forbidden(
+        self, api_client: APIClient, org_user_admin: User, organization: Organization
+    ):
+        dt = DeliveryType.objects.create(name="Direct", slug="direct", description="Direct delivery")
+        _add_create_credentials(api_client, org_user_admin)
+        response = api_client.post("/api/program/", self._payload(organization, dt.id), format="json")
+        assert response.status_code == 403
+
+    def test_create_program_missing_fields(
+        self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
+    ):
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post(
+            "/api/program/", {"name": "Incomplete", "organization": program_manager_org.slug}, format="json"
+        )
+        assert response.status_code == 400
+
+    def test_create_program_end_date_before_start(
+        self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
+    ):
+        dt = DeliveryType.objects.create(name="Direct", slug="direct", description="Direct delivery")
+        payload = self._payload(program_manager_org, dt.id)
+        payload["start_date"] = "2026-12-31"
+        payload["end_date"] = "2026-01-01"
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.post("/api/program/", payload, format="json")
+        assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestListPrograms:
+    def test_list_programs_for_pm_org(
+        self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
+    ):
+        ProgramFactory(organization=program_manager_org)
+        ProgramFactory()
+        _add_create_credentials(api_client, program_manager_org_user_admin)
+        response = api_client.get(f"/api/program/?organization={program_manager_org.slug}")
+        assert response.status_code == 200
+        assert len(response.data) == 1

--- a/commcare_connect/program/tests/test_creation_api.py
+++ b/commcare_connect/program/tests/test_creation_api.py
@@ -82,15 +82,33 @@ class TestCreateProgram:
 
 @pytest.mark.django_db
 class TestListPrograms:
-    def test_list_programs_for_pm_org(
+    def test_list_programs_scoped_to_user_orgs(
         self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
     ):
         ProgramFactory(organization=program_manager_org)
-        ProgramFactory()
-        _add_create_credentials(api_client, program_manager_org_user_admin)
+        ProgramFactory()  # different org - user has no membership, should not appear
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.get("/api/program/")
+        assert response.status_code == 200
+        assert len(response.data) == 1  # only sees programs from their own org
+
+    def test_list_programs_filtered_by_org(
+        self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
+    ):
+        ProgramFactory(organization=program_manager_org)
+        api_client.force_authenticate(program_manager_org_user_admin)
         response = api_client.get(f"/api/program/?organization={program_manager_org.slug}")
         assert response.status_code == 200
         assert len(response.data) == 1
+
+    def test_list_programs_no_scope_required_for_read(
+        self, api_client: APIClient, program_manager_org_user_admin: User, program_manager_org: Organization
+    ):
+        """GET requests don't require the 'create' OAuth scope - just authentication."""
+        ProgramFactory(organization=program_manager_org)
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.get("/api/program/")
+        assert response.status_code == 200
 
 
 @pytest.mark.django_db
@@ -253,7 +271,7 @@ class TestProgramApplicationAPI:
             created_by="test@test.com",
             modified_by="test@test.com",
         )
-        _add_create_credentials(api_client, program_manager_org_user_admin)
+        api_client.force_authenticate(program_manager_org_user_admin)
         response = api_client.get(f"/api/program/{program.program_id}/applications/")
         assert response.status_code == 200
         assert len(response.data) == 1

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -10,6 +10,7 @@ from commcare_connect.opportunity.api.views import (
     ConfirmPaymentView,
     DeliverUnitViewSet,
     DeliveryProgressView,
+    InviteUsersView,
     OpportunityViewSet,
     PaymentUnitViewSet,
     UserLearnProgressView,
@@ -60,4 +61,5 @@ urlpatterns = [
     path("opportunity/<slug:pk>/delivery_progress", DeliveryProgressView.as_view(), name="deliver_progress"),
     path("payment/<slug:pk>/confirm", ConfirmPaymentView.as_view(), name="confirm_payment"),
     path("payment/confirm", ConfirmPaymentsView.as_view(), name="confirm_payments"),
+    path("opportunity/<slug:opportunity_id>/invite/", InviteUsersView.as_view(), name="invite_users"),
 ]

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -15,7 +15,7 @@ from commcare_connect.opportunity.api.views import (
     UserLearnProgressView,
     UserVisitViewSet,
 )
-from commcare_connect.program.api.views import ManagedOpportunityViewSet, ProgramViewSet
+from commcare_connect.program.api.views import ManagedOpportunityViewSet, ProgramApplicationViewSet, ProgramViewSet
 from commcare_connect.users.api.views import UserViewSet
 
 if settings.DEBUG:
@@ -44,6 +44,11 @@ router.register(
     "program/(?P<program_id>[^/.]+)/opportunity",
     ManagedOpportunityViewSet,
     basename="ManagedOpportunity",
+)
+router.register(
+    "program/(?P<program_id>[^/.]+)/applications",
+    ProgramApplicationViewSet,
+    basename="ProgramApplication",
 )
 
 app_name = "api"

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -13,6 +13,7 @@ from commcare_connect.opportunity.api.views import (
     UserLearnProgressView,
     UserVisitViewSet,
 )
+from commcare_connect.program.api.views import ProgramViewSet
 from commcare_connect.users.api.views import UserViewSet
 
 if settings.DEBUG:
@@ -26,6 +27,7 @@ router.register("opportunity/(?P<opportunity_id>.+)/user_visit", UserVisitViewSe
 router.register("lookups/delivery_types", DeliveryTypeViewSet, basename="DeliveryType")
 router.register("lookups/currencies", CurrencyViewSet, basename="Currency")
 router.register("lookups/countries", CountryViewSet, basename="Country")
+router.register("program", ProgramViewSet, basename="Program")
 
 app_name = "api"
 urlpatterns = [

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -13,7 +13,7 @@ from commcare_connect.opportunity.api.views import (
     UserLearnProgressView,
     UserVisitViewSet,
 )
-from commcare_connect.program.api.views import ProgramViewSet
+from commcare_connect.program.api.views import ManagedOpportunityViewSet, ProgramViewSet
 from commcare_connect.users.api.views import UserViewSet
 
 if settings.DEBUG:
@@ -28,6 +28,11 @@ router.register("lookups/delivery_types", DeliveryTypeViewSet, basename="Deliver
 router.register("lookups/currencies", CurrencyViewSet, basename="Currency")
 router.register("lookups/countries", CountryViewSet, basename="Country")
 router.register("program", ProgramViewSet, basename="Program")
+router.register(
+    "program/(?P<program_id>[^/.]+)/opportunity",
+    ManagedOpportunityViewSet,
+    basename="ManagedOpportunity",
+)
 
 app_name = "api"
 urlpatterns = [

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -10,6 +10,7 @@ from commcare_connect.opportunity.api.views import (
     ConfirmPaymentView,
     DeliveryProgressView,
     OpportunityViewSet,
+    PaymentUnitViewSet,
     UserLearnProgressView,
     UserVisitViewSet,
 )
@@ -24,6 +25,11 @@ else:
 router.register("users", UserViewSet)
 router.register("opportunity", OpportunityViewSet, basename="Opportunity")
 router.register("opportunity/(?P<opportunity_id>.+)/user_visit", UserVisitViewSet, basename="UserVisit")
+router.register(
+    "opportunity/(?P<opportunity_id>[^/.]+)/payment_units",
+    PaymentUnitViewSet,
+    basename="PaymentUnit",
+)
 router.register("lookups/delivery_types", DeliveryTypeViewSet, basename="DeliveryType")
 router.register("lookups/currencies", CurrencyViewSet, basename="Currency")
 router.register("lookups/countries", CountryViewSet, basename="Country")

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter, SimpleRouter
 
 from commcare_connect.form_receiver.views import FormReceiver
+from commcare_connect.opportunity.api.lookups import CountryViewSet, CurrencyViewSet, DeliveryTypeViewSet
 from commcare_connect.opportunity.api.views import (
     ClaimOpportunityView,
     ConfirmPaymentsView,
@@ -22,6 +23,9 @@ else:
 router.register("users", UserViewSet)
 router.register("opportunity", OpportunityViewSet, basename="Opportunity")
 router.register("opportunity/(?P<opportunity_id>.+)/user_visit", UserVisitViewSet, basename="UserVisit")
+router.register("lookups/delivery_types", DeliveryTypeViewSet, basename="DeliveryType")
+router.register("lookups/currencies", CurrencyViewSet, basename="Currency")
+router.register("lookups/countries", CountryViewSet, basename="Country")
 
 app_name = "api"
 urlpatterns = [

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -8,6 +8,7 @@ from commcare_connect.opportunity.api.views import (
     ClaimOpportunityView,
     ConfirmPaymentsView,
     ConfirmPaymentView,
+    DeliverUnitViewSet,
     DeliveryProgressView,
     OpportunityViewSet,
     PaymentUnitViewSet,
@@ -29,6 +30,11 @@ router.register(
     "opportunity/(?P<opportunity_id>[^/.]+)/payment_units",
     PaymentUnitViewSet,
     basename="PaymentUnit",
+)
+router.register(
+    "opportunity/(?P<opportunity_id>[^/.]+)/deliver_units",
+    DeliverUnitViewSet,
+    basename="DeliverUnit",
 )
 router.register("lookups/delivery_types", DeliveryTypeViewSet, basename="DeliveryType")
 router.register("lookups/currencies", CurrencyViewSet, basename="Currency")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -386,6 +386,7 @@ OAUTH2_PROVIDER = {
         "read": "Read scope",
         "write": "Write scope",
         "export": "Allow exporting data to other platforms using export API's.",
+        "create": "Allow creating programs, opportunities, and related resources via API.",
     },
     "OAUTH2_VALIDATOR_CLASS": "commcare_connect.users.oauth2_validator.CustomOAuth2Validator",
     "OIDC_ENABLED": True,


### PR DESCRIPTION
## Product Description

Adds REST API endpoints to enable full end-to-end creation of Programs, ManagedOpportunities, PaymentUnits, DeliverUnits, and user invitations — filling the gap where these operations were previously only available through the web UI.

A new `create` OAuth scope gates all write endpoints. Read endpoints require only authentication (no scope), matching the existing `OpportunityViewSet` pattern.

## Technical Summary

**Jira:** CCC-XXX (feature request for Connect team)
**Draft PR:** https://github.com/dimagi/commcare-connect/pull/1070

### New Endpoints

| Method | URL | Auth | Purpose |
|--------|-----|------|---------|
| GET | `/api/lookups/delivery_types/` | IsAuthenticated | List delivery types |
| GET | `/api/lookups/currencies/` | IsAuthenticated | List currencies |
| GET | `/api/lookups/countries/` | IsAuthenticated | List countries |
| GET/POST | `/api/program/` | Read: IsAuth / Write: + create scope + PM admin | List/create programs |
| GET/POST | `/api/program/<id>/opportunity/` | Read: IsAuth / Write: + create scope + PM admin | List/create managed opportunities |
| GET/POST | `/api/program/<id>/applications/` | Read: IsAuth / Write: + create scope + PM admin | List/invite orgs to program |
| GET/POST/DELETE | `/api/opportunity/<id>/payment_units/` | Read: IsAuth / Write: + create scope + PM admin | CRUD payment units |
| GET/POST/DELETE | `/api/opportunity/<id>/deliver_units/` | Read: IsAuth / Write: + create scope + PM admin | CRUD deliver units |
| POST | `/api/opportunity/<id>/invite/` | create scope + PM admin | Invite users by phone number |

### Key Design Decisions

- **OAuth scope**: New `create` scope for writes only (mirrors `export` scope pattern). Reads require only `IsAuthenticated`, matching existing API convention.
- **Permissions**: `IsOrgProgramManagerAdmin` DRF permission class mirrors the existing `org_program_manager_required` decorator. For nested routes (under Program), `initial()` injects the PM org slug from the program for permission checking.
- **Queryset scoping**: All read querysets are scoped to the user's org memberships (direct org membership OR PM org via program), preventing cross-org data leakage.
- **Program inheritance**: ManagedOpportunity auto-inherits currency/country/delivery_type from parent Program.
- **Response format**: `ReadSerializerResponseMixin` ensures POST responses return the full read serializer (with `id`, UUID, `slug`, timestamps) instead of just echoing input fields.
- **Validation**: DeliverUnit validates that `payment_unit` belongs to the URL opportunity. InviteUsers checks `has_ended` before queueing.

### New Files

```
commcare_connect/opportunity/api/permissions.py   - IsOrgProgramManagerAdmin permission class
commcare_connect/opportunity/api/lookups.py       - Lookup viewsets (DeliveryType, Currency, Country)
commcare_connect/program/api/__init__.py          - Package init
commcare_connect/program/api/serializers.py       - Program, ManagedOpp, ProgramApplication serializers
commcare_connect/program/api/views.py             - Program, ManagedOpp, ProgramApplication viewsets
commcare_connect/opportunity/tests/test_creation_api.py - 14 tests
commcare_connect/program/tests/test_creation_api.py     - 12 tests
```

### Safety Story

- All write endpoints require both OAuth `create` scope AND org program manager admin role
- Read querysets scoped to user's org memberships (prevents cross-org enumeration)
- DeliverUnit validates payment_unit FK belongs to same opportunity (prevents cross-opp injection)
- InviteUsers checks opportunity.has_ended (returns 400 instead of silently queueing no-op)
- Non-existent program_id returns 404 (not confusing 403)
- 26 tests covering create, list, permission rejection, validation, and edge cases
- Full existing test suite (696 tests) passes with no regressions
- Stress tested locally against running dev server (full E2E flow)

## QA Plan

- [x] Verify OAuth token with `create` scope can access write endpoints
- [x] Verify OAuth token without `create` scope gets 403 on writes but 200 on reads
- [x] Verify non-PM org admin gets 403 on write endpoints
- [x] Verify unauthenticated requests get 401
- [x] Test full creation flow: Program -> ProgramApplication -> ManagedOpportunity -> PaymentUnit -> DeliverUnit -> Invite
- [x] Verify POST responses include full read serializer (id, UUID, slug, timestamps)
- [x] Verify invite to ended opportunity returns 400
- [ ] Verify cross-org queryset scoping (user from org A cannot read org B's resources)

🤖 Generated with [Claude Code](https://claude.ai/code)