### PR TITLE
check nested versions for released status in CommCare app fetch

### DIFF
--- a/commcare_connect/utils/commcarehq_api.py
+++ b/commcare_connect/utils/commcarehq_api.py
@@ -111,7 +111,11 @@ async def _get_commcare_app_json(client, domain):
 
     for application in data.get("objects", []):
         app_name = application.get("name")
-        if not application.get("is_released"):
+        # The top-level app object is always a draft (is_released=False).
+        # Released builds are nested inside 'versions', so we check there.
+        versions = application.get("versions", [])
+        is_released = any(v.get("is_released") for v in versions)
+        if not is_released:
             app_name = f"Unreleased - {app_name}"
         applications.append({"id": application.get("id"), "name": app_name})
     return applications


### PR DESCRIPTION
## Product Description
When viewing the list of CommCare apps for an opportunity, all apps were showing as "Unreleased" even when they had published builds. This fix ensures apps with at least one released build are correctly labeled, giving users an accurate view of which apps are live.

<img width="625" height="456" alt="Screenshot 2026-04-07 at 6 32 09 PM" src="https://github.com/user-attachments/assets/3a90d9cb-262a-4690-9c28-d9d8710826be" />


## Technical Summary
https://dimagi.atlassian.net/browse/CI-605

The CommCare HQ API returns app objects where the top-level `is_released` field always reflects draft status. The actual released builds live in a nested `versions` array. The code was only checking the top-level field, so every app was marked as unreleased. This change looks inside `versions` to determine if any build is released before applying the "Unreleased" label.

## Safety Assurance

### Safety story

The change is narrow and isolated to the function that fetches and labels CommCare apps. It only affects how the app name is displayed — no data is written or modified. The logic is a straightforward check on data already returned by the API.

### QA Plan
Not needed

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
