### PR TITLE
fix: add --forwarded-allow-ips to gunicorn so Django sees HTTPS scheme

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -5,4 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 450 -w 10
+gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 450 -w 10 --forwarded-allow-ips="*"


### PR DESCRIPTION
## Summary

One-line fix: add `--forwarded-allow-ips=\"*\"` to the gunicorn command in `docker/start` so Django's `request.scheme` correctly reflects HTTPS when the request comes in through Traefik.

## The bug

Gunicorn defaults `--forwarded-allow-ips` to `127.0.0.1`, meaning it only trusts `X-Forwarded-*` headers from loopback. In our containerized Kamal + Traefik deployment, Traefik runs in a separate container so its source IP is NOT 127.0.0.1, and **gunicorn silently strips the `X-Forwarded-Proto: https` header** before handing the request to Django.

Downstream effects inside Django:
- `request.scheme` returns `'http'` even though the client request was HTTPS
- `request.is_secure()` returns `False`
- `request.build_absolute_uri()` emits URLs with `http://` scheme
- Any code path that constructs canonical URLs from the request is broken

## How we found it

During the CommCare Connect Labs v2 paginated-JSON export migration (replacing the v1 streaming CSV exports), we ran an end-to-end parity check against `connect.dimagi.com` and hit the bug immediately. `IdKeysetPagination.get_next_link()` in `commcare_connect/data_export/pagination.py` uses `request.build_absolute_uri()` to construct the `next` URL, and production was returning paginated responses with `http://` in the `next` field:

```python
import httpx
r = httpx.get(
    'https://connect.dimagi.com/export/opportunity/<id>/user_visits/',
    headers={
        'Authorization': 'Bearer ...',
        'Accept': 'application/json; version=2.0',
    },
)
# Status: 200
# Response body:
#   {
#     \"next\": \"http://connect.dimagi.com/export/opportunity/<id>/user_visits/?last_id=...\",
#     \"results\": [...]
#   }
#            ^^^^ should be https://
```

The server accepted the HTTPS request correctly but built the `next` URL with `http://` because Django thought the original request was HTTP. Clients following the link hit the edge's canonical HTTPS redirect and received a 301, which broke any HTTP client that didn't have `follow_redirects=True` (httpx's default is false).

The Labs client worked around it with redirect following, but the root cause is here — and this affects **any** code path that uses `build_absolute_uri()` or `is_secure()`, not just pagination. Latent examples I spotted while investigating:
- Password-reset / email-verification URLs
- Webhook callback URL construction
- Any view that serializes absolute media URLs
- The `SECURE_SSL_REDIRECT` middleware (currently defaults to `False` in `staging.py`, but would infinite-loop if ever flipped to `True` given the current gunicorn config)

## The fix

```diff
--- a/docker/start
+++ b/docker/start
@@ -6,4 +6,4 @@ set -o nounset
 
 
-gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 450 -w 10
+gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 450 -w 10 --forwarded-allow-ips=\"*\"
```

Tell gunicorn to trust `X-Forwarded-*` headers from any source.

### Why this is safe

Gunicorn binds to `0.0.0.0:8000` **inside** the Docker network, where only Traefik can reach it. There is no path for an untrusted source to inject forged forwarded headers — an external attacker would need to first compromise the container network, at which point forwarded-header spoofing is the least of your concerns.

This is also the documented pattern for gunicorn-behind-a-reverse-proxy setups: https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips

Alternative: specify the exact Traefik container's CIDR (e.g., `172.17.0.0/16` for the default Docker bridge network). That's slightly more defensive but brittle — any change to the Docker network layout breaks it. The `\"*\"` pattern is the standard recommendation for containerized reverse-proxy setups.

## Test plan

After this lands and deploys:

- [ ] Hit any paginated v2 endpoint:
  ```
  GET https://connect.dimagi.com/api/data/export/opportunity/<id>/user_visits/
  Accept: application/json; version=2.0
  Authorization: Bearer <token>
  ```

- [ ] Verify the `next` field in the response body starts with `https://`, not `http://`

- [ ] Follow the `next` URL in a second request and confirm it returns 200 directly (not 301)

- [ ] Spot-check any existing feature that uses `build_absolute_uri()` to construct URLs (e.g., email templates, webhook URLs) — these should now generate `https://` URLs

## Related

- Found during labs v2 export migration work ([jjackson/connect-labs#55](https://github.com/jjackson/connect-labs/pull/55))
- The Labs `ExportAPIClient` uses `follow_redirects=True` as a defensive workaround; that can stay in place even after this upstream fix lands, but will become a no-op once `next` URLs are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)