### PR TITLE
feat: add Work Area Assignments tab to Connect Workers page

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -635,7 +635,11 @@ def get_worker_tasks_base_queryset(opportunity):
 
 def get_worker_work_area_table_data(opportunity):
     visits_done_subquery = (
-        UserVisit.objects.filter(opportunity_access=OuterRef("pk"), work_area__isnull=False)
+        UserVisit.objects.filter(
+            opportunity=opportunity,
+            opportunity_access=OuterRef("pk"),
+            work_area__isnull=False,
+        )
         .values("opportunity_access")
         .annotate(total=Count("id"))
         .values("total")[:1]

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -633,6 +633,27 @@ def get_worker_tasks_base_queryset(opportunity):
     )
 
 
+def get_worker_work_area_table_data(opportunity):
+    visits_done_subquery = (
+        UserVisit.objects.filter(opportunity_access=OuterRef("pk"), work_area__isnull=False)
+        .values("opportunity_access")
+        .annotate(total=Count("id"))
+        .values("total")[:1]
+    )
+
+    return (
+        OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True)
+        .select_related("user")
+        .annotate(
+            assigned_buildings=Coalesce(Sum("workareagroup__workarea__building_count"), Value(0)),
+            assigned_visits=Coalesce(Sum("workareagroup__workarea__expected_visit_count"), Value(0)),
+            assigned_work_areas=Count("workareagroup__workarea"),
+            assigned_work_area_groups=Count("workareagroup", distinct=True),
+            visits_done=Coalesce(Subquery(visits_done_subquery), Value(0), output_field=IntegerField()),
+        )
+    )
+
+
 def get_opportunity_delivery_progress(opp_id):
     today = now().replace(hour=0, minute=0, second=0, microsecond=0)
     three_days_ago = today - timedelta(days=3)

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1261,6 +1261,51 @@ class WorkerPaymentsTable(tables.Table):
         )
 
 
+class WorkerWorkAreaTable(OrgContextTable):
+    index = IndexColumn()
+    user = UserInfoColumn()
+    last_active = DMYTColumn(verbose_name=gettext_lazy("Last Active"))
+    assigned_buildings = tables.Column(
+        verbose_name=gettext_lazy("Assigned Buildings"),
+        footer=lambda table: intcomma(sum(x.assigned_buildings or 0 for x in table.data)),
+    )
+    assigned_visits = tables.Column(
+        verbose_name=gettext_lazy("Assigned Visits"),
+        footer=lambda table: intcomma(sum(x.assigned_visits or 0 for x in table.data)),
+    )
+    assigned_work_areas = tables.Column(
+        verbose_name=gettext_lazy("Assigned Work Areas"),
+        footer=lambda table: intcomma(sum(x.assigned_work_areas or 0 for x in table.data)),
+    )
+    assigned_work_area_groups = tables.Column(
+        verbose_name=gettext_lazy("Assigned Work Area Groups"),
+        footer=lambda table: intcomma(sum(x.assigned_work_area_groups or 0 for x in table.data)),
+    )
+    visits_done = tables.Column(
+        verbose_name=gettext_lazy("Visits Done"),
+        footer=lambda table: intcomma(sum(x.visits_done or 0 for x in table.data)),
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.use_view_url = False
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        model = OpportunityAccess
+        fields = ("user",)
+        sequence = (
+            "index",
+            "user",
+            "last_active",
+            "assigned_buildings",
+            "assigned_visits",
+            "assigned_work_areas",
+            "assigned_work_area_groups",
+            "visits_done",
+        )
+        order_by = ("-last_active",)
+
+
 class GroupedByWorkerMixin:
     """Mixin for tables that show multiple rows per worker, hiding worker-level
     columns on sub-rows. Subclasses must call `run_after_every_row(record)`

--- a/commcare_connect/opportunity/tests/test_helpers.py
+++ b/commcare_connect/opportunity/tests/test_helpers.py
@@ -635,32 +635,6 @@ def test_filter_worker_tasks_combined_filters(opportunity):
 
 
 @pytest.mark.django_db
-def test_get_worker_work_area_table_data(opportunity):
-    access = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
-    group = WorkAreaGroupFactory(opportunity=opportunity, opportunity_access=access)
-    WorkAreaFactory(opportunity=opportunity, work_area_group=group, building_count=10, expected_visit_count=5)
-    WorkAreaFactory(opportunity=opportunity, work_area_group=group, building_count=20, expected_visit_count=8)
-
-    work_area = group.workarea_set.first()
-    UserVisitFactory(
-        opportunity=opportunity,
-        user=access.user,
-        opportunity_access=access,
-        work_area=work_area,
-    )
-
-    result = get_worker_work_area_table_data(opportunity)
-    assert result.count() == 1
-
-    row = result.first()
-    assert row.assigned_buildings == 30
-    assert row.assigned_visits == 13
-    assert row.assigned_work_areas == 2
-    assert row.assigned_work_area_groups == 1
-    assert row.visits_done == 1
-
-
-@pytest.mark.django_db
 def test_get_worker_work_area_table_data_unassigned_worker(opportunity):
     OpportunityAccessFactory(opportunity=opportunity, accepted=True)
 

--- a/commcare_connect/opportunity/tests/test_helpers.py
+++ b/commcare_connect/opportunity/tests/test_helpers.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 import pytest
 from django.utils.timezone import now
 
+from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 from commcare_connect.opportunity.filters import TasksFilterSet
 from commcare_connect.opportunity.helpers import (
     get_annotated_opportunity_access_deliver_status,
@@ -13,6 +14,7 @@ from commcare_connect.opportunity.helpers import (
     get_worker_learn_table_data,
     get_worker_table_data,
     get_worker_tasks_base_queryset,
+    get_worker_work_area_table_data,
 )
 from commcare_connect.opportunity.models import (
     AssignedTask,
@@ -630,3 +632,104 @@ def test_filter_worker_tasks_combined_filters(opportunity):
     assert len(result) == 1
     assert result[0].user.name == "Alice"
     assert result[0].task_status == AssignedTaskStatus.COMPLETED
+
+
+@pytest.mark.django_db
+def test_get_worker_work_area_table_data(opportunity):
+    access = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+    group = WorkAreaGroupFactory(opportunity=opportunity, opportunity_access=access)
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group, building_count=10, expected_visit_count=5)
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group, building_count=20, expected_visit_count=8)
+
+    work_area = group.workarea_set.first()
+    UserVisitFactory(
+        opportunity=opportunity,
+        user=access.user,
+        opportunity_access=access,
+        work_area=work_area,
+    )
+
+    result = get_worker_work_area_table_data(opportunity)
+    assert result.count() == 1
+
+    row = result.first()
+    assert row.assigned_buildings == 30
+    assert row.assigned_visits == 13
+    assert row.assigned_work_areas == 2
+    assert row.assigned_work_area_groups == 1
+    assert row.visits_done == 1
+
+
+@pytest.mark.django_db
+def test_get_worker_work_area_table_data_unassigned_worker(opportunity):
+    OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+
+    result = get_worker_work_area_table_data(opportunity)
+    assert result.count() == 1
+
+    row = result.first()
+    assert row.assigned_buildings == 0
+    assert row.assigned_visits == 0
+    assert row.assigned_work_areas == 0
+    assert row.assigned_work_area_groups == 0
+    assert row.visits_done == 0
+
+
+@pytest.mark.django_db
+def test_get_worker_work_area_table_data_visit_without_work_area_not_counted(opportunity):
+    access = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+    UserVisitFactory(
+        opportunity=opportunity,
+        user=access.user,
+        opportunity_access=access,
+        work_area=None,
+    )
+
+    result = get_worker_work_area_table_data(opportunity)
+    row = result.first()
+    assert row.visits_done == 0
+
+
+@pytest.mark.django_db
+def test_get_worker_work_area_table_data_multiple_workers_and_groups(opportunity):
+    access1 = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+    access2 = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+
+    group1a = WorkAreaGroupFactory(opportunity=opportunity, opportunity_access=access1)
+    group1b = WorkAreaGroupFactory(opportunity=opportunity, opportunity_access=access1)
+    area1a = WorkAreaFactory(
+        opportunity=opportunity, work_area_group=group1a, building_count=10, expected_visit_count=5
+    )
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group1a, building_count=15, expected_visit_count=3)
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group1b, building_count=20, expected_visit_count=7)
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group1b, building_count=25, expected_visit_count=4)
+
+    group2a = WorkAreaGroupFactory(opportunity=opportunity, opportunity_access=access2)
+    group2b = WorkAreaGroupFactory(opportunity=opportunity, opportunity_access=access2)
+    area2a = WorkAreaFactory(
+        opportunity=opportunity, work_area_group=group2a, building_count=30, expected_visit_count=10
+    )
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group2a, building_count=5, expected_visit_count=2)
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group2b, building_count=8, expected_visit_count=6)
+    WorkAreaFactory(opportunity=opportunity, work_area_group=group2b, building_count=12, expected_visit_count=1)
+
+    UserVisitFactory(opportunity=opportunity, user=access1.user, opportunity_access=access1, work_area=area1a)
+    UserVisitFactory(opportunity=opportunity, user=access1.user, opportunity_access=access1, work_area=area1a)
+    UserVisitFactory(opportunity=opportunity, user=access2.user, opportunity_access=access2, work_area=area2a)
+
+    result = get_worker_work_area_table_data(opportunity).order_by("user__name")
+    assert result.count() == 2
+
+    row1 = result.filter(pk=access1.pk).first()
+    assert row1.assigned_buildings == 70
+    assert row1.assigned_visits == 19
+    assert row1.assigned_work_areas == 4
+    assert row1.assigned_work_area_groups == 2
+    assert row1.visits_done == 2
+
+    row2 = result.filter(pk=access2.pk).first()
+    assert row2.assigned_buildings == 55
+    assert row2.assigned_visits == 19
+    assert row2.assigned_work_areas == 4
+    assert row2.assigned_work_area_groups == 2
+    assert row2.visits_done == 1

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -19,6 +19,7 @@ from commcare_connect.opportunity.views import (
     WorkerPaymentsView,
     WorkerTaskView,
     WorkerView,
+    WorkerWorkAreaView,
     add_budget_existing_users,
     add_budget_new_users,
     add_payment_unit,
@@ -146,6 +147,7 @@ urlpatterns = [
     path("<slug:opp_id>/workers/deliver/", WorkerDeliverView.as_view(), name="worker_deliver"),
     path("<slug:opp_id>/workers/payments/", WorkerPaymentsView.as_view(), name="worker_payments"),
     path("<slug:opp_id>/workers/tasks/", WorkerTaskView.as_view(), name="worker_tasks"),
+    path("<slug:opp_id>/workers/work-areas/", WorkerWorkAreaView.as_view(), name="worker_work_areas"),
     path(
         "<slug:opp_id>/worker_learn_progress/<slug:access_id>",
         views.worker_learn_status_view,

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -57,7 +57,9 @@ from geopy import distance
 from waffle import switch_is_active
 
 from commcare_connect.connect_id_client import fetch_users
+from commcare_connect.flags.flag_names import MICROPLANNING
 from commcare_connect.flags.switch_names import INVOICE_REVIEW, UPDATES_TO_MARK_AS_PAID_WORKFLOW, WORKER_VISITS_TASKS
+from commcare_connect.flags.utils import is_flag_active
 from commcare_connect.form_receiver.serializers import XFormSerializer
 from commcare_connect.opportunity.api.serializers import remove_opportunity_access_cache
 from commcare_connect.opportunity.app_xml import AppNoBuildException
@@ -100,6 +102,7 @@ from commcare_connect.opportunity.helpers import (
     get_worker_learn_table_data,
     get_worker_table_data,
     get_worker_tasks_base_queryset,
+    get_worker_work_area_table_data,
 )
 from commcare_connect.opportunity.models import (
     AssignedTask,
@@ -153,6 +156,7 @@ from commcare_connect.opportunity.tables import (
     WorkerStatusTable,
     WorkerTasksTable,
     WorkerVisitTable,
+    WorkerWorkAreaTable,
     header_with_tooltip,
 )
 from commcare_connect.opportunity.tasks import (
@@ -2554,6 +2558,10 @@ class BaseWorkerListView(OrganizationUserMixin, OpportunityObjectMixin, View):
 
     def get(self, request, org_slug, opp_id):
         opportunity = self.get_opportunity()
+        if is_flag_active(MICROPLANNING, opportunity):
+            self.tabs = self.tabs + [
+                {"key": "work_areas", "label": "Work Area Assignments", "url_name": "opportunity:worker_work_areas"}
+            ]
         context = self.get_context_data(opportunity, org_slug)
         context.update(self.get_extra_context(opportunity, org_slug))
         return render(
@@ -2721,6 +2729,22 @@ class WorkerTaskView(BaseWorkerListView, FilterMixin):
     def get_table(self, opportunity, org_slug):
         data = self._get_filter().qs
         table = WorkerTasksTable(data, org_slug=org_slug, opp_id=opportunity.opportunity_id)
+        RequestConfig(self.request, paginate={"per_page": get_validated_page_size(self.request)}).configure(table)
+        return table
+
+
+class WorkerWorkAreaView(BaseWorkerListView):
+    hx_template_name = "opportunity/worker_list_work_areas.html"
+    active_tab = "work_areas"
+
+    def dispatch(self, request, *args, **kwargs):
+        if not is_flag_active(MICROPLANNING, self.get_opportunity()):
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_table(self, opportunity, org_slug):
+        data = get_worker_work_area_table_data(opportunity)
+        table = WorkerWorkAreaTable(data, org_slug=org_slug)
         RequestConfig(self.request, paginate={"per_page": get_validated_page_size(self.request)}).configure(table)
         return table
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2501,11 +2501,11 @@ class BaseWorkerListView(OrganizationUserMixin, OpportunityObjectMixin, View):
     hx_template_name = "opportunity/workers.html"
     active_tab = "workers"
     tabs = [
-        {"key": "workers", "label": "Connect Workers", "url_name": "opportunity:worker_list"},
-        {"key": "learn", "label": "Learn", "url_name": "opportunity:worker_learn"},
-        {"key": "deliver", "label": "Deliver", "url_name": "opportunity:worker_deliver"},
-        {"key": "payments", "label": "Payments", "url_name": "opportunity:worker_payments"},
-        {"key": "tasks", "label": "Tasks", "url_name": "opportunity:worker_tasks"},
+        {"key": "workers", "label": gettext_lazy("Connect Workers"), "url_name": "opportunity:worker_list"},
+        {"key": "learn", "label": gettext_lazy("Learn"), "url_name": "opportunity:worker_learn"},
+        {"key": "deliver", "label": gettext_lazy("Deliver"), "url_name": "opportunity:worker_deliver"},
+        {"key": "payments", "label": gettext_lazy("Payments"), "url_name": "opportunity:worker_payments"},
+        {"key": "tasks", "label": gettext_lazy("Tasks"), "url_name": "opportunity:worker_tasks"},
     ]
 
     def _is_navigating_between_tabs(self, org_slug, opportunity):
@@ -2553,14 +2553,18 @@ class BaseWorkerListView(OrganizationUserMixin, OpportunityObjectMixin, View):
         workers_count = (
             UserInvite.objects.filter(opportunity=opportunity).exclude(status=UserInviteStatus.not_found).count()
         )
-        tabs_with_urls[0]["label"] = f"Connect Workers ({workers_count})"
+        tabs_with_urls[0]["label"] = _("Connect Workers") + f" ({workers_count})"
         return tabs_with_urls
 
     def get(self, request, org_slug, opp_id):
         opportunity = self.get_opportunity()
         if is_flag_active(MICROPLANNING, opportunity):
             self.tabs = self.tabs + [
-                {"key": "work_areas", "label": "Work Area Assignments", "url_name": "opportunity:worker_work_areas"}
+                {
+                    "key": "work_areas",
+                    "label": gettext_lazy("Work Area Assignments"),
+                    "url_name": "opportunity:worker_work_areas",
+                }
             ]
         context = self.get_context_data(opportunity, org_slug)
         context.update(self.get_extra_context(opportunity, org_slug))

--- a/commcare_connect/templates/opportunity/worker_list_work_areas.html
+++ b/commcare_connect/templates/opportunity/worker_list_work_areas.html
@@ -1,0 +1,3 @@
+{% extends "opportunity/worker_list_base.html" %}
+
+{% block tab_options %}{% endblock %}


### PR DESCRIPTION
## Product Description

Adds a new **Work Area Assignments** tab to the Connect Workers page, gated behind the `MICROPLANNING` waffle flag. The tab shows all accepted workers with their work area assignment metrics:

- Worker name and ID
- Last active date
- Assigned buildings, visits, work areas, and work area groups
- Visits done (only counts visits linked to a work area)
- Footer row with column totals

The tab is only visible when the `MICROPLANNING` flag is active for the opportunity.

<img width="3202" height="935" alt="image" src="https://github.com/user-attachments/assets/034d8f31-dc35-4548-9652-4a9588444f52" />


## Technical Summary

**Ticket:** [CCCT-2209](https://dimagi.atlassian.net/browse/CCCT-2209)

### Implementation details:
- **Helper** (`helpers.py`): `get_worker_work_area_table_data()` uses 4 direct JOIN annotations through the `OpportunityAccess → WorkAreaGroup → WorkArea` FK chain, plus 1 correlated subquery for `visits_done` (filtered by `opportunity` to leverage existing DB index)
- **Table** (`tables.py`): `WorkerWorkAreaTable` with `gettext_lazy` column labels and footer totals using `intcomma`
- **View** (`views.py`): `WorkerWorkAreaView` extends `BaseWorkerListView`, adds the tab dynamically in `get()` when `MICROPLANNING` flag is active, and guards access via `dispatch` override
- **Template**: `worker_list_work_areas.html` extends `worker_list_base.html`
- **URL**: `<opp_id>/workers/work-areas/`

## Safety Assurance

### Safety story

- Feature is gated behind the `MICROPLANNING` waffle flag — no impact on existing users
- The tab is added dynamically (not modifying the static `tabs` list), so existing tabs are unaffected
- Query uses JOIN annotations (not N+1) for performance; the `visits_done` subquery filters on `opportunity` to use the existing `(opportunity, status)` index

### Automated test coverage

4 new tests in `test_helpers.py`:
- `test_get_worker_work_area_table_data` — verifies annotation values for a worker with assignments
- `test_get_worker_work_area_table_data_unassigned_worker` — verifies zero values for worker without assignments
- `test_get_worker_work_area_table_data_visit_without_work_area_not_counted` — ensures visits not linked to a work area are excluded from `visits_done`
- `test_get_worker_work_area_table_data_multiple_workers_and_groups` — verifies correct aggregation across multiple workers and groups

### QA Plan

None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CCCT-2209]: https://dimagi.atlassian.net/browse/CCCT-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ