### PR TITLE
Add ability to edit task from worker details page

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -2038,6 +2038,7 @@ class EditAssignedTaskForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["due_date"].label = _("New End Date")
         self.fields["due_date"].widget.attrs["min"] = datetime.date.today().isoformat()
         self.helper = FormHelper(self)
         self.helper.form_tag = False

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -2033,7 +2033,7 @@ class EditAssignedTaskForm(forms.ModelForm):
         model = AssignedTask
         fields = ["due_date"]
         widgets = {
-            "due_date": forms.DateInput(attrs={"type": "date"}),
+            "due_date": forms.DateInput(format="%Y-%m-%d", attrs={"type": "date"}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1780,14 +1780,15 @@ class InvoiceDeliveriesTable(tables.Table):
         )
 
 
+_task_select_td_extra = {
+    "@change": "updateSelectAll()",
+    # return None instead of False to skip the attribute.
+    "disabled": lambda record: True if record.status == AssignedTaskStatus.COMPLETED else None,
+}
+
+
 class AssignedTaskListTable(OpportunityContextTable):
-    select = select_column(
-        td_extra={
-            "@change": "updateSelectAll()",
-            # return None instead of False to skip the attribute.
-            "disabled": lambda record: True if record.status == AssignedTaskStatus.COMPLETED else None,
-        },
-    )
+    select = select_column(td_extra=_task_select_td_extra)
     assigned_task_id = tables.Column(verbose_name=gettext_lazy("Task ID"), accessor="pk")
     connect_worker = tables.Column(verbose_name=gettext_lazy("Connect Worker"), accessor="opportunity_access__user")
     status = TaskStatusColumn(verbose_name=gettext_lazy("Status"), accessor="status")
@@ -1846,12 +1847,7 @@ class AssignedTaskListTable(OpportunityContextTable):
 class WorkerCompletedTaskTable(tables.Table):
     use_view_url = True
 
-    select = select_column(
-        td_extra={
-            "@change": "updateSelectAll()",
-            "disabled": lambda record: True if record.status == AssignedTaskStatus.COMPLETED else None,
-        },
-    )
+    select = select_column(td_extra=_task_select_td_extra)
     task_type = tables.Column(verbose_name=_("Task Type"), accessor="task", orderable=False)
     assigned_by = tables.Column(
         verbose_name=_("Assigned By"),

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2556,8 +2556,8 @@ class TestEditAssignedTask:
             self._edit_url(opp, assigned_task),
             data={"due_date": future_date.isoformat(), "reason": "Extended deadline"},
         )
-        assert response.status_code == HTTPStatus.NO_CONTENT
-        assert response["HX-Trigger"] == "reloadTable"
+        assert response.status_code == HTTPStatus.OK
+        assert "HX-Redirect" in response
         assigned_task.refresh_from_db()
         assert assigned_task.due_date == future_date
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3405,7 +3405,6 @@ class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMember
         return context
 
     def form_valid(self, form):
-        response = HttpResponse(status=204)
         if form.has_changed():
             task = form.save(commit=False)
             reason = form.cleaned_data.get("reason", "")
@@ -3415,8 +3414,12 @@ class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMember
                 user_email=self.request.user.email,
             ):
                 task.save(update_fields=["due_date"])
-            response["HX-Trigger"] = "reloadTable"
-        return response
+            messages.success(self.request, _("Task updated successfully."))
+        redirect_url = self.request.headers.get(
+            "HX-Current-URL",
+            _task_redirect_url(self.request, self.kwargs["org_slug"], self.kwargs["opp_id"]),
+        )
+        return HttpResponse(headers={"HX-Redirect": redirect_url})
 
 
 @require_POST

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3399,6 +3399,9 @@ class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMember
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["hx_post_url"] = self.request.path
+        task = self.object
+        context["task_type_name"] = task.task_type.name
+        context["current_due_date"] = task.due_date.isoformat()
         return context
 
     def form_valid(self, form):

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -216,6 +216,7 @@ from commcare_connect.utils.tables import (
 )
 
 EXPORT_ROW_LIMIT = 10_000
+_NEXT_WORKER_TASKS = "worker_tasks"
 
 
 def get_opportunity_or_404(pk, org_slug):
@@ -2116,7 +2117,7 @@ def _can_manage_tasks(request, opportunity):
 
 def _task_redirect_url(request, org_slug, opp_id):
     user_id = request.GET.get("user", "")
-    if request.GET.get("next") == "worker_tasks" and user_id:
+    if request.GET.get("next") == _NEXT_WORKER_TASKS and user_id:
         return reverse("opportunity:user_tasks_list", args=(org_slug, opp_id)) + f"?user={user_id}"
     return reverse("opportunity:assigned_task_list", args=(org_slug, opp_id))
 
@@ -2131,9 +2132,14 @@ class UserTasksView(WorkerPageView):
         context["can_manage_tasks"] = can_manage_tasks
         if can_manage_tasks:
             context["create_task_form"] = CreateTaskForm(opportunity=self.opportunity, access=self.opportunity_access)
+            query_suffix = f"?next={_NEXT_WORKER_TASKS}&user={self.opportunity_access.user.user_id}"
             context["create_task_url"] = (
                 reverse("opportunity:create_task", args=(self.request.org.slug, self.opportunity.opportunity_id))
-                + f"?next=worker_tasks&user={self.opportunity_access.user.user_id}"
+                + query_suffix
+            )
+            context["delete_tasks_url"] = (
+                reverse("opportunity:delete_tasks", args=(self.request.org.slug, self.opportunity.opportunity_id))
+                + query_suffix
             )
         return context
 
@@ -3390,7 +3396,7 @@ class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMember
 
     def get_object(self, queryset=None):
         return get_object_or_404(
-            self.model,
+            self.model.objects.select_related("task_type"),
             pk=self.kwargs["pk"],
             opportunity_access__opportunity=self.get_opportunity(),
             status=AssignedTaskStatus.ASSIGNED,
@@ -3429,7 +3435,7 @@ class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMember
 def create_task(request, org_slug, opp_id):
     opportunity = request.opportunity
     access = None
-    if request.GET.get("next") == "worker_tasks":
+    if request.GET.get("next") == _NEXT_WORKER_TASKS:
         user_id = request.GET.get("user")
         if user_id:
             access = OpportunityAccess.objects.filter(opportunity=opportunity, user__user_id=user_id).first()

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2512,6 +2512,7 @@ def user_task_details(request, org_slug, opp_id, pk):
             completed_task=completed_task,
             images=images,
             hq_link=hq_link,
+            can_manage_tasks=_can_manage_tasks(request, request.opportunity),
         ),
     )
 

--- a/commcare_connect/templates/opportunity/assigned_task_list.html
+++ b/commcare_connect/templates/opportunity/assigned_task_list.html
@@ -71,7 +71,6 @@
 
         <div id="task-list-table" class="bg-white rounded-lg shadow-xs p-4"
              hx-get="{{ request.get_full_path }}"
-             hx-trigger="reloadTable from:body"
              hx-select="#task-list-table"
              hx-swap="outerHTML">
             {% if can_manage_tasks %}

--- a/commcare_connect/templates/opportunity/assigned_task_list.html
+++ b/commcare_connect/templates/opportunity/assigned_task_list.html
@@ -9,11 +9,9 @@
          x-data="{
            showEditTaskModal: false,
            editTaskError: false,
-           editTaskSuccess: false,
            showCreateTaskModal: false,
            ...selectableTable()
-         }"
-         @reload-table.camel.window="showEditTaskModal = false; editTaskError = false; editTaskSuccess = true">
+         }">
         {% include 'components/breadcrumbs.html' with path=path %}
 
         <div class="flex flex-col gap-8 metric-container">
@@ -47,16 +45,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div x-show="editTaskSuccess" x-cloak role="status"
-          class="flex items-center justify-between p-4 rounded-lg border-[0.5px] bg-message-success text-message-success-text border-message-success-border">
-          <div class="flex items-center gap-2">
-            <i class="fa-regular fa-circle-check"></i>
-            <span>{% trans "Task updated successfully." %}</span>
-          </div>
-          <button type="button" class="ml-4 text-xl font-light hover:font-normal focus:outline-none" aria-label="{% trans "Close" %}"
-            @click="editTaskSuccess = false">&times;</button>
         </div>
 
         <div x-show="editTaskError" x-cloak role="alert"

--- a/commcare_connect/templates/opportunity/edit_assigned_task_form.html
+++ b/commcare_connect/templates/opportunity/edit_assigned_task_form.html
@@ -1,5 +1,9 @@
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags i18n %}
 
+<div class="rounded-lg bg-gray-50 p-3 mb-4">
+    <p class="font-medium text-gray-900">{{ task_type_name }}</p>
+    <p class="text-sm text-gray-500">{% translate "Due:" %} {{ current_due_date }}</p>
+</div>
 <form
     id="edit-assigned-task-form-el"
     hx-post="{{ hx_post_url }}"

--- a/commcare_connect/templates/opportunity/edit_assigned_task_modal.html
+++ b/commcare_connect/templates/opportunity/edit_assigned_task_modal.html
@@ -1,23 +1,37 @@
 {% load i18n %}
 
 <div x-show="showEditTaskModal" x-cloak x-transition.opacity class="modal-backdrop" role="dialog" aria-modal="true"
+    aria-labelledby="edit-task-modal-title"
     @keydown.escape.window="showEditTaskModal = false">
-    <div @click.outside="showEditTaskModal = false" class="modal w-full !max-w-2xl">
-        <div class="header flex justify-between items-center">
-            <h2 class="title">{% translate "Edit Task" %}</h2>
-            <button @click="showEditTaskModal = false" class="button-icon" aria-label="{% translate 'Close' %}">
-                <i class="fa-solid fa-xmark text-xl"></i>
+    <div @click.outside="showEditTaskModal = false" class="modal">
+
+        <div class="flex justify-between items-start mb-4">
+            <div>
+                <div class="flex items-center gap-3 mb-1">
+                    <div class="flex items-center justify-center w-10 h-10 rounded-full bg-indigo-100 shrink-0">
+                        <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+                    </div>
+                    <h2 id="edit-task-modal-title" class="text-xl font-bold text-brand-deep-purple">
+                        {% translate "Edit Task" %}
+                    </h2>
+                </div>
+                <p class="text-sm text-gray-500 mt-1">
+                    {% translate "You can modify the end date for this task." %}
+                </p>
+            </div>
+            <button type="button" class="button-icon" @click="showEditTaskModal = false"
+                    aria-label="{% translate 'Close dialog' %}">
+                <i class="fa-solid fa-xmark cursor-pointer" aria-hidden="true"></i>
             </button>
         </div>
-        <div id="edit-assigned-task-form" class="modal-body">
-            {# htmx will load the edit form here #}
+        <div id="edit-assigned-task-form">
         </div>
-        <div class="footer flex justify-end gap-3">
-            <button type="button" @click="showEditTaskModal = false" class="button button-md outline-style">
+        <div class="flex justify-between gap-3 pt-2">
+            <button type="button" @click="showEditTaskModal = false" class="button button-md outline-style flex-1">
                 {% translate "Cancel" %}
             </button>
-            <button type="submit" form="edit-assigned-task-form-el" class="button button-md primary-dark">
-                {% translate "Save" %}
+            <button type="submit" form="edit-assigned-task-form-el" class="button button-md primary-dark flex-1">
+                {% translate "Save Changes" %}
             </button>
         </div>
     </div>

--- a/commcare_connect/templates/opportunity/user_task_details.html
+++ b/commcare_connect/templates/opportunity/user_task_details.html
@@ -105,6 +105,23 @@
     </div>
   </div>
 
+  {% if can_manage_tasks and completed_task.status == "assigned" %}
+  <div class="flex justify-end">
+    <button
+        type="button"
+        class="button button-md outline-style"
+        hx-get="{% url 'opportunity:edit_assigned_task' request.org.slug completed_task.opportunity_access.opportunity.opportunity_id completed_task.pk %}"
+        hx-target="#edit-assigned-task-form"
+        hx-swap="innerHTML"
+        hx-select="unset"
+        @htmx:after-request="if ($event.detail.successful) {
+                showEditTaskModal = true; editTaskError = false
+            } else { editTaskError = true }">
+      <i class="fa-regular fa-pen-to-square mr-1"></i> {% translate "Edit" %}
+    </button>
+  </div>
+  {% endif %}
+
   {% if images %}
   <hr class="h-px bg-gray-200 border-0">
 

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -8,6 +8,8 @@
 <div class="w-full space-y-4"
      x-data="{
        showCreateTaskModal: false,
+       showEditTaskModal: false,
+       editTaskError: false,
        ...selectableTable()
      }">
   {% include "components/worker_page/worker_profile_kpi.html" %}
@@ -77,6 +79,7 @@
 
   {% if can_manage_tasks %}
   {% include 'tasks/new_task_modal.html' with modal_name="showCreateTaskModal" form=create_task_form %}
+  {% include 'opportunity/edit_assigned_task_modal.html' %}
   {% include 'components/confirm_modal.html' %}
   {% endif %}
 </div>

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -23,7 +23,7 @@
       {% if can_manage_tasks %}
       <div class="flex gap-4 items-center justify-start mt-4">
         <form x-ref="deleteTasksForm"
-          hx-post="{% url 'opportunity:delete_tasks' org_slug=request.org.slug opp_id=opportunity.opportunity_id %}?next=worker_tasks&user={{ opportunity_access.user.user_id }}"
+          hx-post="{{ delete_tasks_url }}"
           hx-trigger="submit" class="hidden">
           {% csrf_token %}
           <template x-for="id in selected">

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -12,14 +12,14 @@
        editTaskError: false,
        ...selectableTable()
      }"
-     @reload-table.camel.window="showEditTaskModal = false; editTaskError = false">
+  >
   {% include "components/worker_page/worker_profile_kpi.html" %}
   {% include 'components/worker_page/visit_task_tabs.html' %}
   <div class="w-full grid grid-cols-10 gap-2">
     <div class="col-span-6" hx-indicator="#loading-spinner">
       <div
         hx-get="{% url 'opportunity:user_tasks_table' request.org.slug opportunity.opportunity_id %}{% querystring %}"
-        hx-trigger="load, reloadTable from:body" hx-swap="outerHTML"></div>
+        hx-trigger="load" hx-swap="outerHTML"></div>
       {% if can_manage_tasks %}
       <div class="flex gap-4 items-center justify-start mt-4">
         <form x-ref="deleteTasksForm"

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -13,6 +13,16 @@
        ...selectableTable()
      }"
   >
+  <div x-show="editTaskError" x-cloak role="alert"
+    class="flex items-center justify-between p-4 rounded-lg border-[0.5px] bg-message-error text-message-error-text border-message-error-border">
+    <div class="flex items-center gap-2">
+      <i class="fa-solid fa-circle-exclamation"></i>
+      <span>{% trans "Failed to load task. Please try again." %}</span>
+    </div>
+    <button type="button" class="ml-4 text-xl font-light hover:font-normal focus:outline-none" aria-label="{% trans "Close" %}"
+      @click="editTaskError = false">&times;</button>
+  </div>
+
   {% include "components/worker_page/worker_profile_kpi.html" %}
   {% include 'components/worker_page/visit_task_tabs.html' %}
   <div class="w-full grid grid-cols-10 gap-2">

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -11,14 +11,15 @@
        showEditTaskModal: false,
        editTaskError: false,
        ...selectableTable()
-     }">
+     }"
+     @reload-table.camel.window="showEditTaskModal = false; editTaskError = false">
   {% include "components/worker_page/worker_profile_kpi.html" %}
   {% include 'components/worker_page/visit_task_tabs.html' %}
   <div class="w-full grid grid-cols-10 gap-2">
     <div class="col-span-6" hx-indicator="#loading-spinner">
       <div
         hx-get="{% url 'opportunity:user_tasks_table' request.org.slug opportunity.opportunity_id %}{% querystring %}"
-        hx-trigger="load" hx-swap="outerHTML"></div>
+        hx-trigger="load, reloadTable from:body" hx-swap="outerHTML"></div>
       {% if can_manage_tasks %}
       <div class="flex gap-4 items-center justify-start mt-4">
         <form x-ref="deleteTasksForm"


### PR DESCRIPTION
## Product Description
This PR makes it possible to edit a task from the Connect Worker details page.

Worker details page:
<img width="1679" height="858" alt="image" src="https://github.com/user-attachments/assets/abeebeaa-eb5d-40c6-801e-68b409ad4d29" />

Edit modal:
<img width="1679" height="858" alt="image" src="https://github.com/user-attachments/assets/29888a0f-bcb5-474e-b9ce-f71bcac2f0af" />

## Technical Summary
#### RP 3
Ticket: https://dimagi.atlassian.net/browse/CCCT-2187

This PR reuses existing views and modals to make it possible to edit existing (non-completed) tasks from the Connect Worker details page. 

The PR also updates the UI of the edit modal to look more similar to that of the "create task" modal (and the balsamiq mockup).

One key note is that the edit view now forces a reload instead of simply emitting an event to reload the table - this was done for 2 reasons:
1. The create / delete actions reloads the page so this follows the same pattern.
2. It's simpler to make this work on the worker details page which have to reload multiple parts on the page after an edit.

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
Updated a single test - tests for the views already exist.

### QA Plan
N.A for RP 3

### Labels & Review
- [x ] The set of people pinged as reviewers is appropriate for the level of risk of the change
