### PR TITLE
Assignment Mode UI

### DIFF
--- a/commcare_connect/microplanning/filters.py
+++ b/commcare_connect/microplanning/filters.py
@@ -1,5 +1,6 @@
 import django_filters
 from django import forms
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from commcare_connect.microplanning.models import WorkArea, WorkAreaStatus
@@ -41,6 +42,10 @@ class WorkAreaMapFilterSet(django_filters.FilterSet):
         widget=forms.DateInput(attrs={"type": "date", "class": INPUT_CSS}),
     )
 
+    unassigned_only = django_filters.BooleanFilter(
+        method="filter_unassigned_only",
+    )
+
     class Meta:
         model = WorkArea
         fields = []
@@ -65,6 +70,13 @@ class WorkAreaMapFilterSet(django_filters.FilterSet):
         # Display "name (username)" instead of default __str__
         # which shows email or username (not useful for mobile workers)
         self.filters["assignee"].field.label_from_instance = lambda obj: obj.display_name_with_username()
+
+    def filter_unassigned_only(self, queryset, name, value):
+        if value:
+            return queryset.filter(
+                Q(work_area_group__isnull=True) | Q(work_area_group__opportunity_access__isnull=True)
+            )
+        return queryset
 
 
 class UserVisitMapFilterSet(django_filters.FilterSet):

--- a/commcare_connect/microplanning/forms.py
+++ b/commcare_connect/microplanning/forms.py
@@ -4,6 +4,12 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup
+from commcare_connect.opportunity.models import OpportunityAccess
+
+INPUT_CSS = (
+    "w-full rounded-md border border-gray-300 px-3 py-2 "
+    "text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+)
 
 
 class WorkAreaModelForm(forms.ModelForm):
@@ -40,3 +46,44 @@ class WorkAreaModelForm(forms.ModelForm):
     def has_changed(self):
         # Ignore "reason" form is unchanged unless model fields change
         return any(f in self.changed_data for f in self._meta.fields)
+
+
+class AssignmentModeForm(forms.Form):
+    work_area_group = forms.ModelChoiceField(
+        queryset=WorkAreaGroup.objects.none(),
+        required=False,
+        empty_label=_("— Select Group —"),
+        label=_("Select Work Area Group"),
+        widget=forms.Select(
+            attrs={
+                "class": INPUT_CSS,
+                "x-ref": "groupSelect",
+                "@change": "selectGroup($event.target.value)",
+            }
+        ),
+    )
+
+    assignee = forms.ModelChoiceField(
+        queryset=OpportunityAccess.objects.none(),
+        required=False,
+        empty_label=_("— Select FLW —"),
+        label=_("Select new Assignee"),
+        widget=forms.Select(
+            attrs={
+                "class": INPUT_CSS,
+                "x-ref": "assigneeSelect",
+                "@change": "selectedAssigneeId = $event.target.value; selectByAssignee($event.target.value)",
+            }
+        ),
+    )
+
+    def __init__(self, *args, opportunity=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if opportunity:
+            self.fields["work_area_group"].queryset = WorkAreaGroup.objects.filter(opportunity=opportunity)
+            self.fields["assignee"].queryset = (
+                OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True, suspended=False)
+                .select_related("user")
+                .order_by("user__name")
+            )
+            self.fields["assignee"].label_from_instance = lambda obj: obj.user.name

--- a/commcare_connect/microplanning/forms.py
+++ b/commcare_connect/microplanning/forms.py
@@ -72,7 +72,12 @@ class AssignmentModeForm(forms.Form):
             attrs={
                 "class": INPUT_CSS,
                 "x-ref": "assigneeSelect",
-                "@change": "selectedAssigneeId = $event.target.value; selectByAssignee($event.target.value)",
+                "@change": (
+                    "selectedAssigneeId = $event.target.value;"
+                    " flwSummaryAssigneeId = $event.target.value;"
+                    " if ($refs.flwSummarySelect) $refs.flwSummarySelect.value = $event.target.value;"
+                    " selectByAssignee($event.target.value)"
+                ),
             }
         ),
     )

--- a/commcare_connect/microplanning/urls.py
+++ b/commcare_connect/microplanning/urls.py
@@ -33,8 +33,8 @@ urlpatterns = [
     path("<slug:opp_id>/download_work_areas/", views.download_work_areas, name="download_work_areas"),
     path(
         "<slug:opp_id>/assignment/group_work_areas/<int:group_id>/",
-        views.assignment_group_work_areas,
-        name="assignment_group_work_areas",
+        views.get_work_areas_for_assignment,
+        name="get_work_areas_for_assignment",
     ),
     path(
         "<slug:opp_id>/assignment/flw_work_areas/<int:assignee_id>/",

--- a/commcare_connect/microplanning/urls.py
+++ b/commcare_connect/microplanning/urls.py
@@ -31,4 +31,24 @@ urlpatterns = [
         name="modify_work_area",
     ),
     path("<slug:opp_id>/download_work_areas/", views.download_work_areas, name="download_work_areas"),
+    path(
+        "<slug:opp_id>/assignment/group_work_areas/<int:group_id>/",
+        views.assignment_group_work_areas,
+        name="assignment_group_work_areas",
+    ),
+    path(
+        "<slug:opp_id>/assignment/flw_work_areas/<int:assignee_id>/",
+        views.assignment_flw_work_areas,
+        name="assignment_flw_work_areas",
+    ),
+    path(
+        "<slug:opp_id>/assignment/flw_summary/",
+        views.assignment_flw_summary,
+        name="assignment_flw_summary",
+    ),
+    path(
+        "<slug:opp_id>/assignment/save/",
+        views.assignment_save,
+        name="assignment_save",
+    ),
 ]

--- a/commcare_connect/microplanning/urls.py
+++ b/commcare_connect/microplanning/urls.py
@@ -38,17 +38,17 @@ urlpatterns = [
     ),
     path(
         "<slug:opp_id>/assignment/flw_work_areas/<int:assignee_id>/",
-        views.assignment_flw_work_areas,
-        name="assignment_flw_work_areas",
+        views.get_flw_work_areas_for_assignment,
+        name="get_flw_work_areas_for_assignment",
     ),
     path(
         "<slug:opp_id>/assignment/flw_summary/",
-        views.assignment_flw_summary,
-        name="assignment_flw_summary",
+        views.get_flw_summary_for_assignment,
+        name="get_flw_summary_for_assignment",
     ),
     path(
         "<slug:opp_id>/assignment/save/",
-        views.assignment_save,
-        name="assignment_save",
+        views.save_assignment,
+        name="save_assignment",
     ),
 ]

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -34,7 +34,7 @@ from commcare_connect.flags.decorators import require_flag_for_opp
 from commcare_connect.flags.flag_names import MICROPLANNING
 from commcare_connect.microplanning.const import WORK_AREA_STATUS_COLORS
 from commcare_connect.microplanning.filters import UserVisitMapFilterSet, WorkAreaMapFilterSet
-from commcare_connect.microplanning.forms import WorkAreaModelForm
+from commcare_connect.microplanning.forms import AssignmentModeForm, WorkAreaModelForm
 from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup, WorkAreaStatus
 from commcare_connect.opportunity.models import OpportunityAccess, UserVisit
 from commcare_connect.organization.decorators import (
@@ -139,9 +139,7 @@ def microplanning_home(request, *args, **kwargs):
         org_slug = request.org.slug
         opp_id = opportunity.opportunity_id
 
-        context["work_area_groups_json"] = list(
-            WorkAreaGroup.objects.filter(opportunity=opportunity).values("id", "name")
-        )
+        context["assignment_form"] = AssignmentModeForm(opportunity=opportunity)
         context["assignees_json"] = list(
             OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True, suspended=False)
             .select_related("user")

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -165,7 +165,7 @@ def _get_assignment_mode_context(request, opportunity):
             .values("id", "user__name", "user_id")
         ),
         "group_work_areas_url": reverse(
-            "microplanning:assignment_group_work_areas",
+            "microplanning:get_work_areas_for_assignment",
             args=[org_slug, opp_id, 0],
         ).replace("/0/", "/__group_id__/"),
         "flw_work_areas_url": reverse(
@@ -532,7 +532,7 @@ class ModifyWorkAreaUpdateView(UpdateView):
 @org_program_manager_required
 @opportunity_required
 @require_flag_for_opp(MICROPLANNING)
-def assignment_group_work_areas(request, org_slug, opp_id, group_id):
+def get_work_areas_for_assignment(request, org_slug, opp_id, group_id):
     work_areas = list(
         WorkArea.objects.filter(
             opportunity=request.opportunity,

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -136,39 +136,7 @@ def microplanning_home(request, *args, **kwargs):
     }
 
     if assignment_mode:
-        org_slug = request.org.slug
-        opp_id = opportunity.opportunity_id
-
-        context["assignment_form"] = AssignmentModeForm(opportunity=opportunity)
-        context["assignees_json"] = list(
-            OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True, suspended=False)
-            .select_related("user")
-            .values("id", "user__name", "user_id")
-        )
-        context["group_work_areas_url"] = reverse(
-            "microplanning:assignment_group_work_areas",
-            args=[org_slug, opp_id, 0],
-        ).replace("/0/", "/__group_id__/")
-        context["flw_work_areas_url"] = reverse(
-            "microplanning:assignment_flw_work_areas",
-            args=[org_slug, opp_id, 0],
-        ).replace("/0/", "/__assignee_id__/")
-        context["flw_summary_url"] = reverse(
-            "microplanning:assignment_flw_summary",
-            kwargs={"org_slug": org_slug, "opp_id": opp_id},
-        )
-        context["assignment_save_url"] = reverse(
-            "microplanning:assignment_save",
-            kwargs={"org_slug": org_slug, "opp_id": opp_id},
-        )
-        context["user_visits_url"] = reverse(
-            "opportunity:user_visits_list",
-            args=[org_slug, opp_id],
-        )
-        context["worker_list_url"] = reverse(
-            "opportunity:worker_list",
-            args=[org_slug, opp_id],
-        )
+        context.update(_get_assignment_mode_context(request, opportunity))
 
     return render(
         request,
@@ -184,6 +152,43 @@ def get_metrics_for_microplanning(opportunity):
             "value": max((opportunity.end_date - localdate()).days, 0) if opportunity.end_date else "--",
         },
     ]
+
+
+def _get_assignment_mode_context(request, opportunity):
+    org_slug = request.org.slug
+    opp_id = opportunity.opportunity_id
+    return {
+        "assignment_form": AssignmentModeForm(opportunity=opportunity),
+        "assignees_json": list(
+            OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True, suspended=False)
+            .select_related("user")
+            .values("id", "user__name", "user_id")
+        ),
+        "group_work_areas_url": reverse(
+            "microplanning:assignment_group_work_areas",
+            args=[org_slug, opp_id, 0],
+        ).replace("/0/", "/__group_id__/"),
+        "flw_work_areas_url": reverse(
+            "microplanning:assignment_flw_work_areas",
+            args=[org_slug, opp_id, 0],
+        ).replace("/0/", "/__assignee_id__/"),
+        "flw_summary_url": reverse(
+            "microplanning:assignment_flw_summary",
+            kwargs={"org_slug": org_slug, "opp_id": opp_id},
+        ),
+        "assignment_save_url": reverse(
+            "microplanning:assignment_save",
+            kwargs={"org_slug": org_slug, "opp_id": opp_id},
+        ),
+        "user_visits_url": reverse(
+            "opportunity:user_visits_list",
+            args=[org_slug, opp_id],
+        ),
+        "worker_list_url": reverse(
+            "opportunity:worker_list",
+            args=[org_slug, opp_id],
+        ),
+    }
 
 
 @method_decorator([org_admin_required, opportunity_required, require_flag_for_opp(MICROPLANNING)], name="dispatch")
@@ -528,13 +533,13 @@ class ModifyWorkAreaUpdateView(UpdateView):
 @opportunity_required
 @require_flag_for_opp(MICROPLANNING)
 def assignment_group_work_areas(request, org_slug, opp_id, group_id):
-    ids = list(
+    work_areas = list(
         WorkArea.objects.filter(
             opportunity=request.opportunity,
             work_area_group_id=group_id,
-        ).values_list("id", flat=True)
+        ).values("id", "building_count", "expected_visit_count")
     )
-    return JsonResponse({"work_area_ids": ids})
+    return JsonResponse({"work_areas": work_areas})
 
 
 @require_GET
@@ -542,13 +547,13 @@ def assignment_group_work_areas(request, org_slug, opp_id, group_id):
 @opportunity_required
 @require_flag_for_opp(MICROPLANNING)
 def assignment_flw_work_areas(request, org_slug, opp_id, assignee_id):
-    ids = list(
+    work_areas = list(
         WorkArea.objects.filter(
             opportunity=request.opportunity,
             work_area_group__opportunity_access_id=assignee_id,
-        ).values_list("id", flat=True)
+        ).values("id", "building_count", "expected_visit_count")
     )
-    return JsonResponse({"work_area_ids": ids})
+    return JsonResponse({"work_areas": work_areas})
 
 
 @require_GET

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -24,7 +24,7 @@ from django.utils.decorators import method_decorator
 from django.utils.timezone import localdate
 from django.utils.translation import gettext as _
 from django.views import View
-from django.views.decorators.http import require_GET, require_http_methods, require_POST
+from django.views.decorators.http import require_GET, require_POST
 from django.views.generic.edit import UpdateView
 from vectortiles import VectorLayer
 from vectortiles.views import MVTView
@@ -577,7 +577,7 @@ def assignment_flw_summary(request, org_slug, opp_id):
     )
 
 
-@require_http_methods(["POST"])
+@require_POST
 @org_program_manager_required
 @opportunity_required
 @require_flag_for_opp(MICROPLANNING)

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -15,7 +15,7 @@ from django.core.cache import cache
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db import transaction
-from django.db.models import F, FloatField, Func, Value
+from django.db.models import F, FloatField, Func, Sum, Value
 from django.db.models.functions import Cast
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import redirect, render
@@ -24,7 +24,7 @@ from django.utils.decorators import method_decorator
 from django.utils.timezone import localdate
 from django.utils.translation import gettext as _
 from django.views import View
-from django.views.decorators.http import require_GET, require_POST
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from django.views.generic.edit import UpdateView
 from vectortiles import VectorLayer
 from vectortiles.views import MVTView
@@ -36,8 +36,13 @@ from commcare_connect.microplanning.const import WORK_AREA_STATUS_COLORS
 from commcare_connect.microplanning.filters import UserVisitMapFilterSet, WorkAreaMapFilterSet
 from commcare_connect.microplanning.forms import WorkAreaModelForm
 from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup, WorkAreaStatus
-from commcare_connect.opportunity.models import UserVisit
-from commcare_connect.organization.decorators import opportunity_required, org_admin_required
+from commcare_connect.opportunity.models import OpportunityAccess, UserVisit
+from commcare_connect.organization.decorators import (
+    opportunity_required,
+    org_admin_required,
+    org_program_manager_required,
+    request_user_is_program_manager,
+)
 from commcare_connect.utils.celery import CELERY_TASK_FAILURE, CELERY_TASK_SUCCESS
 from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 from commcare_connect.utils.file import get_file_extension
@@ -103,29 +108,74 @@ def microplanning_home(request, *args, **kwargs):
         for status in WorkAreaStatus
     }
 
+    is_program_manager = request_user_is_program_manager(request)
+    assignment_mode = is_program_manager and bool(request.GET.get("assignment_mode"))
+
     filterset = WorkAreaMapFilterSet(
         data=request.GET,
         opportunity=opportunity,
     )
+
+    context = {
+        "show_area_btn": show_area_btn,
+        "show_workarea_groups_btn": show_workarea_groups_btn,
+        "mapbox_api_key": settings.MAPBOX_TOKEN,
+        "task_id": request.GET.get("task_id"),
+        "opportunity": opportunity,
+        "metrics": get_metrics_for_microplanning(opportunity),
+        "tiles_url": tiles_url,
+        "visit_tiles_url": visit_tiles_url,
+        "groups_url": groups_url,
+        "status_meta": status_meta,
+        "workarea_min_zoom": WORKAREA_MIN_ZOOM,
+        "edit_work_area_url": edit_work_area_url,
+        "download_url": download_url,
+        "filter_form": filterset.form,
+        "is_program_manager": is_program_manager,
+        "assignment_mode": assignment_mode,
+    }
+
+    if assignment_mode:
+        org_slug = request.org.slug
+        opp_id = opportunity.opportunity_id
+
+        context["work_area_groups_json"] = list(
+            WorkAreaGroup.objects.filter(opportunity=opportunity).values("id", "name")
+        )
+        context["assignees_json"] = list(
+            OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True, suspended=False)
+            .select_related("user")
+            .values("id", "user__name", "user_id")
+        )
+        context["group_work_areas_url"] = reverse(
+            "microplanning:assignment_group_work_areas",
+            args=[org_slug, opp_id, 0],
+        ).replace("/0/", "/__group_id__/")
+        context["flw_work_areas_url"] = reverse(
+            "microplanning:assignment_flw_work_areas",
+            args=[org_slug, opp_id, 0],
+        ).replace("/0/", "/__assignee_id__/")
+        context["flw_summary_url"] = reverse(
+            "microplanning:assignment_flw_summary",
+            kwargs={"org_slug": org_slug, "opp_id": opp_id},
+        )
+        context["assignment_save_url"] = reverse(
+            "microplanning:assignment_save",
+            kwargs={"org_slug": org_slug, "opp_id": opp_id},
+        )
+        context["user_visits_url"] = reverse(
+            "opportunity:user_visits_list",
+            args=[org_slug, opp_id],
+        )
+        context["worker_list_url"] = reverse(
+            "opportunity:worker_list",
+            args=[org_slug, opp_id],
+        )
+
     return render(
         request,
         template_name="microplanning/home.html",
-        context={
-            "show_area_btn": show_area_btn,
-            "show_workarea_groups_btn": show_workarea_groups_btn,
-            "mapbox_api_key": settings.MAPBOX_TOKEN,
-            "task_id": request.GET.get("task_id"),
-            "opportunity": opportunity,
-            "metrics": get_metrics_for_microplanning(opportunity),
-            "tiles_url": tiles_url,
-            "visit_tiles_url": visit_tiles_url,
-            "groups_url": groups_url,
-            "status_meta": status_meta,
-            "workarea_min_zoom": WORKAREA_MIN_ZOOM,
-            "edit_work_area_url": edit_work_area_url,
-            "download_url": download_url,
-            "filter_form": filterset.form,
-        },
+        context=context,
     )
 
 
@@ -473,3 +523,66 @@ class ModifyWorkAreaUpdateView(UpdateView):
             }
         )
         return response
+
+
+@require_GET
+@org_program_manager_required
+@opportunity_required
+@require_flag_for_opp(MICROPLANNING)
+def assignment_group_work_areas(request, org_slug, opp_id, group_id):
+    ids = list(
+        WorkArea.objects.filter(
+            opportunity=request.opportunity,
+            work_area_group_id=group_id,
+        ).values_list("id", flat=True)
+    )
+    return JsonResponse({"work_area_ids": ids})
+
+
+@require_GET
+@org_program_manager_required
+@opportunity_required
+@require_flag_for_opp(MICROPLANNING)
+def assignment_flw_work_areas(request, org_slug, opp_id, assignee_id):
+    ids = list(
+        WorkArea.objects.filter(
+            opportunity=request.opportunity,
+            work_area_group__opportunity_access_id=assignee_id,
+        ).values_list("id", flat=True)
+    )
+    return JsonResponse({"work_area_ids": ids})
+
+
+@require_GET
+@org_program_manager_required
+@opportunity_required
+@require_flag_for_opp(MICROPLANNING)
+def assignment_flw_summary(request, org_slug, opp_id):
+    assignee_id = request.GET.get("assignee_id")
+    if not assignee_id:
+        return JsonResponse({"error": "assignee_id required"}, status=400)
+
+    qs = WorkArea.objects.filter(
+        opportunity=request.opportunity,
+        work_area_group__opportunity_access_id=assignee_id,
+    )
+    stats = qs.aggregate(
+        buildings=Sum("building_count"),
+        visits=Sum("expected_visit_count"),
+    )
+    return JsonResponse(
+        {
+            "assigned_buildings": stats["buildings"] or 0,
+            "assigned_visits": stats["visits"] or 0,
+            "assigned_work_areas": qs.count(),
+        }
+    )
+
+
+@require_http_methods(["POST"])
+@org_program_manager_required
+@opportunity_required
+@require_flag_for_opp(MICROPLANNING)
+def assignment_save(request, org_slug, opp_id):
+    """Stub endpoint for saving work area assignments. Accepts the payload but does not persist changes yet."""
+    return JsonResponse({"status": "ok"})

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -169,15 +169,15 @@ def _get_assignment_mode_context(request, opportunity):
             args=[org_slug, opp_id, 0],
         ).replace("/0/", "/__group_id__/"),
         "flw_work_areas_url": reverse(
-            "microplanning:assignment_flw_work_areas",
+            "microplanning:get_flw_work_areas_for_assignment",
             args=[org_slug, opp_id, 0],
         ).replace("/0/", "/__assignee_id__/"),
         "flw_summary_url": reverse(
-            "microplanning:assignment_flw_summary",
+            "microplanning:get_flw_summary_for_assignment",
             kwargs={"org_slug": org_slug, "opp_id": opp_id},
         ),
         "assignment_save_url": reverse(
-            "microplanning:assignment_save",
+            "microplanning:save_assignment",
             kwargs={"org_slug": org_slug, "opp_id": opp_id},
         ),
         "user_visits_url": reverse(
@@ -546,7 +546,7 @@ def get_work_areas_for_assignment(request, org_slug, opp_id, group_id):
 @org_program_manager_required
 @opportunity_required
 @require_flag_for_opp(MICROPLANNING)
-def assignment_flw_work_areas(request, org_slug, opp_id, assignee_id):
+def get_flw_work_areas_for_assignment(request, org_slug, opp_id, assignee_id):
     work_areas = list(
         WorkArea.objects.filter(
             opportunity=request.opportunity,
@@ -560,7 +560,7 @@ def assignment_flw_work_areas(request, org_slug, opp_id, assignee_id):
 @org_program_manager_required
 @opportunity_required
 @require_flag_for_opp(MICROPLANNING)
-def assignment_flw_summary(request, org_slug, opp_id):
+def get_flw_summary_for_assignment(request, org_slug, opp_id):
     assignee_id = request.GET.get("assignee_id")
     if not assignee_id:
         return JsonResponse({"error": "assignee_id required"}, status=400)
@@ -586,6 +586,6 @@ def assignment_flw_summary(request, org_slug, opp_id):
 @org_program_manager_required
 @opportunity_required
 @require_flag_for_opp(MICROPLANNING)
-def assignment_save(request, org_slug, opp_id):
+def save_assignment(request, org_slug, opp_id):
     """Stub endpoint for saving work area assignments. Accepts the payload but does not persist changes yet."""
     return JsonResponse({"status": "ok"})

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -70,6 +70,21 @@
                     <i class="fa-solid fa-play"></i> {% translate "Create Work Area Groups" %}
                 </button>
             {% endif %}
+            {% if is_program_manager and not assignment_mode %}
+                <a href="?assignment_mode=1" class="button button-md primary-dark ml-auto">
+                    <i class="fa-solid fa-users-gear"></i> {% translate "Enter Assignment Mode" %}
+                </a>
+            {% endif %}
+            {% if assignment_mode %}
+                <div class="flex items-center gap-2 ml-auto">
+                    <span class="text-sm font-semibold text-indigo-700 bg-indigo-100 px-3 py-1 rounded-full">
+                        <i class="fa-solid fa-users-gear"></i> {% translate "Assignment Mode" %}
+                    </span>
+                    <a href="{{ request.path }}" class="button button-md outline-style text-sm">
+                        <i class="fa-solid fa-xmark"></i> {% translate "Exit" %}
+                    </a>
+                </div>
+            {% endif %}
         </div>
         <div x-show="showImportWorkAreaModal" id="modal-container"></div>
         {% if show_workarea_groups_btn %}
@@ -91,6 +106,7 @@
 
         <!-- Sidebars (stacked) -->
         <div class="w-full xl:w-96 shrink-0 flex flex-col gap-2 min-h-0 xl:h-full">
+        {% if not assignment_mode %}
             <aside id="sidebar" class="bg-white shadow-md p-4 overflow-auto xl:flex-1 min-h-0">
                 <div class="flex items-center justify-between mb-2">
                     <h2 class="text-lg font-semibold">{% translate "Filter Map Work Areas" %}</h2>
@@ -127,63 +143,230 @@
                 </form>
             </aside>
 
-        <aside id="lower-sidebar" class="bg-white shadow-md p-4 xl:flex-1 min-h-0">
-            {{ status_meta|json_script:"status-meta-data" }}
-            <h2 class="text-lg font-semibold mb-2">{% translate "Select Work Area" %}</h2>
-            <template x-if="!selectedFeature">
-                <div class="flex flex-col items-center justify-center h-full text-center text-gray-400 gap-2 py-8">
-                    <i class="fa-regular fa-map text-3xl"></i>
-                    <p class="text-sm">{% translate "Click a work area on the map to view details." %}</p>
-                </div>
-            </template>
+            <aside id="lower-sidebar" class="bg-white shadow-md p-4 xl:flex-1 min-h-0">
+                {{ status_meta|json_script:"status-meta-data" }}
+                <h2 class="text-lg font-semibold mb-2">{% translate "Select Work Area" %}</h2>
+                <template x-if="!selectedFeature">
+                    <div class="flex flex-col items-center justify-center h-full text-center text-gray-400 gap-2 py-8">
+                        <i class="fa-regular fa-map text-3xl"></i>
+                        <p class="text-sm">{% translate "Click a work area on the map to view details." %}</p>
+                    </div>
+                </template>
 
-            <!-- Selected work area detail panel -->
-            <template x-if="selectedFeature">
-                <div>
-                    <dl class="space-y-2">
-                        <div class="grid grid-cols-2 items-center gap-2">
-                            <dt class="text-sm text-gray-500">{% translate "Assignee" %}</dt>
-                            <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
-                                x-text="selectedFeature.assignee_name ?? '—'"></dd>
+                <!-- Selected work area detail panel -->
+                <template x-if="selectedFeature">
+                    <div>
+                        <dl class="space-y-2">
+                            <div class="grid grid-cols-2 items-center gap-2">
+                                <dt class="text-sm text-gray-500">{% translate "Assignee" %}</dt>
+                                <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
+                                    x-text="selectedFeature.assignee_name ?? '—'"></dd>
 
-                            <dt class="text-sm text-gray-500">{% translate "Work Area Group" %}</dt>
-                            <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
-                                x-text="selectedFeature.group_name ?? '—'"></dd>
+                                <dt class="text-sm text-gray-500">{% translate "Work Area Group" %}</dt>
+                                <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
+                                    x-text="selectedFeature.group_name ?? '—'"></dd>
 
-                            <dt class="text-sm text-gray-500">{% translate "Expected Visit Count" %}</dt>
-                            <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                x-text="selectedFeature.expected_visit_count ?? '—'"></dd>
+                                <dt class="text-sm text-gray-500">{% translate "Expected Visit Count" %}</dt>
+                                <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
+                                    x-text="selectedFeature.expected_visit_count ?? '—'"></dd>
 
-                            <dt class="text-sm text-gray-500">{% translate "Number of Buildings" %}</dt>
-                            <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                x-text="selectedFeature.building_count ?? '—'"></dd>
+                                <dt class="text-sm text-gray-500">{% translate "Number of Buildings" %}</dt>
+                                <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
+                                    x-text="selectedFeature.building_count ?? '—'"></dd>
+                            </div>
+                            <div class="flex items-center gap-4"
+                                x-data="{statusMeta: JSON.parse(document.getElementById('status-meta-data').textContent)}">
+                                <dt class="text-sm text-gray-500 shrink-0">{% translate "Status" %}</dt>
+                                <dd class="flex-1 min-w-0">
+                                    <span class="block w-full text-center text-sm font-semibold rounded-lg px-3 py-2"
+                                        :class="statusMeta[selectedFeature.status]?.class"
+                                        x-text="statusMeta[selectedFeature.status]?.label">
+                                    </span>
+                                </dd>
+                            </div>
+                        </dl>
+                        <div class="mt-4 flex justify-end">
+                            <button class="button button-md button-outline-rounded" @click="openWorkAreaEditModal(selectedFeature._id)">
+                                <i class="fa-regular fa-pen-to-square"></i>
+                                {% translate "Modify Work Area" %}
+                            </button>
+                            <div x-show="showWorkAreaEditModal" x-cloak @click.self="showWorkAreaEditModal = false"
+                                @work-area-updated.window="showWorkAreaEditModal = false" class="modal-backdrop">
+                                <div class="modal relative" @click.stop>
+                                    <div id="work-area-form"></div>
+                                </div>
+                            </div>
                         </div>
-                        <div class="flex items-center gap-4"
-                            x-data="{statusMeta: JSON.parse(document.getElementById('status-meta-data').textContent)}">
-                            <dt class="text-sm text-gray-500 shrink-0">{% translate "Status" %}</dt>
-                            <dd class="flex-1 min-w-0">
-                                <span class="block w-full text-center text-sm font-semibold rounded-lg px-3 py-2"
-                                    :class="statusMeta[selectedFeature.status]?.class"
-                                    x-text="statusMeta[selectedFeature.status]?.label">
-                                </span>
-                            </dd>
-                        </div>
-                    </dl>
-                <div class="mt-4 flex justify-end">
-                    <button class="button button-md button-outline-rounded" @click="openWorkAreaEditModal(selectedFeature._id)">
-                        <i class="fa-regular fa-pen-to-square"></i>
-                        {% translate "Modify Work Area" %}
+                    </div>
+                </template>
+            </aside>
+        {% endif %}
+
+        {% if assignment_mode %}
+            {{ work_area_groups_json|json_script:"work-area-groups-data" }}
+            {{ assignees_json|json_script:"assignees-data" }}
+
+            <aside class="bg-white shadow-md p-4 overflow-auto flex flex-col gap-4 xl:flex-1 min-h-0">
+                <!-- Show only unassigned toggle -->
+                <div class="flex items-center justify-between">
+                    <label for="unassigned-toggle" class="text-sm text-gray-700">{% translate "Show only unassigned Work Areas" %}</label>
+                    <button id="unassigned-toggle" type="button" role="switch" :aria-checked="showOnlyUnassigned"
+                        @click="showOnlyUnassigned = !showOnlyUnassigned"
+                        :class="showOnlyUnassigned ? 'bg-indigo-600' : 'bg-gray-200'"
+                        class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">
+                        <span :class="showOnlyUnassigned ? 'translate-x-5' : 'translate-x-0'"
+                            class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"></span>
                     </button>
-                    <div x-show="showWorkAreaEditModal" x-cloak @click.self="showWorkAreaEditModal = false"
-                        @work-area-updated.window="showWorkAreaEditModal = false" class="modal-backdrop">
-                        <div class="modal relative" @click.stop>
-                            <div id="work-area-form"></div>
+                </div>
+
+                <!-- Panel 1: Select Work Areas to Assign -->
+                <div class="border-t pt-3">
+                    <h3 class="text-sm font-semibold mb-2">{% translate "Select Work Areas to Assign" %}</h3>
+                    <div class="space-y-2">
+                        <div>
+                            <label class="block text-xs text-gray-500 mb-1">{% translate "Select Work Area Group" %}</label>
+                            <select x-ref="groupSelect" @change="selectGroup($event.target.value)"
+                                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500">
+                                <option value="">{% translate "— Select Group —" %}</option>
+                                <template x-for="g in workAreaGroups" :key="g.id">
+                                    <option :value="g.id" x-text="g.name"></option>
+                                </template>
+                            </select>
+                        </div>
+                        <div class="flex items-center justify-between">
+                            <p class="text-xs text-gray-500">
+                                <span x-text="selectedWorkAreas.size"></span> {% translate "work areas selected" %}
+                            </p>
+                            <button type="button" @click="clearSelection()"
+                                :disabled="selectedWorkAreas.size === 0"
+                                class="button button-sm button-outline-rounded text-xs">
+                                {% translate "Unassign Selected Areas" %}
+                            </button>
                         </div>
                     </div>
                 </div>
+
+                <!-- Panel 2: Select new Assignee -->
+                <div class="border-t pt-3">
+                    <h3 class="text-sm font-semibold mb-2">{% translate "Select new Assignee" %}</h3>
+                    <select x-ref="assigneeSelect"
+                        @change="selectedAssigneeId = $event.target.value; selectByAssignee($event.target.value)"
+                        class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500">
+                        <option value="">{% translate "— Select FLW —" %}</option>
+                        <template x-for="a in assignees" :key="a.id">
+                            <option :value="a.id" x-text="a.user__name"></option>
+                        </template>
+                    </select>
                 </div>
-            </template>
-        </aside>
+
+                <!-- Panel 3: FLW Summary -->
+                <div class="border-t pt-3">
+                    <h3 class="text-sm font-semibold mb-2">{% translate "FLW Summary" %}</h3>
+                    <template x-if="!selectedAssigneeId">
+                        <p class="text-sm text-gray-400">{% translate "Select an assignee to view summary." %}</p>
+                    </template>
+                    <template x-if="selectedAssigneeId && flwSummaryLoading">
+                        <div class="flex justify-center py-4"><i class="fa-solid fa-spinner fa-spin text-gray-400"></i></div>
+                    </template>
+                    <template x-if="selectedAssigneeId && !flwSummaryLoading && flwSummary">
+                        <div>
+                            <dl class="space-y-2">
+                                <div class="grid grid-cols-2 items-center gap-2 text-sm">
+                                    <dt class="text-gray-500">{% translate "Count of Assigned Buildings" %}</dt>
+                                    <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
+                                        x-text="flwSummary.assigned_buildings + getSelectedStats().buildings"></dd>
+                                    <dt class="text-gray-500">{% translate "Count of Assigned Visits" %}</dt>
+                                    <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
+                                        x-text="flwSummary.assigned_visits + getSelectedStats().visits"></dd>
+                                    <dt class="text-gray-500">{% translate "Count of Assigned Work Areas" %}</dt>
+                                    <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
+                                        x-text="flwSummary.assigned_work_areas + selectedWorkAreas.size"></dd>
+                                </div>
+                            </dl>
+                            <div class="flex gap-2 mt-3">
+                                <a href="{{ worker_list_url }}" target="_blank"
+                                    class="button button-sm button-outline-rounded text-xs">
+                                    {% translate "View Summary by FLW" %}
+                                </a>
+                                <a :href="'{{ user_visits_url }}?user=' + getAssigneeUserId()" target="_blank"
+                                    class="button button-sm button-outline-rounded text-xs">
+                                    {% translate "View Visits" %}
+                                </a>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+
+                <!-- Bottom action bar -->
+                <div class="flex gap-2 mt-auto pt-4 border-t">
+                    <button type="button" @click="handleCancel()"
+                        class="button button-md outline-style flex-1">
+                        {% translate "Cancel" %}
+                    </button>
+                    <button type="button" class="button button-md primary-dark flex-1"
+                                          :disabled="selectedWorkAreas.size === 0 || !selectedAssigneeId"
+                                          @click="showConfirmModal = true">
+                      {% translate "Save and Confirm" %}
+                    </button>
+                </div>
+            </aside>
+
+            <!-- Save and Confirm modal -->
+            <div x-show="showConfirmModal" x-cloak @click.self="showConfirmModal = false" class="modal-backdrop">
+                <div class="modal relative p-6" @click.stop>
+                    <h3 class="text-lg font-semibold mb-3">{% translate "Warning" %}</h3>
+                    <p class="text-sm mb-4">
+                        {% translate "Saving these changes will alert all impacted FLWs that their assignment has changed. Are you sure you want to continue?" %}
+                    </p>
+                    <template x-if="flwSummary">
+                        <dl class="text-sm space-y-1 mb-4 bg-gray-50 rounded-lg p-3">
+                            <div class="flex justify-between">
+                                <dt>{% translate "Assignee" %}</dt>
+                                <dd class="font-semibold" x-text="getAssigneeName()"></dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt>{% translate "Work Areas" %}</dt>
+                                <dd class="font-semibold" x-text="selectedWorkAreas.size"></dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt>{% translate "Total Buildings" %}</dt>
+                                <dd class="font-semibold" x-text="getSelectedStats().buildings"></dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt>{% translate "Total Expected Visits" %}</dt>
+                                <dd class="font-semibold" x-text="getSelectedStats().visits"></dd>
+                            </div>
+                        </dl>
+                    </template>
+                    <div class="flex gap-2 justify-between">
+                        <button class="button button-md outline-style" @click="showConfirmModal = false">
+                            {% translate "Back to Edit" %}
+                        </button>
+                        <button class="button button-md primary-dark" @click="saveAssignment()">
+                            {% translate "Save and Confirm" %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Cancel/Discard modal -->
+            <div x-show="showDiscardModal" x-cloak @click.self="showDiscardModal = false" class="modal-backdrop">
+                <div class="modal relative p-6" @click.stop>
+                    <h3 class="text-lg font-semibold mb-3">{% translate "Warning" %}</h3>
+                    <p class="text-sm mb-4">
+                        {% translate "Your changes won't be saved. Are you sure you want to continue?" %}
+                    </p>
+                    <div class="flex gap-2 justify-between">
+                        <a href="{{ request.path }}" class="button button-md outline-style">
+                            {% translate "Continue" %}
+                        </a>
+                        <button class="button button-md primary-dark" @click="showDiscardModal = false">
+                            {% translate "Back to Edit" %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
 </div>
 </div>
 </div>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -203,7 +203,6 @@
         {% endif %}
 
         {% if assignment_mode %}
-            {{ work_area_groups_json|json_script:"work-area-groups-data" }}
             {{ assignees_json|json_script:"assignees-data" }}
 
             <aside class="bg-white shadow-md p-4 overflow-auto flex flex-col gap-4 xl:flex-1 min-h-0">
@@ -224,19 +223,21 @@
                     <h3 class="text-sm font-semibold mb-2">{% translate "Select Work Areas to Assign" %}</h3>
                     <div class="space-y-2">
                         <div>
-                            <label class="block text-xs text-gray-500 mb-1">{% translate "Select Work Area Group" %}</label>
-                            <select x-ref="groupSelect" @change="selectGroup($event.target.value)"
-                                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500">
-                                <option value="">{% translate "— Select Group —" %}</option>
-                                <template x-for="g in workAreaGroups" :key="g.id">
-                                    <option :value="g.id" x-text="g.name"></option>
-                                </template>
-                            </select>
+                            <label for="{{ assignment_form.work_area_group.id_for_label }}"
+                                class="block text-xs text-gray-500 mb-1">
+                                {{ assignment_form.work_area_group.label }}
+                            </label>
+                            {{ assignment_form.work_area_group }}
                         </div>
-                        <div class="flex items-center justify-between">
-                            <p class="text-xs text-gray-500">
-                                <span x-text="selectedWorkAreas.size"></span> {% translate "work areas selected" %}
-                            </p>
+                        <p class="text-xs text-gray-500">
+                            <span x-text="selectedWorkAreas.size"></span> {% translate "work areas selected" %}
+                        </p>
+                        <div class="flex items-center gap-2">
+                            <button type="button" disabled
+                                title="{% translate 'Exclude from Opportunity will be available in a future update' %}"
+                                class="button button-sm button-outline-rounded text-xs opacity-50 cursor-not-allowed">
+                                {% translate "Exclude from Opportunity" %}
+                            </button>
                             <button type="button" @click="clearSelection()"
                                 :disabled="selectedWorkAreas.size === 0"
                                 class="button button-sm button-outline-rounded text-xs">
@@ -248,15 +249,8 @@
 
                 <!-- Panel 2: Select new Assignee -->
                 <div class="border-t pt-3">
-                    <h3 class="text-sm font-semibold mb-2">{% translate "Select new Assignee" %}</h3>
-                    <select x-ref="assigneeSelect"
-                        @change="selectedAssigneeId = $event.target.value; selectByAssignee($event.target.value)"
-                        class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500">
-                        <option value="">{% translate "— Select FLW —" %}</option>
-                        <template x-for="a in assignees" :key="a.id">
-                            <option :value="a.id" x-text="a.user__name"></option>
-                        </template>
-                    </select>
+                    <h3 class="text-sm font-semibold mb-2">{{ assignment_form.assignee.label }}</h3>
+                    {{ assignment_form.assignee }}
                 </div>
 
                 <!-- Panel 3: FLW Summary -->

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -287,25 +287,36 @@
                 <!-- Panel 3: FLW Summary -->
                 <div class="border-t border-gray-200 pt-3">
                     <h3 class="text-sm font-semibold mb-2">{% translate "FLW Summary" %}</h3>
-                    <template x-if="!selectedAssigneeId">
-                        <p class="text-sm text-gray-400">{% translate "Select an assignee to view summary." %}</p>
+                    <div class="mb-2">
+                        <label class="block text-xs text-gray-500 mb-1">{% translate "Select FLW" %}</label>
+                        <select x-ref="flwSummarySelect"
+                            @change="flwSummaryAssigneeId = $event.target.value; updateFlwSummary()"
+                            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500">
+                            <option value="">{% translate "— Select FLW —" %}</option>
+                            <template x-for="a in assignees" :key="a.id">
+                                <option :value="a.id" x-text="a.user__name"></option>
+                            </template>
+                        </select>
+                    </div>
+                    <template x-if="!flwSummaryAssigneeId">
+                        <p class="text-sm text-gray-400">{% translate "Select an FLW to view summary." %}</p>
                     </template>
-                    <template x-if="selectedAssigneeId && flwSummaryLoading">
+                    <template x-if="flwSummaryAssigneeId && flwSummaryLoading">
                         <div class="flex justify-center py-4"><i class="fa-solid fa-spinner fa-spin text-gray-400"></i></div>
                     </template>
-                    <template x-if="selectedAssigneeId && !flwSummaryLoading && flwSummary">
+                    <template x-if="flwSummaryAssigneeId && !flwSummaryLoading && flwSummary">
                         <div>
                             <dl class="space-y-2">
                                 <div class="grid grid-cols-2 items-center gap-2 text-sm">
                                     <dt class="text-gray-500">{% translate "Count of Assigned Buildings" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_buildings + getQueuedStatsForAssignee().buildings + getSelectedStats().buildings"></dd>
+                                        x-text="flwSummary.assigned_buildings + getQueuedStatsForAssignee().buildings + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStats().buildings : 0)"></dd>
                                     <dt class="text-gray-500">{% translate "Count of Assigned Visits" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_visits + getQueuedStatsForAssignee().visits + getSelectedStats().visits"></dd>
+                                        x-text="flwSummary.assigned_visits + getQueuedStatsForAssignee().visits + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStats().visits : 0)"></dd>
                                     <dt class="text-gray-500">{% translate "Count of Assigned Work Areas" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_work_areas + getQueuedStatsForAssignee().workAreas + selectedWorkAreas.size"></dd>
+                                        x-text="flwSummary.assigned_work_areas + getQueuedStatsForAssignee().workAreas + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? selectedWorkAreas.size : 0)"></dd>
                                 </div>
                             </dl>
                             <div class="flex gap-2 mt-3">
@@ -313,7 +324,7 @@
                                     class="button button-sm outline-style text-xs">
                                     {% translate "View Summary by FLW" %}
                                 </a>
-                                <a :href="'{{ user_visits_url }}?user=' + getAssigneeUserId()" target="_blank"
+                                <a :href="'{{ user_visits_url }}?user=' + getFlwSummaryUserId()" target="_blank"
                                     class="button button-sm outline-style text-xs">
                                     {% translate "View Visits" %}
                                 </a>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -238,9 +238,9 @@
                                 class="button button-sm outline-style text-xs opacity-50 cursor-not-allowed">
                                 {% translate "Exclude from Opportunity" %}
                             </button>
-                            <button type="button" @click="clearSelection()"
-                                :disabled="selectedWorkAreas.size === 0"
-                                class="button button-sm outline-style text-xs">
+                            <button type="button" disabled
+                                title="{% translate 'Unassign Selected Areas will be available in a future update' %}"
+                                class="button button-sm outline-style text-xs opacity-50 cursor-not-allowed">
                                 {% translate "Unassign Selected Areas" %}
                             </button>
                         </div>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -251,7 +251,38 @@
                 <div class="border-t border-gray-200 pt-3">
                     <h3 class="text-sm font-semibold mb-2">{{ assignment_form.assignee.label }}</h3>
                     {{ assignment_form.assignee }}
+                    <div class="flex justify-end">
+                      <button type="button" @click="addToQueue()"
+                          :disabled="selectedWorkAreas.size === 0 || !selectedAssigneeId"
+                          class="button button-sm primary-dark text-xs mt-2">
+                          <i class="fa-solid fa-plus"></i> {% translate "Save" %}
+                      </button>
+                    </div>
                 </div>
+
+                <!-- Queued assignments -->
+                <template x-if="assignmentQueue.length > 0">
+                    <div class="border-t border-gray-200 pt-3">
+                        <h3 class="text-sm font-semibold mb-2">
+                            {% translate "Pending Assignments" %}
+                            <span class="text-gray-400 font-normal" x-text="'(' + assignmentQueue.length + ')'"></span>
+                        </h3>
+                        <div class="space-y-2 max-h-40 overflow-auto">
+                            <template x-for="(entry, index) in assignmentQueue" :key="index">
+                                <div class="flex items-center justify-between bg-gray-50 rounded-lg px-3 py-2 text-xs">
+                                    <div class="min-w-0">
+                                        <span class="font-medium truncate block" x-text="entry.assignee_name"></span>
+                                        <span class="text-gray-500" x-text="entry.work_area_ids.length + ' work areas'"></span>
+                                    </div>
+                                    <button type="button" @click="removeFromQueue(index)"
+                                        class="text-red-500 hover:text-red-700 ml-2 shrink-0">
+                                        <i class="fa-solid fa-xmark"></i>
+                                    </button>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                </template>
 
                 <!-- Panel 3: FLW Summary -->
                 <div class="border-t border-gray-200 pt-3">
@@ -268,13 +299,13 @@
                                 <div class="grid grid-cols-2 items-center gap-2 text-sm">
                                     <dt class="text-gray-500">{% translate "Count of Assigned Buildings" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_buildings + getSelectedStats().buildings"></dd>
+                                        x-text="flwSummary.assigned_buildings + getQueuedStatsForAssignee().buildings + getSelectedStats().buildings"></dd>
                                     <dt class="text-gray-500">{% translate "Count of Assigned Visits" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_visits + getSelectedStats().visits"></dd>
+                                        x-text="flwSummary.assigned_visits + getQueuedStatsForAssignee().visits + getSelectedStats().visits"></dd>
                                     <dt class="text-gray-500">{% translate "Count of Assigned Work Areas" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_work_areas + selectedWorkAreas.size"></dd>
+                                        x-text="flwSummary.assigned_work_areas + getQueuedStatsForAssignee().workAreas + selectedWorkAreas.size"></dd>
                                 </div>
                             </dl>
                             <div class="flex gap-2 mt-3">
@@ -298,8 +329,8 @@
                         {% translate "Cancel" %}
                     </button>
                     <button type="button" class="button button-md primary-dark flex-1"
-                                          :disabled="selectedWorkAreas.size === 0 || !selectedAssigneeId"
-                                          @click="showConfirmModal = true">
+                        :disabled="assignmentQueue.length === 0 && (selectedWorkAreas.size === 0 || !selectedAssigneeId)"
+                        @click="handleSaveAndConfirm()">
                       {% translate "Save and Confirm" %}
                     </button>
                 </div>
@@ -312,26 +343,28 @@
                     <p class="text-sm mb-4">
                         {% translate "Saving these changes will alert all impacted FLWs that their assignment has changed. Are you sure you want to continue?" %}
                     </p>
-                    <template x-if="flwSummary">
-                        <dl class="text-sm space-y-1 mb-4 bg-gray-50 rounded-lg p-3">
-                            <div class="flex justify-between">
-                                <dt>{% translate "Assignee" %}</dt>
-                                <dd class="font-semibold" x-text="getAssigneeName()"></dd>
-                            </div>
-                            <div class="flex justify-between">
-                                <dt>{% translate "Work Areas" %}</dt>
-                                <dd class="font-semibold" x-text="selectedWorkAreas.size"></dd>
-                            </div>
-                            <div class="flex justify-between">
-                                <dt>{% translate "Total Buildings" %}</dt>
-                                <dd class="font-semibold" x-text="getSelectedStats().buildings"></dd>
-                            </div>
-                            <div class="flex justify-between">
-                                <dt>{% translate "Total Expected Visits" %}</dt>
-                                <dd class="font-semibold" x-text="getSelectedStats().visits"></dd>
-                            </div>
-                        </dl>
-                    </template>
+                    <div class="space-y-2 mb-4 max-h-60 overflow-auto">
+                        <template x-for="(entry, index) in assignmentQueue" :key="index">
+                            <dl class="text-sm space-y-1 bg-gray-50 rounded-lg p-3">
+                                <div class="flex justify-between">
+                                    <dt>{% translate "Assignee" %}</dt>
+                                    <dd class="font-semibold" x-text="entry.assignee_name"></dd>
+                                </div>
+                                <div class="flex justify-between">
+                                    <dt>{% translate "Work Areas" %}</dt>
+                                    <dd class="font-semibold" x-text="entry.work_area_ids.length"></dd>
+                                </div>
+                                <div class="flex justify-between">
+                                    <dt>{% translate "Total Buildings" %}</dt>
+                                    <dd class="font-semibold" x-text="entry.buildings"></dd>
+                                </div>
+                                <div class="flex justify-between">
+                                    <dt>{% translate "Total Expected Visits" %}</dt>
+                                    <dd class="font-semibold" x-text="entry.visits"></dd>
+                                </div>
+                            </dl>
+                        </template>
+                    </div>
                     <div class="flex gap-2 justify-between">
                         <button class="button button-md outline-style" @click="showConfirmModal = false">
                             {% translate "Back to Edit" %}

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -272,7 +272,7 @@
                                 <div class="flex items-center justify-between bg-gray-50 rounded-lg px-3 py-2 text-xs">
                                     <div class="min-w-0">
                                         <span class="font-medium truncate block" x-text="entry.assignee_name"></span>
-                                        <span class="text-gray-500" x-text="entry.work_area_ids.length + ' work areas'"></span>
+                                        <span class="text-gray-500"><span x-text="entry.work_area_ids.length"></span> {% translate "work areas" %}</span>
                                     </div>
                                     <button type="button" @click="removeFromQueue(index)"
                                         class="text-red-500 hover:text-red-700 ml-2 shrink-0">

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -219,7 +219,7 @@
                 </div>
 
                 <!-- Panel 1: Select Work Areas to Assign -->
-                <div class="border-t pt-3">
+                <div class="border-t border-gray-200 pt-3">
                     <h3 class="text-sm font-semibold mb-2">{% translate "Select Work Areas to Assign" %}</h3>
                     <div class="space-y-2">
                         <div>
@@ -248,13 +248,13 @@
                 </div>
 
                 <!-- Panel 2: Select new Assignee -->
-                <div class="border-t pt-3">
+                <div class="border-t border-gray-200 pt-3">
                     <h3 class="text-sm font-semibold mb-2">{{ assignment_form.assignee.label }}</h3>
                     {{ assignment_form.assignee }}
                 </div>
 
                 <!-- Panel 3: FLW Summary -->
-                <div class="border-t pt-3">
+                <div class="border-t border-gray-200 pt-3">
                     <h3 class="text-sm font-semibold mb-2">{% translate "FLW Summary" %}</h3>
                     <template x-if="!selectedAssigneeId">
                         <p class="text-sm text-gray-400">{% translate "Select an assignee to view summary." %}</p>
@@ -292,7 +292,7 @@
                 </div>
 
                 <!-- Bottom action bar -->
-                <div class="flex gap-2 mt-auto pt-4 border-t">
+                <div class="flex gap-2 mt-auto pt-4 border-t border-gray-200">
                     <button type="button" @click="handleCancel()"
                         class="button button-md outline-style flex-1">
                         {% translate "Cancel" %}

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -232,15 +232,15 @@
                         <p class="text-xs text-gray-500">
                             <span x-text="selectedWorkAreas.size"></span> {% translate "work areas selected" %}
                         </p>
-                        <div class="flex items-center gap-2">
+                        <div class="flex flex-col items-end gap-2">
                             <button type="button" disabled
                                 title="{% translate 'Exclude from Opportunity will be available in a future update' %}"
-                                class="button button-sm button-outline-rounded text-xs opacity-50 cursor-not-allowed">
+                                class="button button-sm outline-style text-xs opacity-50 cursor-not-allowed">
                                 {% translate "Exclude from Opportunity" %}
                             </button>
                             <button type="button" @click="clearSelection()"
                                 :disabled="selectedWorkAreas.size === 0"
-                                class="button button-sm button-outline-rounded text-xs">
+                                class="button button-sm outline-style text-xs">
                                 {% translate "Unassign Selected Areas" %}
                             </button>
                         </div>
@@ -279,11 +279,11 @@
                             </dl>
                             <div class="flex gap-2 mt-3">
                                 <a href="{{ worker_list_url }}" target="_blank"
-                                    class="button button-sm button-outline-rounded text-xs">
+                                    class="button button-sm outline-style text-xs">
                                     {% translate "View Summary by FLW" %}
                                 </a>
                                 <a :href="'{{ user_visits_url }}?user=' + getAssigneeUserId()" target="_blank"
-                                    class="button button-sm button-outline-rounded text-xs">
+                                    class="button button-sm outline-style text-xs">
                                     {% translate "View Visits" %}
                                 </a>
                             </div>

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -24,6 +24,7 @@
             showOnlyUnassigned: false,
             assignees: [],
             workAreaProperties: new Map(),
+            assignmentQueue: [],
 
 
             openWorkAreaEditModal(workAreaId) {
@@ -229,6 +230,20 @@
                 return { buildings, visits };
             },
 
+            getQueuedStatsForAssignee() {
+                let buildings = 0;
+                let visits = 0;
+                let workAreas = 0;
+                for (const entry of this.assignmentQueue) {
+                    if (String(entry.assignee_id) === String(this.selectedAssigneeId)) {
+                        buildings += entry.buildings;
+                        visits += entry.visits;
+                        workAreas += entry.work_area_ids.length;
+                    }
+                }
+                return { buildings, visits, workAreas };
+            },
+
             getAssigneeName() {
                 const a = this.assignees.find(a => String(a.id) === String(this.selectedAssigneeId));
                 return a ? a.user__name : '';
@@ -239,11 +254,35 @@
                 return a ? a.user_id : '';
             },
 
-            async saveAssignment() {
-                const payload = {
+            addToQueue() {
+                if (this.selectedWorkAreas.size === 0 || !this.selectedAssigneeId) return;
+                this.assignmentQueue.push({
                     assignee_id: this.selectedAssigneeId,
+                    assignee_name: this.getAssigneeName(),
                     work_area_ids: Array.from(this.selectedWorkAreas),
-                };
+                    buildings: this.getSelectedStats().buildings,
+                    visits: this.getSelectedStats().visits,
+                });
+                this.clearSelection();
+                if (this.$refs.assigneeSelect) this.$refs.assigneeSelect.value = '';
+                this.selectedAssigneeId = null;
+                this.flwSummary = null;
+            },
+
+            removeFromQueue(index) {
+                this.assignmentQueue.splice(index, 1);
+            },
+
+            handleSaveAndConfirm() {
+                if (this.selectedWorkAreas.size > 0 && this.selectedAssigneeId) {
+                    this.addToQueue();
+                }
+                if (this.assignmentQueue.length > 0) {
+                    this.showConfirmModal = true;
+                }
+            },
+
+            async saveAssignment() {
                 try {
                     const resp = await fetch('{{ assignment_save_url|escapejs }}', {
                         method: 'POST',
@@ -251,11 +290,12 @@
                             'Content-Type': 'application/json',
                             'X-CSRFToken': '{{ csrf_token }}',
                         },
-                        body: JSON.stringify(payload),
+                        body: JSON.stringify({ assignments: this.assignmentQueue }),
                     });
                     if (resp.ok) {
                         this.showConfirmModal = false;
                         this.showToast("{% translate 'Assignment saved successfully!' %}");
+                        this.assignmentQueue = [];
                         this.clearSelection();
                         if (this.$refs.assigneeSelect) this.$refs.assigneeSelect.value = '';
                         this.selectedAssigneeId = null;
@@ -269,7 +309,7 @@
             },
 
             handleCancel() {
-                if (this.selectedWorkAreas.size > 0 || this.selectedAssigneeId) {
+                if (this.assignmentQueue.length > 0 || this.selectedWorkAreas.size > 0 || this.selectedAssigneeId) {
                     this.showDiscardModal = true;
                 } else {
                     window.location.href = window.location.pathname;

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -9,6 +9,23 @@
             showVisits: false,
             filterQuery: '',
 
+            // Assignment mode state
+            assignmentMode: {{ assignment_mode|yesno:'true,false' }},
+            selectedWorkAreas: new Set(),
+            groupWorkAreaIds: new Set(),
+            flwFilterWorkAreaIds: new Set(),
+            selectedGroupId: null,
+            selectedFlwFilterId: null,
+            selectedAssigneeId: null,
+            flwSummary: null,
+            flwSummaryLoading: false,
+            showConfirmModal: false,
+            showDiscardModal: false,
+            showOnlyUnassigned: false,
+            workAreaGroups: [],
+            assignees: [],
+            workAreaProperties: new Map(),
+
 
             openWorkAreaEditModal(workAreaId) {
                 const editWorkAreaUrl = '{{ edit_work_area_url|escapejs }}';
@@ -66,10 +83,213 @@
                 this.applyFilters();
             },
 
+            // --- Assignment mode methods ---
+
+            toggleWorkAreaSelection(id, properties) {
+                if (this.selectedWorkAreas.has(id)) {
+                    this.selectedWorkAreas.delete(id);
+                    this.groupWorkAreaIds.delete(id);
+                    this.flwFilterWorkAreaIds.delete(id);
+                } else {
+                    this.selectedWorkAreas.add(id);
+                    if (properties) {
+                        this.workAreaProperties.set(id, properties);
+                    }
+                }
+                this.map.setFeatureState(
+                    { source: 'workareas', sourceLayer: 'workareas', id },
+                    { assignment_selected: this.selectedWorkAreas.has(id) }
+                );
+                this.updateFlwSummary();
+            },
+
+            async selectGroup(groupId) {
+                // Clear previous group selections
+                for (const id of this.groupWorkAreaIds) {
+                    this.selectedWorkAreas.delete(id);
+                    this.map.setFeatureState(
+                        { source: 'workareas', sourceLayer: 'workareas', id },
+                        { assignment_selected: false }
+                    );
+                }
+                this.groupWorkAreaIds.clear();
+                this.selectedGroupId = groupId || null;
+
+                if (!groupId) {
+                    this.updateFlwSummary();
+                    return;
+                }
+
+                try {
+                    const url = '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId);
+                    const resp = await fetch(url);
+                    const data = await resp.json();
+                    for (const id of data.work_area_ids) {
+                        this.selectedWorkAreas.add(id);
+                        this.groupWorkAreaIds.add(id);
+                        this.map.setFeatureState(
+                            { source: 'workareas', sourceLayer: 'workareas', id },
+                            { assignment_selected: true }
+                        );
+                    }
+                } catch (e) {
+                    this.showToast("{% translate 'Failed to load group work areas' %}", true);
+                }
+                this.updateFlwSummary();
+            },
+
+            async selectByAssignee(assigneeId) {
+                // Clear previous FLW-filter selections
+                for (const id of this.flwFilterWorkAreaIds) {
+                    this.selectedWorkAreas.delete(id);
+                    this.map.setFeatureState(
+                        { source: 'workareas', sourceLayer: 'workareas', id },
+                        { assignment_selected: false }
+                    );
+                }
+                this.flwFilterWorkAreaIds.clear();
+                this.selectedFlwFilterId = assigneeId || null;
+
+                if (!assigneeId) {
+                    this.updateFlwSummary();
+                    return;
+                }
+
+                try {
+                    const url = '{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId);
+                    const resp = await fetch(url);
+                    const data = await resp.json();
+                    for (const id of data.work_area_ids) {
+                        this.selectedWorkAreas.add(id);
+                        this.flwFilterWorkAreaIds.add(id);
+                        this.map.setFeatureState(
+                            { source: 'workareas', sourceLayer: 'workareas', id },
+                            { assignment_selected: true }
+                        );
+                    }
+                } catch (e) {
+                    this.showToast("{% translate 'Failed to load FLW work areas' %}", true);
+                }
+                this.updateFlwSummary();
+            },
+
+            clearSelection() {
+                for (const id of this.selectedWorkAreas) {
+                    this.map.setFeatureState(
+                        { source: 'workareas', sourceLayer: 'workareas', id },
+                        { assignment_selected: false }
+                    );
+                }
+                this.selectedWorkAreas.clear();
+                this.groupWorkAreaIds.clear();
+                this.flwFilterWorkAreaIds.clear();
+                if (this.$refs.groupSelect) this.$refs.groupSelect.value = '';
+                this.selectedGroupId = null;
+                this.selectedFlwFilterId = null;
+                this.updateFlwSummary();
+            },
+
+            async updateFlwSummary() {
+                if (!this.selectedAssigneeId) {
+                    this.flwSummary = null;
+                    return;
+                }
+                this.flwSummaryLoading = true;
+                try {
+                    const url = `{{ flw_summary_url|escapejs }}?assignee_id=${this.selectedAssigneeId}`;
+                    const resp = await fetch(url);
+                    this.flwSummary = await resp.json();
+                } catch (e) {
+                    this.showToast("{% translate 'Failed to load FLW summary' %}", true);
+                }
+                this.flwSummaryLoading = false;
+            },
+
+            getSelectedStats() {
+                let buildings = 0;
+                let visits = 0;
+                for (const id of this.selectedWorkAreas) {
+                    const props = this.workAreaProperties.get(id);
+                    if (props) {
+                        buildings += parseInt(props.building_count) || 0;
+                        visits += parseInt(props.expected_visit_count) || 0;
+                    }
+                }
+                return { buildings, visits };
+            },
+
+            getAssigneeName() {
+                const a = this.assignees.find(a => String(a.id) === String(this.selectedAssigneeId));
+                return a ? a.user__name : '';
+            },
+
+            getAssigneeUserId() {
+                const a = this.assignees.find(a => String(a.id) === String(this.selectedAssigneeId));
+                return a ? a.user_id : '';
+            },
+
+            async saveAssignment() {
+                const payload = {
+                    assignee_id: this.selectedAssigneeId,
+                    work_area_ids: Array.from(this.selectedWorkAreas),
+                };
+                try {
+                    const resp = await fetch('{{ assignment_save_url|escapejs }}', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': '{{ csrf_token }}',
+                        },
+                        body: JSON.stringify(payload),
+                    });
+                    if (resp.ok) {
+                        this.showConfirmModal = false;
+                        this.showToast("{% translate 'Assignment saved successfully!' %}");
+                        this.clearSelection();
+                        if (this.$refs.assigneeSelect) this.$refs.assigneeSelect.value = '';
+                        this.selectedAssigneeId = null;
+                        this.flwSummary = null;
+                    } else {
+                        this.showToast("{% translate 'Failed to save assignment' %}", true);
+                    }
+                } catch (e) {
+                    this.showToast("{% translate 'Failed to save assignment' %}", true);
+                }
+            },
+
+            handleCancel() {
+                if (this.selectedWorkAreas.size > 0 || this.selectedAssigneeId) {
+                    this.showDiscardModal = true;
+                } else {
+                    window.location.href = window.location.pathname;
+                }
+            },
+
+            applyUnassignedFilter() {
+                if (!this.map) return;
+                const baseUrl = `${window.location.origin}{{ tiles_url|escapejs }}`;
+                const newUrl = this.showOnlyUnassigned ? `${baseUrl}?unassigned_only=true` : baseUrl;
+                const source = this.map.getSource('workareas');
+                if (source) {
+                    source.setTiles([newUrl]);
+                }
+            },
+
             init() {
                 this.$nextTick(() => {
                     this.initializeMap();
                 });
+
+                if (this.assignmentMode) {
+                    const groupsEl = document.getElementById('work-area-groups-data');
+                    const assigneesEl = document.getElementById('assignees-data');
+                    if (groupsEl) this.workAreaGroups = JSON.parse(groupsEl.textContent);
+                    if (assigneesEl) this.assignees = JSON.parse(assigneesEl.textContent);
+
+                    this.$watch('showOnlyUnassigned', () => {
+                        this.applyUnassignedFilter();
+                    });
+                }
 
                 document.addEventListener('workAreaUpdated', (e) => {
                     const data = e.detail;
@@ -236,6 +456,39 @@
                     }
                 });
 
+                // Orange highlight for assignment mode multi-select
+                if (this.assignmentMode) {
+                    this.map.addLayer({
+                        id: 'workareas-assignment-selected',
+                        type: 'line',
+                        source: 'workareas',
+                        'source-layer': 'workareas',
+                        minzoom: 8,
+                        paint: {
+                            'line-color': '#ff8c00',
+                            'line-width': 3,
+                            'line-opacity': [
+                                'case',
+                                ['boolean', ['feature-state', 'assignment_selected'], false],
+                                1,
+                                0
+                            ]
+                        }
+                    });
+
+                    // Reapply assignment_selected state when tiles reload (pan/zoom)
+                    this.map.on('sourcedata', (e) => {
+                        if (e.sourceId === 'workareas' && e.isSourceLoaded) {
+                            for (const id of this.selectedWorkAreas) {
+                                this.map.setFeatureState(
+                                    { source: 'workareas', sourceLayer: 'workareas', id },
+                                    { assignment_selected: true }
+                                );
+                            }
+                        }
+                    });
+                }
+
                 // Source and layer are added lazily on first toggle to avoid
                 // fetching tiles while the layer is hidden.
                 const visitBaseUrl = `${window.location.origin}{{ visit_tiles_url|escapejs }}`;
@@ -338,6 +591,13 @@
                     const feature = e.features?.[0];
                     if (!feature || feature.id == null) return;
                     const id = feature.id;
+
+                    // In assignment mode, toggle multi-select instead of single-select
+                    if (this.assignmentMode) {
+                        this.toggleWorkAreaSelection(id, feature.properties);
+                        return;
+                    }
+
                     if (this.selectedFeature) {
                         this.map.setFeatureState(
                             {

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -22,7 +22,6 @@
             showConfirmModal: false,
             showDiscardModal: false,
             showOnlyUnassigned: false,
-            workAreaGroups: [],
             assignees: [],
             workAreaProperties: new Map(),
 
@@ -281,9 +280,7 @@
                 });
 
                 if (this.assignmentMode) {
-                    const groupsEl = document.getElementById('work-area-groups-data');
                     const assigneesEl = document.getElementById('assignees-data');
-                    if (groupsEl) this.workAreaGroups = JSON.parse(groupsEl.textContent);
                     if (assigneesEl) this.assignees = JSON.parse(assigneesEl.textContent);
 
                     this.$watch('showOnlyUnassigned', () => {

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -17,6 +17,7 @@
             selectedGroupId: null,
             selectedFlwFilterId: null,
             selectedAssigneeId: null,
+            flwSummaryAssigneeId: null,
             flwSummary: null,
             flwSummaryLoading: false,
             showConfirmModal: false,
@@ -202,13 +203,13 @@
             },
 
             async updateFlwSummary() {
-                if (!this.selectedAssigneeId) {
+                if (!this.flwSummaryAssigneeId) {
                     this.flwSummary = null;
                     return;
                 }
                 this.flwSummaryLoading = true;
                 try {
-                    const url = `{{ flw_summary_url|escapejs }}?assignee_id=${this.selectedAssigneeId}`;
+                    const url = `{{ flw_summary_url|escapejs }}?assignee_id=${this.flwSummaryAssigneeId}`;
                     const resp = await fetch(url);
                     this.flwSummary = await resp.json();
                 } catch (e) {
@@ -235,7 +236,7 @@
                 let visits = 0;
                 let workAreas = 0;
                 for (const entry of this.assignmentQueue) {
-                    if (String(entry.assignee_id) === String(this.selectedAssigneeId)) {
+                    if (String(entry.assignee_id) === String(this.flwSummaryAssigneeId)) {
                         buildings += entry.buildings;
                         visits += entry.visits;
                         workAreas += entry.work_area_ids.length;
@@ -251,6 +252,11 @@
 
             getAssigneeUserId() {
                 const a = this.assignees.find(a => String(a.id) === String(this.selectedAssigneeId));
+                return a ? a.user_id : '';
+            },
+
+            getFlwSummaryUserId() {
+                const a = this.assignees.find(a => String(a.id) === String(this.flwSummaryAssigneeId));
                 return a ? a.user_id : '';
             },
 

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -137,11 +137,12 @@
                     const url = '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId);
                     const resp = await fetch(url);
                     const data = await resp.json();
-                    for (const id of data.work_area_ids) {
-                        this.selectedWorkAreas.add(id);
-                        this.groupWorkAreaIds.add(id);
+                    for (const wa of data.work_areas) {
+                        this.selectedWorkAreas.add(wa.id);
+                        this.groupWorkAreaIds.add(wa.id);
+                        this.workAreaProperties.set(wa.id, wa);
                         this.map.setFeatureState(
-                            { source: 'workareas', sourceLayer: 'workareas', id },
+                            { source: 'workareas', sourceLayer: 'workareas', id: wa.id },
                             { assignment_selected: true }
                         );
                     }
@@ -172,11 +173,12 @@
                     const url = '{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId);
                     const resp = await fetch(url);
                     const data = await resp.json();
-                    for (const id of data.work_area_ids) {
-                        this.selectedWorkAreas.add(id);
-                        this.flwFilterWorkAreaIds.add(id);
+                    for (const wa of data.work_areas) {
+                        this.selectedWorkAreas.add(wa.id);
+                        this.flwFilterWorkAreaIds.add(wa.id);
+                        this.workAreaProperties.set(wa.id, wa);
                         this.map.setFeatureState(
-                            { source: 'workareas', sourceLayer: 'workareas', id },
+                            { source: 'workareas', sourceLayer: 'workareas', id: wa.id },
                             { assignment_selected: true }
                         );
                     }

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -513,7 +513,7 @@
                     }
                 });
 
-                // Orange highlight for assignment mode multi-select
+                // Black highlight for assignment mode multi-select
                 if (this.assignmentMode) {
                     this.map.addLayer({
                         id: 'workareas-assignment-selected',
@@ -522,7 +522,7 @@
                         'source-layer': 'workareas',
                         minzoom: 8,
                         paint: {
-                            'line-color': '#ff8c00',
+                            'line-color': '#000000',
                             'line-width': 3,
                             'line-opacity': [
                                 'case',

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -85,9 +85,9 @@
             // --- Assignment mode methods ---
 
             toggleWorkAreaSelection(id, properties) {
-                if (this.selectedWorkAreas.has(id)) {
+                const isDeselecting = this.selectedWorkAreas.has(id);
+                if (isDeselecting) {
                     this.selectedWorkAreas.delete(id);
-                    this.groupWorkAreaIds.delete(id);
                     this.flwFilterWorkAreaIds.delete(id);
                 } else {
                     this.selectedWorkAreas.add(id);
@@ -95,6 +95,18 @@
                         this.workAreaProperties.set(id, properties);
                     }
                 }
+
+                // Clear group dropdown if the map click breaks the group selection:
+                // either deselecting a WA inside the group, or selecting one outside it
+                if (this.selectedGroupId) {
+                    const isGroupWa = this.groupWorkAreaIds.has(id);
+                    if ((isDeselecting && isGroupWa) || (!isDeselecting && !isGroupWa)) {
+                        this.groupWorkAreaIds.clear();
+                        this.selectedGroupId = null;
+                        if (this.$refs.groupSelect) this.$refs.groupSelect.value = '';
+                    }
+                }
+
                 this.map.setFeatureState(
                     { source: 'workareas', sourceLayer: 'workareas', id },
                     { assignment_selected: this.selectedWorkAreas.has(id) }


### PR DESCRIPTION
## Product Description
- Adds an "Assignment Mode" for PMs on the microplanning coverage map to bulk-assign work areas to FLWs                                                                                            - PMs can select work areas via map clicks or group dropdown, pick an assignee, and queue multiple assignments before confirming                                                                   
- Includes FLW Summary panel with independent FLW lookup showing assigned buildings/visits/work areas (including pending queue)                                                                    
- Backend endpoints for group work areas, FLW work areas, FLW summary, and a stub save endpoint
- "Enter Assignment Mode" button (PM-only) with mode badge and exit                                                                                                                                
- Multi-select work areas on map (orange highlight) or Select a Work Area group via dropdown
- Assignee dropdown with "Save" button to queue assignments
- Pending Assignments list with remove capability
- Confirmation and discard modals 
- "Show only unassigned" toggle                                             

[Screencast_20260409_183101.webm](https://github.com/user-attachments/assets/36d33e84-f410-4a41-a829-04714dd8cad0)


## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2276)


## Safety Assurance
### Safety story
- Tested Locally, Mostly UI changes.


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
