### PR TITLE
CCCT-2338: Standardize status indicator across Learn, Deliver, and Payments tabs

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -289,6 +289,7 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity, fi
         total_over_limit_for_user = completed_work_status_total_subquery(CompletedWorkStatus.over_limit)
 
         queryset = queryset.annotate(
+            status=Subquery(UserInvite.objects.filter(opportunity_access=OuterRef("pk")).values("status")[:1]),
             payment_unit_id=Value(payment_unit.pk, output_field=IntegerField()),
             payment_unit_payment_unit_id=Value(payment_unit.payment_unit_id, output_field=UUIDField()),
             payment_unit=Value(payment_unit.name, output_field=CharField()),
@@ -593,6 +594,7 @@ def get_worker_learn_table_data(opportunity):
         .values("total_duration")[:1]
     )
     queryset = OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True).annotate(
+        status=Subquery(UserInvite.objects.filter(opportunity_access=OuterRef("pk")).values("status")[:1]),
         completed_modules_count=Count("completedmodule__module", distinct=True),
         assesment_count=Count("assessment", distinct=True),
         learning_hours=Subquery(duration_subquery, output_field=DurationField()),

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1212,7 +1212,7 @@ class WorkerStatusTable(tables.Table):
 class WorkerPaymentsTable(tables.Table):
     index = IndexColumn()
     user = UserInfoColumn(footer="Total")
-    suspended = SuspendedIndicatorColumn()
+    status = StatusIndicatorColumn(orderable=False)
     last_active = DMYTColumn()
     payment_accrued = tables.Column(
         verbose_name="Accrued", footer=lambda table: intcomma(sum(x.payment_accrued or 0 for x in table.data))
@@ -1243,11 +1243,11 @@ class WorkerPaymentsTable(tables.Table):
 
     class Meta:
         model = OpportunityAccess
-        fields = ("user", "suspended", "payment_accrued", "confirmed_paid")
+        fields = ("user", "payment_accrued", "confirmed_paid")
         sequence = (
             "index",
+            "status",
             "user",
-            "suspended",
             "last_active",
             "payment_accrued",
             "total_paid",
@@ -1368,7 +1368,7 @@ class WorkerTasksTable(GroupedByWorkerMixin, OrgContextTable):
 class WorkerLearnTable(OrgContextTable):
     index = IndexColumn()
     user = UserInfoColumn()
-    suspended = SuspendedIndicatorColumn()
+    status = StatusIndicatorColumn(orderable=False)
     last_active = DMYTColumn()
     started_learning = DMYTColumn(accessor="date_learn_started", verbose_name="Started Learning")
     modules_completed = tables.TemplateColumn(
@@ -1396,11 +1396,11 @@ class WorkerLearnTable(OrgContextTable):
 
     class Meta:
         model = OpportunityAccess
-        fields = ("suspended", "user")
+        fields = ("user",)
         sequence = (
             "index",
+            "status",
             "user",
-            "suspended",
             "last_active",
             "started_learning",
             "modules_completed",
@@ -1500,7 +1500,7 @@ class WorkerDeliveryTable(GroupedByWorkerMixin, OrgContextTable):
     id = tables.Column(visible=False)
     index = IndexColumn()
     user = tables.Column(orderable=False, verbose_name="Name", footer="Total")
-    suspended = SuspendedIndicatorColumn()
+    status = StatusIndicatorColumn(orderable=False)
     last_active = DMYTColumn(empty_values=())
     payment_unit = tables.Column(orderable=False)
     delivery_progress = tables.Column(accessor="total_visits", empty_values=(), orderable=False)
@@ -1537,11 +1537,11 @@ class WorkerDeliveryTable(GroupedByWorkerMixin, OrgContextTable):
 
     class Meta:
         model = OpportunityAccess
-        fields = ("id", "suspended", "user")
+        fields = ("id", "user")
         sequence = (
             "index",
+            "status",
             "user",
-            "suspended",
             "last_active",
             "payment_unit",
             "delivery_progress",

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1559,6 +1559,11 @@ class WorkerDeliveryTable(GroupedByWorkerMixin, OrgContextTable):
         self.use_view_url = False
         super().__init__(*args, **kwargs)
 
+    def render_status(self, record, value):
+        if self._is_seen(record):
+            return ""
+        return StatusIndicatorColumn.render(self.columns["status"].column, record)
+
     def render_delivery_progress(self, record):
         current = record.completed
         total = record.total_visits

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1588,11 +1588,6 @@ class WorkerDeliveryTable(GroupedByWorkerMixin, OrgContextTable):
         self.run_after_every_row(record)
         return format_html(template, url)
 
-    def render_suspended(self, record, value):
-        if self._is_seen(record):
-            return ""
-        return SuspendedIndicatorColumn().render(value)
-
     def render_delivered(self, record, value):
         rows = [
             {"label": "Completed", "value": record.completed},

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2730,6 +2730,7 @@ class WorkerPaymentsView(BaseWorkerListView):
             opportunity=opportunity, payment_accrued__gte=0, accepted=True
         ).order_by("-payment_accrued")
         query_set = query_set.annotate(
+            status=Subquery(UserInvite.objects.filter(opportunity_access=OuterRef("pk")).values("status")[:1]),
             last_paid=Max("payment__date_paid"),
             total_paid_d=get_payment_subquery(),
             confirmed_paid_d=get_payment_subquery(True),


### PR DESCRIPTION
## Summary
- Replaces the simple suspended-only color bar on the **Learn**, **Deliver**, and **Payments** tabs with the same icon-based \`StatusIndicatorColumn\` already used on the **Connect Workers** tab
- Annotates each tab's queryset with the worker's \`UserInvite\` status via subquery so the correct icon renders
- Moves the Status column to the second position (after \`#\`) on all tabs for consistency

**Status icons:**
- ✅ Green check — Invite accepted
- 🕐 Orange clock — Invite pending
- ❌ Red X — User not found / Invite failed  
- ⊟ Black minus — User suspended

Jira: https://dimagi.atlassian.net/browse/CCCT-2338

## Screenshots

<!-- Screenshots showing status icons on Learn, Deliver, and Payments tabs matching Connect Workers -->
<img width="1428" height="642" alt="Screenshot 2026-04-14 at 5 43 37 PM" src="https://github.com/user-attachments/assets/0f9286a0-24ed-4ccd-baf6-5c21d75eda58" />

## Test plan
- [ ] Navigate to an opportunity with workers in different invite states
- [ ] Verify Connect Workers tab status icons are unchanged
- [ ] Verify Learn tab shows matching status icons
- [ ] Verify Deliver tab shows matching status icons
- [ ] Verify Payments tab shows matching status icons with Status as second column
- [ ] Verify suspended workers show the minus-square icon on all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)