### PR TITLE
Fix nested form causing Tab key to submit Invite Member modal

### DIFF
--- a/commcare_connect/organization/forms.py
+++ b/commcare_connect/organization/forms.py
@@ -134,6 +134,7 @@ class MembershipForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.helper = helper.FormHelper(self)
+        self.helper.form_tag = False
         self.helper.layout = layout.Layout(
             layout.Row(
                 layout.Field("email", wrapper_class="col-md-5"),


### PR DESCRIPTION
## Summary

- Fixes [CI-618](https://dimagi.atlassian.net/browse/CI-618): Tab key in the workspace Invite Member modal was submitting the form instead of advancing focus.
- Root cause: `MembershipForm`'s crispy helper had `form_tag = True` (the default), so `{% crispy membership_form %}` rendered its own `<form>` tag inside the outer `<form>` already present in `add_org_member_modal.html`. Per the HTML5 spec, browsers ignore the inner `<form>` start tag but process its `</form>` closing tag, which closes the outer form early — creating invalid HTML with unpredictable Tab-key behavior.
- Fix: added `self.helper.form_tag = False` to `MembershipForm.__init__` so crispy renders only the fields and submit button without its own form wrapper.

## Test plan

- [ ] Open a workspace and click "Add Members" to open the Invite Member modal
- [ ] Tab through the email field, role dropdown, and Submit button — focus should advance normally without submitting
- [ ] Confirm the form still submits correctly when clicking the Submit button or pressing Enter on it
- [ ] All existing `TestAddMembersView` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CI-618]: https://dimagi.atlassian.net/browse/CI-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ