### PR TITLE
Fix race condition in notify_user_for_scored_assessment task

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -244,7 +244,7 @@ def process_assessments(user, xform: XForm, app: CommCareApp, opportunity: Oppor
         )
 
         if not created:
-            return ProcessingError("Learn Assessment is already completed")
+            raise ProcessingError("Learn Assessment is already completed")
 
         transaction.on_commit(partial(notify_user_for_scored_assessment.delay, assessment.pk))
 

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -246,7 +246,7 @@ def process_assessments(user, xform: XForm, app: CommCareApp, opportunity: Oppor
         if not created:
             return ProcessingError("Learn Assessment is already completed")
 
-        notify_user_for_scored_assessment.delay(assessment.pk)
+        transaction.on_commit(partial(notify_user_for_scored_assessment.delay, assessment.pk))
 
 
 def process_deliver_form(user, xform: XForm, app: CommCareApp, opportunity: Opportunity):

--- a/commcare_connect/form_receiver/tests/test_process_xform.py
+++ b/commcare_connect/form_receiver/tests/test_process_xform.py
@@ -203,14 +203,21 @@ class TestProcessTaskModules:
 
 @pytest.mark.django_db
 @mock.patch("commcare_connect.form_receiver.processor.notify_user_for_scored_assessment.delay")
-def test_process_assessments(notification_patch):
+def test_process_assessments(notification_patch, django_capture_on_commit_callbacks):
     app = CommCareAppFactory()
     opportunity_access = OpportunityAccessFactory()
     assessment_form = AssessmentStubFactory().json
     xform = get_form_model(form_block=assessment_form)
     matches = _get_matching_blocks(ASSESSMENT_JSONPATH, xform)
 
-    process_assessments(opportunity_access.user, xform, app, opportunity_access.opportunity, matches)
+    with django_capture_on_commit_callbacks(execute=True):
+        process_assessments(
+            opportunity_access.user,
+            xform,
+            app,
+            opportunity_access.opportunity,
+            matches,
+        )
 
     user_assessment = opportunity_access.user.assessments.first()
 


### PR DESCRIPTION
## Technical Summary

Observed intermittent `Assessment.DoesNotExist` errors in a Celery task (reported via [Sentry](https://dimagi.sentry.io/issues/7379966563/?environment=production&project=4505635339829248&query=is%3Aunresolved&referrer=issue-stream)). Investigated the following possible causes:

1. Transaction rollback after task enqueue
If the request failed mid-way (500 error), the DB transaction would roll back while the task remained queued. Ruled out — no corresponding 500 errors were found in Sentry for the form receiver around the same timestamps.

2. Race condition between DB commit and task execution
The Celery task was being enqueued before the transaction commit. In rare cases, a fast Celery worker could pick up the task before the Assessment record became visible to other DB connections.

Fix
Wrapped the Celery task invocation in transaction.on_commit() to ensure the task is only enqueued after the database transaction is successfully committed.

## Safety Assurance

### Safety story
This is the recommended and safe pattern for enqueueing asynchronous tasks that depend on database state.
Using transaction.on_commit() ensures the task runs only after the data is fully persisted and visible, eliminating race conditions.

### Automated test coverage
All existing tests pass.

### QA Plan
Not needed

### Labels & Review
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change