### PR TITLE
Display error message when email already exists for social-login account

### DIFF
--- a/commcare_connect/templates/account/login.html
+++ b/commcare_connect/templates/account/login.html
@@ -17,6 +17,9 @@
     {% endif %}
     <h6 class="title text-brand-deep-purple">Login</h6>
     <span class="text-sm text-gray-600">Please enter your details</span>
+    {% if messages %}
+      {% for message in messages %}<p class="text-sm text-red-600">* {{ message }}</p>{% endfor %}
+    {% endif %}
     {% if form.non_field_errors %}
       {% for error in form.non_field_errors %}<p class="text-sm text-red-600">* {{ error }}</p>{% endfor %}
     {% endif %}

--- a/commcare_connect/users/adapters.py
+++ b/commcare_connect/users/adapters.py
@@ -30,8 +30,6 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return
         if email_address_exists(email):
             messages.error(
-                request,
-                _("An account with the email %(email)s already exists. Please sign in with your email and password.")
-                % {"email": email},
+                request, _("An account with that email already exists. Please sign in with your email and password.")
             )
             raise ImmediateHttpResponse(redirect("account_login"))

--- a/commcare_connect/users/adapters.py
+++ b/commcare_connect/users/adapters.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.http import HttpRequest
 from django.shortcuts import redirect
+from django.utils.translation import gettext as _
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -30,6 +31,7 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         if email_address_exists(email):
             messages.error(
                 request,
-                f"An account with the email {email} already exists. " "Please sign in with your email and password.",
+                _("An account with the email %(email)s already exists. Please sign in with your email and password.")
+                % {"email": email},
             )
             raise ImmediateHttpResponse(redirect("account_login"))

--- a/commcare_connect/users/adapters.py
+++ b/commcare_connect/users/adapters.py
@@ -29,7 +29,5 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         if not email:
             return
         if email_address_exists(email):
-            messages.error(
-                request, _("An account with that email already exists. Please sign in with your email and password.")
-            )
+            messages.error(request, _("Unable to sign in with SSO. Please sign in with your email and password."))
             raise ImmediateHttpResponse(redirect("account_login"))

--- a/commcare_connect/users/adapters.py
+++ b/commcare_connect/users/adapters.py
@@ -1,9 +1,15 @@
 from typing import Any
 
 from allauth.account.adapter import DefaultAccountAdapter
+from allauth.account.utils import user_email
+from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.socialaccount.models import SocialLogin
+from allauth.utils import email_address_exists
 from django.conf import settings
+from django.contrib import messages
 from django.http import HttpRequest
+from django.shortcuts import redirect
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -14,3 +20,16 @@ class AccountAdapter(DefaultAccountAdapter):
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
     def is_open_for_signup(self, request: HttpRequest, sociallogin: Any):
         return getattr(settings, "ACCOUNT_ALLOW_REGISTRATION", True)
+
+    def pre_social_login(self, request: HttpRequest, sociallogin: SocialLogin):
+        if sociallogin.is_existing:
+            return
+        email = user_email(sociallogin.user)
+        if not email:
+            return
+        if email_address_exists(email):
+            messages.error(
+                request,
+                f"An account with the email {email} already exists. " "Please sign in with your email and password.",
+            )
+            raise ImmediateHttpResponse(redirect("account_login"))


### PR DESCRIPTION
## Product Description

[Ticket](https://dimagi.atlassian.net/browse/CI-619)

This resolves a bug in sign-in flow where blank onboarding screen is shown when a user with a given email/password tries to login with HQ with same email. Instead of showing a blank screen we now find if the user account already exists and display a relevant error message to login with email/password instead.
<img width="583" height="519" alt="Screenshot 2026-04-21 at 1 11 43 PM" src="https://github.com/user-attachments/assets/45ba645b-86d2-4f7b-92b6-1cc0745f69f6" />


## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tested locally

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Tested locally
### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
