### PR TITLE
feat(oauth): RFC 8414 authorization server discovery metadata

### DIFF
--- a/config/tests/test_oauth_discovery.py
+++ b/config/tests/test_oauth_discovery.py
@@ -1,0 +1,64 @@
+import json
+
+from django.conf import settings
+from django.test import RequestFactory
+from django.urls import reverse
+
+from config.views import oauth_authorization_server
+
+URL = "/.well-known/oauth-authorization-server"
+
+
+def _get(rf=None, **extra):
+    rf = rf or RequestFactory()
+    return oauth_authorization_server(rf.get(URL, secure=True, **extra))
+
+
+def test_discovery_returns_json_200():
+    response = _get()
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/json"
+    assert "Cache-Control" in response
+    assert "max-age=3600" in response["Cache-Control"]
+
+
+def test_discovery_contains_required_endpoints():
+    data = json.loads(_get().content)
+    for key in ("issuer", "authorization_endpoint", "token_endpoint", "introspection_endpoint"):
+        assert key in data, f"missing {key}"
+        assert data[key].startswith("https://"), f"{key} must be absolute HTTPS URL, got {data[key]}"
+
+
+def test_discovery_response_and_grant_types():
+    data = json.loads(_get().content)
+    assert "code" in data["response_types_supported"]
+    assert set(data["grant_types_supported"]) >= {"authorization_code", "refresh_token"}
+
+
+def test_discovery_pkce_s256_only():
+    data = json.loads(_get().content)
+    methods = data["code_challenge_methods_supported"]
+    assert "S256" in methods
+    assert "plain" not in methods
+
+
+def test_discovery_scopes_match_oauth2_provider_config():
+    data = json.loads(_get().content)
+    real_scopes = set(settings.OAUTH2_PROVIDER["SCOPES"].keys())
+    advertised = set(data["scopes_supported"])
+    assert advertised, "scopes_supported must not be empty"
+    assert advertised <= real_scopes, f"advertised scopes not in OAUTH2_PROVIDER config: {advertised - real_scopes}"
+
+
+def test_discovery_endpoints_match_oauth2_provider_urls():
+    data = json.loads(_get().content)
+    assert data["authorization_endpoint"].endswith(reverse("oauth2_provider:authorize"))
+    assert data["token_endpoint"].endswith(reverse("oauth2_provider:token"))
+    assert data["introspection_endpoint"].endswith(reverse("oauth2_provider:introspect"))
+    assert data["userinfo_endpoint"].endswith(reverse("oauth2_provider:user-info"))
+
+
+def test_discovery_rejects_post():
+    rf = RequestFactory()
+    response = oauth_authorization_server(rf.post(URL, secure=True))
+    assert response.status_code == 405

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,6 +15,11 @@ urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
     path("about/", TemplateView.as_view(template_name="pages/about.html"), name="about"),
     path(".well-known/assetlinks.json", views.assetlinks_json, name="assetlinks_json"),
+    path(
+        ".well-known/oauth-authorization-server",
+        views.oauth_authorization_server,
+        name="oauth_authorization_server",
+    ),
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),
     path("o/", include("oauth2_provider.urls", namespace="oauth2_provider")),

--- a/config/views.py
+++ b/config/views.py
@@ -1,4 +1,32 @@
+from django.conf import settings
 from django.http import JsonResponse
+from django.urls import reverse
+from django.views.decorators.http import require_GET
+
+
+@require_GET
+def oauth_authorization_server(request):
+    """RFC 8414 OAuth 2.0 Authorization Server Metadata."""
+
+    def absolute(url_name):
+        return request.build_absolute_uri(reverse(url_name))
+
+    scopes = list(settings.OAUTH2_PROVIDER.get("SCOPES", {}).keys())
+    metadata = {
+        "issuer": f"{request.scheme}://{request.get_host()}",
+        "authorization_endpoint": absolute("oauth2_provider:authorize"),
+        "token_endpoint": absolute("oauth2_provider:token"),
+        "introspection_endpoint": absolute("oauth2_provider:introspect"),
+        "userinfo_endpoint": absolute("oauth2_provider:user-info"),
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+        "code_challenge_methods_supported": ["S256"],
+        "scopes_supported": scopes,
+    }
+    response = JsonResponse(metadata)
+    response["Cache-Control"] = "public, max-age=3600"
+    return response
 
 
 def assetlinks_json(request):


### PR DESCRIPTION
## Summary
Adds /.well-known/oauth-authorization-server serving OAuth 2.0 authorization
server metadata per RFC 8414. Enables modern OAuth clients — including a remote
MCP server being built in commcare-connect-labs — to auto-discover endpoints
instead of hardcoding them.

django-oauth-toolkit doesn't ship this endpoint by default, which is why this
needs to be added manually.

## What's advertised
- issuer: the server's canonical base URL
- authorization_endpoint, token_endpoint, introspection_endpoint, userinfo_endpoint
- grant types: authorization_code, refresh_token
- code_challenge_methods: S256 only (no plain-PKCE)
- scopes: sourced from existing oauth2_provider config — single source of truth

## Test plan
- [ ] curl https://connect.dimagi.com/.well-known/oauth-authorization-server
- [ ] Verify JSON parses and has all required fields
- [ ] Confirm issuer matches the public hostname
- [ ] New unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)