### PR TITLE
Show suspension date and reason

### DIFF
--- a/commcare_connect/templates/components/cards/user_status_card.html
+++ b/commcare_connect/templates/components/cards/user_status_card.html
@@ -29,6 +29,23 @@
     </button>
   </div>
 
+  {% if opportunity_access.suspended %}
+    <div class="flex flex-col gap-1 text-sm">
+      {% if opportunity_access.suspension_date %}
+        <div class="flex gap-2 text-gray-500">
+          <span class="whitespace-nowrap">{% translate "Suspended on" %}:</span>
+          <span>{{ opportunity_access.suspension_date|date:"N j, Y" }}</span>
+        </div>
+      {% endif %}
+      {% if opportunity_access.suspension_reason %}
+        <div class="flex gap-2 text-gray-500">
+          <span class="whitespace-nowrap">{% translate "Reason" %}:</span>
+          <span>{{ opportunity_access.suspension_reason }}</span>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+
   <div x-cloak x-show="showSuspendModal" x-transition.opacity class="modal-backdrop">
     <div @click.away="showSuspendModal = false" x-transition class="modal">
       <div class="header flex justify-between items-center">


### PR DESCRIPTION
## Product Description

When a mobile user is suspended from an opportunity, the user status card now shows the suspension date and reason (if available). This gives program managers more context about why a user was suspended directly in the UI.

**Before:** The card showed the suspended status but no details.
**After:** The card additionally shows "Suspended on: <date>" and "Reason: <reason>" when those fields are set.

<img width="718" height="251" alt="image" src="https://github.com/user-attachments/assets/50cf794d-a2b5-4ab7-903f-349d2e55b898" />

## Technical Summary

https://dimagi.atlassian.net/browse/CCCT-2365

Small template-only change to `user_status_card.html`: added a conditional block that renders `suspension_date` and `suspension_reason` from `opportunity_access` when the user is suspended. No model or view changes required — the fields already exist on the model.

## Safety Assurance

### Safety story

Template-only change. The new block is guarded by `{% if opportunity_access.suspended %}` and each field by its own `{% if %}`, so no output is produced for non-suspended users or when fields are blank. No data is mutated.

### Automated test coverage

No new tests needed — this is a pure template rendering change with no business logic.

### QA Plan
N.A

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change