### PR TITLE
Visually Group User Visits with Work Areas on Microplanning Map

### DIFF
--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -483,6 +483,7 @@ class TestUserVisitVectorLayer:
 
         assert round(visit["location_point"].x, 1) == 77.1
         assert round(visit["location_point"].y, 1) == 28.6
+        assert visit["work_area_id"] == visit_data.work_area.id
 
     def test_queryset_only_includes_visits_for_opportunity(self, opportunity, visit_data):
         other_opp = OpportunityFactory()

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -308,7 +308,7 @@ class WorkAreaTileView(MVTView):
 
 class UserVisitVectorLayer(VectorLayer):
     id = "user-visits"
-    tile_fields = ()
+    tile_fields = ("work_area_id",)
     geom_field = "location_point"
     min_zoom = WORKAREA_MIN_ZOOM
 
@@ -342,7 +342,7 @@ class UserVisitVectorLayer(VectorLayer):
                     output_field=PointField(srid=4326),
                 )
             )
-            .values("location_point")
+            .values("location_point", "work_area_id")
         )
 
 

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -5,6 +5,7 @@
         Alpine.data("mapController", () => ({
             map: null,
             selectedFeature: null,
+            highlightedWorkAreaId: null,
             showWorkAreaEditModal: false,
             showVisits: false,
             filterQuery: '',
@@ -33,6 +34,12 @@
                 const url = editWorkAreaUrl + workAreaId + '/';
                 htmx.ajax('GET', url, { target: '#work-area-form', swap: 'innerHTML' })
                 .then(() => this.showWorkAreaEditModal = true)
+            },
+
+            updateHighlightedWorkAreaId() {
+                this.highlightedWorkAreaId = (this.assignmentMode || !this.selectedFeature)
+                    ? null
+                    : this.selectedFeature._id;
             },
 
             getDownloadUrl() {
@@ -338,6 +345,8 @@
                 this.$nextTick(() => {
                     this.initializeMap();
                 });
+
+                this.$watch('selectedFeature', () => this.updateHighlightedWorkAreaId());
 
                 if (this.assignmentMode) {
                     const assigneesEl = document.getElementById('assignees-data');

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -79,8 +79,8 @@
                     },
                     paint: {
                         'text-color': '#22c55e',
-                        'text-halo-color': '#ffffff',
-                        'text-halo-width': 1.5,
+                        'text-halo-color': '#000000',
+                        'text-halo-width': 2.5,
                     },
                 });
             },

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -58,6 +58,35 @@
                 };
             },
 
+            refreshVisitStyling() {
+                if (!this.map) return;
+
+                if (this.map.getLayer('user-visits-circle')) {
+                    this.map.setPaintProperty(
+                        'user-visits-circle',
+                        'circle-opacity',
+                        this.highlightedWorkAreaId !== null ? 0.2 : 0.7,
+                    );
+                }
+
+                if (this.map.getLayer('user-visits-highlight')) {
+                    const id = this.highlightedWorkAreaId;
+                    if (id === null) {
+                        this.map.setLayoutProperty('user-visits-highlight', 'visibility', 'none');
+                    } else {
+                        this.map.setFilter(
+                            'user-visits-highlight',
+                            ['==', ['get', 'work_area_id'], id],
+                        );
+                        this.map.setLayoutProperty(
+                            'user-visits-highlight',
+                            'visibility',
+                            this.showVisits ? 'visible' : 'none',
+                        );
+                    }
+                }
+            },
+
             getDownloadUrl() {
                 const baseUrl = '{{ download_url|escapejs }}';
                 return this.filterQuery ? `${baseUrl}?${this.filterQuery}` : baseUrl;
@@ -363,6 +392,7 @@
                 });
 
                 this.$watch('selectedFeature', () => this.updateHighlightedWorkAreaId());
+                this.$watch('highlightedWorkAreaId', () => this.refreshVisitStyling());
 
                 if (this.assignmentMode) {
                     const assigneesEl = document.getElementById('assignees-data');

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -58,6 +58,33 @@
                 };
             },
 
+            addVisitHighlightLayer() {
+                if (!this.map || this.map.getLayer('user-visits-highlight')) return;
+                this.map.addLayer({
+                    id: 'user-visits-highlight',
+                    type: 'symbol',
+                    source: 'user-visits',
+                    'source-layer': 'user-visits',
+                    layout: {
+                        'text-field': '◆',
+                        'text-size': [
+                            'interpolate', ['linear'], ['zoom'],
+                            8, 13,
+                            14, 22,
+                        ],
+                        'text-font': ['DIN Pro Medium', 'Arial Unicode MS Regular'],
+                        'text-allow-overlap': true,
+                        'text-ignore-placement': true,
+                        'visibility': 'none',
+                    },
+                    paint: {
+                        'text-color': '#22c55e',
+                        'text-halo-color': '#ffffff',
+                        'text-halo-width': 1.5,
+                    },
+                });
+            },
+
             refreshVisitStyling() {
                 if (!this.map) return;
 
@@ -623,13 +650,17 @@
                             'source-layer': 'user-visits',
                             paint: this.buildVisitCirclePaint(),
                         });
+                        this.addVisitHighlightLayer();
                         visitsLayerAdded = true;
                     } else if (visitsLayerAdded) {
-                        this.map.setLayoutProperty(
-                            'user-visits-circle',
-                            'visibility',
-                            visible ? 'visible' : 'none'
-                        );
+                        this.map.setLayoutProperty('user-visits-circle', 'visibility', visible ? 'visible' : 'none');
+                        if (this.map.getLayer('user-visits-highlight')) {
+                            if (!visible) {
+                                this.map.setLayoutProperty('user-visits-highlight', 'visibility', 'none');
+                            } else {
+                                this.refreshVisitStyling();
+                            }
+                        }
                     }
                 });
 

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -42,6 +42,22 @@
                     : this.selectedFeature._id;
             },
 
+            buildVisitCirclePaint() {
+                const hasSelection = this.highlightedWorkAreaId !== null;
+                return {
+                    'circle-radius': [
+                        'interpolate', ['linear'], ['zoom'],
+                        8, 2,
+                        14, 5,
+                    ],
+                    'circle-color': '#e74c3c',
+                    'circle-opacity': hasSelection ? 0.2 : 0.7,
+                    'circle-stroke-width': 1,
+                    'circle-stroke-color': '#ffffff',
+                    'circle-stroke-opacity': 0.5,
+                };
+            },
+
             getDownloadUrl() {
                 const baseUrl = '{{ download_url|escapejs }}';
                 return this.filterQuery ? `${baseUrl}?${this.filterQuery}` : baseUrl;
@@ -575,18 +591,7 @@
                             type: 'circle',
                             source: 'user-visits',
                             'source-layer': 'user-visits',
-                            paint: {
-                                'circle-radius': [
-                                    'interpolate', ['linear'], ['zoom'],
-                                    8, 2,
-                                    14, 5
-                                ],
-                                'circle-color': '#e74c3c',
-                                'circle-opacity': 0.7,
-                                'circle-stroke-width': 1,
-                                'circle-stroke-color': '#ffffff',
-                                'circle-stroke-opacity': 0.5,
-                            }
+                            paint: this.buildVisitCirclePaint(),
                         });
                         visitsLayerAdded = true;
                     } else if (visitsLayerAdded) {

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -652,6 +652,7 @@
                         });
                         this.addVisitHighlightLayer();
                         visitsLayerAdded = true;
+                        this.refreshVisitStyling();
                     } else if (visitsLayerAdded) {
                         this.map.setLayoutProperty('user-visits-circle', 'visibility', visible ? 'visible' : 'none');
                         if (this.map.getLayer('user-visits-highlight')) {


### PR DESCRIPTION
## Product Description

When a work area is selected on the microplanning map, its linked user visits are now highlighted as green diamonds rendered on top of the existing red dots. All unrelated visits simultaneously fade to 20% opacity so the selected work area's visits visually pop out. Clearing the selection returns visits to their normal red-dot appearance.

An example of a work area selected, showing green diamonds overlaid on its visits with other visits dimmed:
<img width="1571" height="794" alt="Screenshot_20260424_151449" src="https://github.com/user-attachments/assets/25154c57-4b72-48c7-b37f-2c2f8409aa6b" />

An example of the default state (no selection) for comparison:
<img width="1668" height="737" alt="Screenshot_20260423_131606" src="https://github.com/user-attachments/assets/f8f4b897-08bc-4a53-b23b-853c9c4a2b6b" />

This only applies in normal mode — assignment mode does not support showing user visits and so highlighting of user visits does not apply to that mode.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2340)

This is a release path 3 feature — Experiments & early stage iterations of product area.

Implementation is frontend-first with one small backend change. The existing `selectedFeature` in the `mapController` Alpine component remains the single source of truth; a derived `highlightedWorkAreaId` (synced via a `$watch` on `selectedFeature`) drives styling on two Mapbox layers. A `symbol` layer type is required for the diamond shape because Mapbox's `circle` layer can only render circles.

- **Backend — expose `work_area_id` on visit tiles:** `UserVisitVectorLayer` now includes `work_area_id` in `tile_fields` and in the queryset values so the client can filter features without re-fetching tiles.
- **Client — derived highlight state:** new Alpine field `highlightedWorkAreaId`, updated by `updateHighlightedWorkAreaId()` which returns `null` in assignment mode or when nothing is selected, otherwise the selected feature's id. Wired via `$watch('selectedFeature', ...)`.
- **Client — hidden symbol layer:** new `user-visits-highlight` layer (symbol type, `◆` text-field, green fill, white halo) added alongside `user-visits-circle`. Added via `addVisitHighlightLayer()` when visits are first shown; starts hidden.
- **Client — styling driver:** new `refreshVisitStyling()`, wired via `$watch('highlightedWorkAreaId', ...)`, sets `circle-opacity` on the base circles (0.2 dimmed / 0.7 default) and toggles + filters the highlight layer (`["==", ["get", "work_area_id"], id]`).
- **Client — paint builder extraction:** circle paint config was extracted into `buildVisitCirclePaint()` so layer creation and styling refresh stay in sync.

## Safety Assurance

### Safety story

This change is purely additive:

- Backend change is a no-op for existing consumers: `tile_fields` and `.values()` additions ship one extra column (`work_area_id`) in tiles. Existing clients that don't reference the property ignore it.
- No migrations, no data mutations, no new endpoints, no permission changes.
- New layer and state are gated on `showVisits` and start hidden; in the default (no-selection) state the map looks and behaves exactly as before.
- Assignment mode is explicitly excluded from the highlight logic via `updateHighlightedWorkAreaId`, so the assignment-mode UX is unaffected.
- Reversible by revert — no persisted state.

### Automated test coverage

- `TestUserVisitVectorLayer.test_queryset_annotates_location_point` in [commcare_connect/microplanning/tests/test_views.py](commcare_connect/microplanning/tests/test_views.py) was extended to assert `visit["work_area_id"] == visit_data.work_area.id`. Catches regressions in `tile_fields` or the queryset `.values()` that would strip `work_area_id` from emitted tiles.

Frontend interaction changes are verified manually (see QA Plan).

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Open the microplanning map for an opportunity that has user visits and confirm the baseline state: red dots at 0.7 opacity, no diamonds visible.
- [ ] Toggle "Show Visits" off and on; confirm visits appear/disappear without errors and styling state is preserved.
- [ ] Click a work area that has linked visits; confirm:
  - Green diamonds appear on exactly the visits whose `work_area_id` matches the selected work area.
  - All other visit circles dim to ~0.2 opacity.
  - Diamonds are visibly larger than the base circles at typical zoom levels (zoom 8 → 14).
- [ ] Click the same work area again to deselect; confirm diamonds disappear and circles return to 0.7 opacity.
- [ ] Click a different work area; confirm the diamond set updates to match the new selection (no stale diamonds from the previous selection).
- [ ] Click a work area with **no** linked visits; confirm circles dim but no diamonds appear.
- [ ] Change filters while a work area is selected; confirm the tile reload preserves correct diamond/dim state for the new feature set.
- [ ] Enter assignment mode, multi-select several work areas; confirm **no** diamond highlighting and **no** circle dimming occurs (assignment mode is excluded).
- [ ] Exit assignment mode back to normal mode; confirm highlight behavior resumes on next single-select.
- [ ] Zoom in and out across the visit zoom range; confirm diamonds remain legibly sized and aligned over their circles.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
