### PR TITLE
Show Correct Label on Opp List for Ended Opps

### DIFF
--- a/commcare_connect/templates/opportunity/dashboard.html
+++ b/commcare_connect/templates/opportunity/dashboard.html
@@ -106,11 +106,11 @@
                   {% endfor %}
                   <div>
                     {% if object.is_active %}
-                        <span class="badge badge-md positive-dark">Active</span>
-                    {% elif object.has_ended %}
-                        <span class="badge badge-md warning-dark">Ended</span>
+                        <span class="badge badge-md positive-dark">{% trans 'Active' %}</span>
+                    {% elif object.active and object.has_ended %}
+                        <span class="badge badge-md warning-dark">{% trans 'Ended' %}</span>
                     {% else %}
-                        <span class="badge badge-md negative-dark">Inactive</span>
+                        <span class="badge badge-md negative-dark">{% trans 'Inactive' %}</span>
                     {% endif %}
                   </div>
               </div>


### PR DESCRIPTION
## Product Description

On the opportunity dashboard, the status badge now reflects the opportunity's active flag independent of its end date. An opportunity with `active=False` will show "Inactive" regardless of whether its end date has passed; "Ended" is only shown for opportunities that are still active but past their end date.

<img width="1576" height="403" alt="Screenshot_20260427_125008" src="https://github.com/user-attachments/assets/72c7c879-6342-4917-8f5f-bf431c9f8869" />

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-635)

This is a release path 1 feature — Improvements to existing features & quick wins.

The dashboard's status badge previously used `object.has_ended` as the second branch, which only checks `end_date < today` and ignores the `active` flag — so any opportunity past its end date was labelled "Ended" even if it had been deactivated. The fix narrows the "Ended" branch to require `object.active and object.has_ended`, so deactivated opportunities fall through to "Inactive". The `is_active` and `has_ended` model properties were left unchanged because `has_ended` is referenced in nine other call sites (menu, worker actions, forms, tasks) where the existing semantics are correct.

- **Template-only change:** [`dashboard.html`](commcare_connect/templates/opportunity/dashboard.html) status badge conditional updated; labels also wrapped in `{% trans %}` for i18n consistency.
- **No model or property changes:** `Opportunity.is_active` and `Opportunity.has_ended` are unchanged to avoid affecting unrelated callsites.

## Safety Assurance

### Safety story

This is a presentation-only change in a single Django template — no data migrations, model changes, query changes, or business logic affected. The conditional was verified against the four possible state combinations of `(active, end_date)`:

| `active` | `end_date` vs today | Badge |
| --- | --- | --- |
| True | future / today | Active |
| True | past | Ended |
| True | null | Inactive (fallback) |
| False | any | Inactive |

Reversible by reverting the single commit.

### Automated test coverage

No new automated tests — the change is a template-only conditional with no extractable business logic. Existing dashboard view tests continue to exercise the rendering path.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Open the dashboard for an opportunity with `active=True` and `end_date` in the future → badge reads "Active".
- [ ] Open the dashboard for an opportunity with `active=True` and `end_date` in the past → badge reads "Ended".
- [ ] Open the dashboard for an opportunity with `active=False` and `end_date` in the past → badge reads "Inactive" (previously "Ended").
- [ ] Open the dashboard for an opportunity with `active=False` and `end_date` in the future → badge reads "Inactive".
- [ ] Confirm the opportunity list page still labels statuses by the existing rules (active+future → Active, active+past → Ended, otherwise Inactive) — no regression there.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
