### PR TITLE
Push Notification on Task Assignment

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -37,6 +37,7 @@ from commcare_connect.opportunity.export import (
 )
 from commcare_connect.opportunity.models import (
     Assessment,
+    AssignedTask,
     BlobMeta,
     CompletedWorkStatus,
     DeliverUnit,
@@ -713,6 +714,28 @@ def _send_auto_invoice_created_notification(invoice_ids):
             )
         except Exception as e:
             logger.error(f"Error sending automated invoice created email for organization {organization.slug}: {e}")
+
+
+@celery_app.task()
+def send_task_assignment_notification(assigned_task_id: int):
+    assigned_task = AssignedTask.objects.select_related(
+        "opportunity_access__user",
+        "opportunity_access__opportunity",
+    ).get(pk=assigned_task_id)
+    access = assigned_task.opportunity_access
+    message = Message(
+        usernames=[access.user.username],
+        data={
+            "action": "ccc_generic_opportunity",
+            "title": "Notification Title",
+            "body": "Notification description",
+            "opportunity_uuid": str(access.opportunity.opportunity_id),
+            "opportunity_status": "delivery",
+            "key": "task_assignment",
+            "session_endpoint_id": "cc_app_home",
+        },
+    )
+    send_message(message)
 
 
 @celery_app.task()

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -727,8 +727,8 @@ def send_task_assignment_notification(assigned_task_id: int):
         usernames=[access.user.username],
         data={
             "action": "ccc_generic_opportunity",
-            "title": "Notification Title",
-            "body": "Notification description",
+            "title": "New Task Assigned",
+            "body": "A task has been assigned to you. You must complete it before continuing Delivery activities.",
             "opportunity_uuid": str(access.opportunity.opportunity_id),
             "opportunity_status": "delivery",
             "key": "task_assignment",

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -494,8 +494,8 @@ def test_send_task_assignment_notification(send_message_patch):
             usernames=[access.user.username],
             data={
                 "action": "ccc_generic_opportunity",
-                "title": "Notification Title",
-                "body": "Notification description",
+                "title": "New Task Assigned",
+                "body": "A task has been assigned to you. You must complete it before continuing Delivery activities.",
                 "opportunity_uuid": str(opportunity.opportunity_id),
                 "opportunity_status": "delivery",
                 "key": "task_assignment",

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -33,9 +33,11 @@ from commcare_connect.opportunity.tasks import (
     generate_work_status_export,
     notify_user_for_scored_assessment,
     save_export,
+    send_task_assignment_notification,
 )
 from commcare_connect.opportunity.tests.factories import (
     AssessmentFactory,
+    AssignedTaskFactory,
     CompletedModuleFactory,
     CompletedWorkFactory,
     LearnModuleFactory,
@@ -43,6 +45,7 @@ from commcare_connect.opportunity.tests.factories import (
     OpportunityClaimFactory,
     OpportunityFactory,
     PaymentUnitFactory,
+    TaskTypeFactory,
     UserVisitFactory,
 )
 from commcare_connect.users.models import User
@@ -473,3 +476,30 @@ class TestExportTasksCreateExportFile:
         args = mock_save.call_args[0]
         assert args[1].endswith("_catchment_area.csv")
         assert args[2] == "csv"
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.opportunity.tasks.send_message")
+def test_send_task_assignment_notification(send_message_patch):
+    opportunity = OpportunityFactory()
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    task_type = TaskTypeFactory(app=opportunity.deliver_app)
+    assigned_task = AssignedTaskFactory(opportunity_access=access, task_type=task_type)
+
+    send_task_assignment_notification(assigned_task.pk)
+
+    assert send_message_patch.call_count == 1
+    send_message_patch.assert_called_with(
+        Message(
+            usernames=[access.user.username],
+            data={
+                "action": "ccc_generic_opportunity",
+                "title": "Notification Title",
+                "body": "Notification description",
+                "opportunity_uuid": str(opportunity.opportunity_id),
+                "opportunity_status": "delivery",
+                "key": "task_assignment",
+                "session_endpoint_id": "cc_app_home",
+            },
+        )
+    )

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2680,6 +2680,22 @@ class TestCreateTask:
         assert response.context["form"].errors
         assert AssignedTask.objects.count() == 0
 
+    @pytest.mark.django_db(transaction=True)
+    def test_create_task_schedules_push_notification(self, client, org_user_member, opportunity, access):
+        client.force_login(org_user_member)
+        task = TaskTypeFactory(app=opportunity.deliver_app)
+        due_date = date.today() + timedelta(days=7)
+
+        with mock.patch("commcare_connect.opportunity.views.send_task_assignment_notification.delay") as delay_patch:
+            response = client.post(
+                self._url(opportunity),
+                data={"task": task.pk, "access": access.pk, "due_date": due_date.isoformat()},
+            )
+
+        assert response.status_code == HTTPStatus.OK
+        assigned = AssignedTask.objects.get(task_type=task, opportunity_access=access)
+        delay_patch.assert_called_once_with(assigned.pk)
+
     @pytest.mark.parametrize(
         "user_fixture, opportunity_fixture",
         [

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -176,6 +176,7 @@ from commcare_connect.opportunity.tasks import (
     invite_user,
     send_invoice_paid_mail,
     send_push_notification_task,
+    send_task_assignment_notification,
     update_user_and_send_invite,
 )
 from commcare_connect.opportunity.utils.completed_work import (
@@ -3505,13 +3506,14 @@ def create_task(request, org_slug, opp_id):
     access = form.cleaned_data["access"]
     due_date = form.cleaned_data["due_date"]
 
-    AssignedTask.objects.create(
+    assigned_task = AssignedTask.objects.create(
         task_type=task,
         opportunity_access=access,
         due_date=due_date,
         status=AssignedTaskStatus.ASSIGNED,
         assigned_by=request.user,
     )
+    transaction.on_commit(lambda: send_task_assignment_notification.delay(assigned_task.pk))
     messages.success(request, _("Task created successfully."))
     redirect_url = _task_redirect_url(request, org_slug, opp_id)
     return HttpResponse(headers={"HX-Redirect": redirect_url})


### PR DESCRIPTION
## Product Description
- New Celery task `send_task_assignment_notification` in `commcare_connect/opportunity/tasks.py` that builds the notification payload and dispatches push notification.
- create_task view schedules the task via transaction.on_commit(...)  required because ATOMIC_REQUESTS = True, so the Celery worker must not race ahead of the DB commit.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2373)

## Safety Assurance
### Safety story
- Tested on staging.

### Automated test coverage
- Added automated tests.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
