### PR TITLE
Work Area Assigned Notification

### DIFF
--- a/commcare_connect/microplanning/tasks.py
+++ b/commcare_connect/microplanning/tasks.py
@@ -315,7 +315,7 @@ def send_work_area_assignment_notification(opportunity_access_id: int):
         data={
             "action": "ccc_generic_opportunity",
             "title": "New Work Areas Assigned",
-            "body": "You have been assigned new work areas. Open the app to start.",
+            "body": "You have been assigned new work areas. Click here to begin.",
             "opportunity_uuid": str(access.opportunity.opportunity_id),
             "opportunity_status": "delivery",
             "key": "work_area_assignment",

--- a/commcare_connect/microplanning/tasks.py
+++ b/commcare_connect/microplanning/tasks.py
@@ -9,6 +9,9 @@ from django.core.files.storage import default_storage
 from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
 
+from commcare_connect.connect_id_client import send_message
+from commcare_connect.connect_id_client.models import Message
+from commcare_connect.opportunity.models import OpportunityAccess
 from config import celery_app
 
 from .clustering import WorkAreaGrouper
@@ -302,6 +305,24 @@ class WorkAreaCSVExporter:
             yield buffer.getvalue()
             buffer.seek(0)
             buffer.truncate(0)
+
+
+@celery_app.task()
+def send_work_area_assignment_notification(opportunity_access_id: int):
+    access = OpportunityAccess.objects.select_related("user", "opportunity").get(pk=opportunity_access_id)
+    message = Message(
+        usernames=[access.user.username],
+        data={
+            "action": "ccc_generic_opportunity",
+            "title": "New Work Areas Assigned",
+            "body": "You have been assigned new work areas. Open the app to start.",
+            "opportunity_uuid": str(access.opportunity.opportunity_id),
+            "opportunity_status": "delivery",
+            "key": "work_area_assignment",
+            "session_endpoint_id": "cc_app_home",
+        },
+    )
+    send_message(message)
 
 
 @celery_app.task()

--- a/commcare_connect/microplanning/tests/test_tasks.py
+++ b/commcare_connect/microplanning/tests/test_tasks.py
@@ -1,11 +1,13 @@
 import csv
 import io
+from unittest import mock
 
 import pytest
 
 from commcare_connect.microplanning.models import WorkArea
-from commcare_connect.microplanning.tasks import WorkAreaCSVImporter
+from commcare_connect.microplanning.tasks import WorkAreaCSVImporter, send_work_area_assignment_notification
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory
+from commcare_connect.opportunity.tests.factories import OpportunityAccessFactory
 
 
 @pytest.fixture
@@ -179,3 +181,18 @@ class TestWorkAreaCSVImporter:
         error_keys = " ".join(result["errors"].keys()).lower()
         expected_error = "Missing values for properties: max_wag, wag_serial_number, lga, state"
         assert expected_error.lower() in error_keys
+
+
+@pytest.mark.django_db
+def test_send_work_area_assignment_notification(opportunity):
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    with mock.patch("commcare_connect.microplanning.tasks.send_message") as send_message_mock:
+        send_work_area_assignment_notification(access.pk)
+
+    send_message_mock.assert_called_once()
+    message = send_message_mock.call_args.args[0]
+    assert message.usernames == [access.user.username]
+    assert message.data["key"] == "work_area_assignment"
+    assert message.data["opportunity_uuid"] == str(opportunity.opportunity_id)
+    assert message.data["title"]
+    assert message.data["body"]

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -737,3 +737,63 @@ class TestDownloadWorkAreas(BaseMicroplanningFlagTest):
         assert row_dict["LGA"] == "RevLGA"
         assert row_dict["State"] == "RevState"
         assert row_dict["Work Area Group Name"] == "Rev Group"
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSaveAssignmentNotification(BaseMicroplanningFlagTest):
+    @pytest.fixture(autouse=True)
+    def setup_microplanning_flag(self, managed_opportunity, request):
+        flag, _ = Flag.objects.get_or_create(name=MICROPLANNING)
+        flag.opportunities.add(managed_opportunity)
+        flag.flush()
+
+    def _url(self, program_manager_org, managed_opportunity):
+        return reverse(
+            "microplanning:save_assignment",
+            kwargs={"org_slug": program_manager_org.slug, "opp_id": managed_opportunity.opportunity_id},
+        )
+
+    def test_schedules_one_notification_per_assignee(
+        self, client, program_manager_org, program_manager_org_user_admin, managed_opportunity
+    ):
+        access_a = OpportunityAccessFactory(opportunity=managed_opportunity)
+        access_b = OpportunityAccessFactory(opportunity=managed_opportunity)
+        client.force_login(program_manager_org_user_admin)
+
+        payload = {
+            "assignments": [
+                {"assignee_id": access_a.pk, "work_area_ids": [1, 2]},
+                {"assignee_id": access_a.pk, "work_area_ids": [3]},
+                {"assignee_id": access_b.pk, "work_area_ids": [4]},
+            ]
+        }
+        with mock.patch(
+            "commcare_connect.microplanning.views.send_work_area_assignment_notification.delay"
+        ) as delay_patch:
+            response = client.post(
+                self._url(program_manager_org, managed_opportunity),
+                data=json.dumps(payload),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        called_ids = sorted(call.args[0] for call in delay_patch.call_args_list)
+        assert called_ids == sorted([access_a.pk, access_b.pk])
+
+    def test_ignores_assignees_from_other_opportunity(
+        self, client, program_manager_org, program_manager_org_user_admin, managed_opportunity
+    ):
+        other_access = OpportunityAccessFactory(opportunity=OpportunityFactory())
+        client.force_login(program_manager_org_user_admin)
+
+        with mock.patch(
+            "commcare_connect.microplanning.views.send_work_area_assignment_notification.delay"
+        ) as delay_patch:
+            response = client.post(
+                self._url(program_manager_org, managed_opportunity),
+                data=json.dumps({"assignments": [{"assignee_id": other_access.pk, "work_area_ids": [1]}]}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        delay_patch.assert_not_called()

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -54,6 +54,7 @@ from .tasks import (
     get_cluster_area_cache_lock_key,
     get_import_area_cache_key,
     import_work_areas_task,
+    send_work_area_assignment_notification,
 )
 
 logger = logging.getLogger(__name__)
@@ -588,4 +589,22 @@ def get_flw_summary_for_assignment(request, org_slug, opp_id):
 @require_flag_for_opp(MICROPLANNING)
 def save_assignment(request, org_slug, opp_id):
     """Stub endpoint for saving work area assignments. Accepts the payload but does not persist changes yet."""
+    try:
+        payload = json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "invalid json"}, status=400)
+
+    assignee_ids = {
+        a["assignee_id"]
+        for a in payload.get("assignments", [])
+        if isinstance(a, dict) and a.get("assignee_id") is not None
+    }
+    valid_assignee_ids = list(
+        OpportunityAccess.objects.filter(pk__in=assignee_ids, opportunity=request.opportunity).values_list(
+            "pk", flat=True
+        )
+    )
+    for access_id in valid_assignee_ids:
+        transaction.on_commit(lambda aid=access_id: send_work_area_assignment_notification.delay(aid))
+
     return JsonResponse({"status": "ok"})


### PR DESCRIPTION
## Product Description
- Adds `send_work_area_assignment_notification` Celery task that sends a single push notification to an FLW with the opportunity UUID and a `work_area_assignment` key (CCCT-2374).
- Wires the task into the `save_assignment` view: dedupes assignees from the payload, validates they belong to the opportunity, and schedules one notification per FLW via `transaction.on_commit`, so multi-area assignments produce a single consolidated notification.


## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2374) 

## Safety Assurance
### Safety story



### Automated test coverage
- Added Automated Tests


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
