### PR TITLE
Preserve Over Limit Status

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -273,11 +273,11 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
     """
     flags = []
     opportunity_flags, _ = OpportunityVerificationFlags.objects.get_or_create(opportunity=user_visit.opportunity)
-    if opportunity_flags.duplicate:
-        if user_visit.status == VisitValidationStatus.duplicate:
+    if user_visit.status == VisitValidationStatus.duplicate:
+        if opportunity_flags.duplicate:
             flags.append(["duplicate", "A beneficiary with the same identifier already exists"])
-    elif user_visit.status == VisitValidationStatus.duplicate:
-        user_visit.status = VisitValidationStatus.pending
+        else:
+            user_visit.status = VisitValidationStatus.pending
     if opportunity_flags.gps and user_visit.location is None:
         flags.append(["gps", "GPS data is missing"])
     if opportunity_flags.location > 0 and user_visit.location:

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -276,7 +276,7 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
     if opportunity_flags.duplicate:
         if user_visit.status == VisitValidationStatus.duplicate:
             flags.append(["duplicate", "A beneficiary with the same identifier already exists"])
-    else:
+    elif user_visit.status == VisitValidationStatus.duplicate:
         user_visit.status = VisitValidationStatus.pending
     if opportunity_flags.gps and user_visit.location is None:
         flags.append(["gps", "GPS data is missing"])

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -245,6 +245,21 @@ def test_receiver_deliver_form_daily_visits_reached(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("opportunity", [{"verification_flags": {"duplicate": False}}], indirect=True)
+def test_over_limit_status_preserved_when_duplicate_flag_disabled(
+    user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
+):
+    # When the duplicate verification flag is off, clean_form_submission() must not
+    # clobber an over_limit status set by the cap check; otherwise auto_approve will
+    # silently accept visits past the per-worker max.
+    oauth_application = opportunity.hq_server.oauth_application
+    form_json = _create_opp_and_form_json(opportunity, user=user_with_connectid_link, daily_max_per_user=0)
+    make_request(api_client, form_json, user_with_connectid_link, oauth_application=oauth_application)
+    visit = UserVisit.objects.get(user=user_with_connectid_link)
+    assert visit.status == VisitValidationStatus.over_limit
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("paymentunit_options", [pytest.param({"max_daily": 2})])
 def test_receiver_deliver_form_max_visits_reached(
     mobile_user_with_connect_link: User, api_client: APIClient, opportunity: Opportunity


### PR DESCRIPTION
## Product Description

Service-delivery submissions that exceed the per-worker `Max Service Deliveries` cap will now be correctly rejected as `Over Limit`. Before this fix, the cap was silently ignored on opportunities where the duplicate verification flag was off, allowing workers to submit beyond their configured limit. There is no new UI or workflow — this restores the intended cap-enforcement behaviour on the backend.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-639)

This is a release path 1 feature — Improvements to existing features & quick wins

The cap-check in `process_deliver_unit()` correctly sets `user_visit.status = over_limit` when a worker exceeds their `OpportunityClaimLimit.max_visits`, but `clean_form_submission()` ran immediately afterwards and unconditionally reset `user_visit.status` back to `pending` whenever `OpportunityVerificationFlags.duplicate` was `False`. With `auto_approve_visits=True` the auto-approve branch then flipped that `pending` straight to `approved`, silently bypassing the cap. The function's docstring describes the *intended* behaviour as "resetting **duplicate** status when the duplicate flag is disabled" — the implementation was just broader than the intent. The fix scopes the reset to only act when the prior status is `duplicate`, leaving `over_limit` and `trial` intact.

- **Code change**: one-line scope tightening in [`commcare_connect/form_receiver/processor.py:280`](../blob/main/commcare_connect/form_receiver/processor.py#L280) — `else:` → `elif user_visit.status == VisitValidationStatus.duplicate:`. No model, schema, or API changes.
- **No backfill in this PR**: the fix prevents *future* over-cap acceptances; existing over-cap rows in production are remediated separately via the script in [this](https://github.com/dimagi/commcare-connect/pull/1152) PR.

## Safety Assurance

### Safety story

- **Blast radius is small and well-bounded.** The change only narrows a status mutation that previously fired in two cases (`status == duplicate` and `status == anything else`) so that it now fires in only one (`status == duplicate`). Any code path that relied on the broader behaviour would have been overwriting `over_limit` or `trial` — neither of which is desirable. All existing tests in `form_receiver/` and `opportunity/` continue to pass (529 passed).
- **Existing data impact**: zero direct impact. Already-saved `UserVisit` rows are not modified by this PR. Over-cap rows that pre-date the fix continue to show their current statuses until the separate remediation script is run.
- **Risk of regression on the opposite case** (duplicate flag *on*): the `if opportunity_flags.duplicate:` branch is unchanged; behaviour for that path is identical to before. Specifically covered by the existing `test_receiver_duplicate` and `test_receiver_duplicate_concurrent_submissions` tests.

### Automated test coverage

New regression test in `commcare_connect/form_receiver/tests/test_receiver_integration.py`:

- `test_over_limit_status_preserved_when_duplicate_flag_disabled` — sets `verification_flags={"duplicate": False}` on the opportunity fixture, submits a form against a payment unit configured with `daily_max_per_user=0` to force the cap to trigger on the very first submission, and asserts the resulting `UserVisit.status == over_limit`. Pre-fix this test fails with `assert 'approved' == 'over_limit'`, exactly mirroring the prod symptom.

Existing coverage that continues to validate the surrounding behaviour:

- `test_receiver_deliver_form_daily_visits_reached`, `test_receiver_deliver_form_max_visits_reached`, `test_receiver_deliver_form_end_date_reached` — cap-enforcement happy paths (with default `duplicate=True`).
- `test_receiver_duplicate`, `test_receiver_duplicate_concurrent_submissions` — duplicate-flagging path, ensuring the touched conditional still preserves duplicate detection.
- Auto-approve, suspended-user, flagged-form, and trial-status tests — confirm no other status-transition regressed.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Identify or create a non-managed opportunity with `OpportunityVerificationFlags.duplicate = False` and `auto_approve_visits = True`.
- [ ] Set a payment unit with a small `max_total` (e.g. 2) to make the cap easy to hit.
- [ ] As an enrolled mobile worker, submit deliveries up to and one beyond the configured `max_total`.
- [ ] Verify the over-cap submission's `UserVisit.status` is `over_limit` (not `approved`) on the worker-deliveries view in the org dashboard.
- [ ] Verify the corresponding `CompletedWork.status` is `over_limit`.
- [ ] Verify the worker's `payment_accrued` does not include the over-cap visit.
- [ ] Repeat against an opportunity with `duplicate = True` to confirm the duplicate-detection path is unaffected: submit two visits with the same `entity_id`; the second should be flagged as `duplicate`, not `over_limit` or `pending`.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
