### PR TITLE
Script to Remediate Over Cap Visits

### DIFF
--- a/docs/plans/script.py
+++ b/docs/plans/script.py
@@ -1,0 +1,153 @@
+"""
+Identify and remediate UserVisit rows that exceed the per-worker cap configured
+on their OpportunityClaimLimit. Caused by the over_limit status-reset bug fixed
+in processor.py:280 (commit <fix-sha>).
+
+Usage:
+    Edit OPP_UUID and DRY_RUN below, then:
+        ./manage.py shell < scripts/remediate_over_cap_visits.py
+"""
+from collections import defaultdict
+from itertools import islice
+
+from django.db import transaction
+
+from commcare_connect.opportunity.models import (
+    CompletedWork,
+    CompletedWorkStatus,
+    OpportunityAccess,
+    OpportunityClaimLimit,
+    UserVisit,
+    VisitValidationStatus,
+)
+from commcare_connect.opportunity.visit_import import update_payment_accrued_for_user
+
+# ---- knobs --------------------------------------------------------------
+OPP_UUID = "<x>"  # set None to scan ALL opportunities
+DRY_RUN = True
+BATCH_SIZE = 500
+# -------------------------------------------------------------------------
+
+
+def _batched(iterable, n):
+    it = iter(iterable)
+    while batch := list(islice(it, n)):
+        yield batch
+
+
+def _find_over_cap_visit_ids():
+    """Yield (claim_limit, [over_cap_visit_id, ...]) for every claim limit with extras."""
+    qs = OpportunityClaimLimit.objects.select_related(
+        "opportunity_claim__opportunity_access",
+        "payment_unit",
+    )
+    if OPP_UUID:
+        qs = qs.filter(
+            opportunity_claim__opportunity_access__opportunity__opportunity_id=OPP_UUID
+        )
+    for cl in qs.iterator():
+        access = cl.opportunity_claim.opportunity_access
+        active_visit_ids = list(
+            UserVisit.objects.filter(
+                opportunity_access=access,
+                deliver_unit__payment_unit=cl.payment_unit,
+            )
+            .exclude(
+                status__in=[
+                    VisitValidationStatus.over_limit,
+                    VisitValidationStatus.trial,
+                ]
+            )
+            .order_by("date_created")
+            .values_list("id", flat=True)
+        )
+        if len(active_visit_ids) > cl.max_visits:
+            yield cl, active_visit_ids[cl.max_visits :]
+
+
+def _completed_works_safe_to_flip(over_cap_visit_ids):
+    """Return CompletedWork ids whose every linked visit is in the over-cap set.
+
+    A CompletedWork that has at least one visit OUTSIDE the over-cap set is left
+    alone and reported as a warning — those need manual review.
+    """
+    over_cap_set = set(over_cap_visit_ids)
+    cw_ids = (
+        UserVisit.objects.filter(id__in=over_cap_set)
+        .exclude(completed_work__isnull=True)
+        .values_list("completed_work_id", flat=True)
+        .distinct()
+    )
+    safe, mixed = [], []
+    for cw_id in cw_ids:
+        all_visit_ids = set(
+            UserVisit.objects.filter(completed_work_id=cw_id).values_list("id", flat=True)
+        )
+        if all_visit_ids.issubset(over_cap_set):
+            safe.append(cw_id)
+        else:
+            mixed.append(cw_id)
+    return safe, mixed
+
+
+def main():
+    plan = []  # list of (claim_limit, over_cap_ids)
+    for cl, over_cap_ids in _find_over_cap_visit_ids():
+        plan.append((cl, over_cap_ids))
+
+    if not plan:
+        print("Nothing to remediate.")
+        return
+
+    total = sum(len(ids) for _, ids in plan)
+    print(f"Found {total} over-cap UserVisit rows across {len(plan)} claim limits.")
+    affected_visit_ids = [vid for _, ids in plan for vid in ids]
+    safe_cw_ids, mixed_cw_ids = _completed_works_safe_to_flip(affected_visit_ids)
+    print(f"  CompletedWork rows to flip: {len(safe_cw_ids)}")
+    if mixed_cw_ids:
+        print(
+            f"  WARNING: {len(mixed_cw_ids)} CompletedWork rows are linked to BOTH "
+            f"in-cap and over-cap visits. They will NOT be flipped automatically. "
+            f"Manual review needed: {mixed_cw_ids}"
+        )
+
+    if DRY_RUN:
+        print("\n--- DRY RUN — printing breakdown ---")
+        per_access = defaultdict(int)
+        for cl, ids in plan:
+            per_access[cl.opportunity_claim.opportunity_access_id] += len(ids)
+        for access_id, n in sorted(per_access.items()):
+            print(f"  access {access_id}: {n} over-cap visit(s) -> over_limit")
+        print("\nRe-run with DRY_RUN = False to apply.")
+        return
+
+    affected_access_ids = set()
+    with transaction.atomic():
+        # Flip UserVisit.status
+        for batch in _batched(affected_visit_ids, BATCH_SIZE):
+            visits = list(
+                UserVisit.objects.select_for_update().filter(id__in=batch)
+            )
+            for v in visits:
+                v.status = VisitValidationStatus.over_limit  # __setattr__ updates status_modified_date
+                affected_access_ids.add(v.opportunity_access_id)
+            UserVisit.objects.bulk_update(
+                visits, fields=["status", "status_modified_date"]
+            )
+
+        # Flip CompletedWork.status (only for completed works fully covered by over-cap visits)
+        if safe_cw_ids:
+            CompletedWork.objects.filter(id__in=safe_cw_ids).update(
+                status=CompletedWorkStatus.over_limit
+            )
+
+    # Recompute payment_accrued for each affected access (full recompute, not incremental)
+    for access_id in sorted(affected_access_ids):
+        access = OpportunityAccess.objects.get(id=access_id)
+        update_payment_accrued_for_user(access, incremental=False)
+
+    print(
+        f"Done. Flipped {len(affected_visit_ids)} UserVisit rows, "
+        f"{len(safe_cw_ids)} CompletedWork rows, recomputed payment_accrued for "
+        f"{len(affected_access_ids)} accesses."
+    )

--- a/docs/plans/script.py
+++ b/docs/plans/script.py
@@ -1,196 +1,44 @@
 """
-Identify and remediate CompletedWork (and their UserVisit) rows that exceed
-the per-worker cap configured on their OpportunityClaimLimit. Caused by the
-over_limit status-reset bug fixed in processor.py:280 (PR https://github.com/dimagi/commcare-connect/pull/1151).
-
-The cap (claim_limit.max_visits) is on EARNED PAYMENT UNITS, not on raw
-UserVisits. A payment unit can have multiple deliver units (e.g. registration
-+ service delivery), so counting visits double-counts in those cases. We count
-CompletedWork rows instead — each CW is unique per (access, entity, payment_unit)
-and represents one earned payment unit regardless of how many deliver-unit
-forms it took to satisfy.
-
-For each over-cap CompletedWork we flip the CW *and all its UserVisits* to
-over_limit as a unit. This avoids any partial-flip inconsistency between a
-CW and its visits.
-
-Usage:
-    Edit OPP_UUID and DRY_RUN below, then:
-        ./manage.py shell < scripts/remediate_over_cap_visits.py
+Remediate the small set of UserVisits (and their CompletedWorks) that were
+left as approved when they should have been over_limit, due to the bug
+fixed in processor.py (PR https://github.com/dimagi/commcare-connect/pull/1151).
 """
-from collections import defaultdict
-from itertools import islice
-
 from django.db import transaction
-from django.db.models import Sum
+from django.utils.timezone import now
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
     CompletedWorkStatus,
-    OpportunityAccess,
-    OpportunityClaimLimit,
     UserVisit,
     VisitValidationStatus,
 )
-from commcare_connect.opportunity.visit_import import update_payment_accrued_for_user
+from commcare_connect.opportunity.tasks import bulk_update_payment_accrued
 
-# ---- knobs --------------------------------------------------------------
-OPP_UUID = "<x>"  # set None to scan ALL opportunities
-DRY_RUN = True
-BATCH_SIZE = 500
-# -------------------------------------------------------------------------
+XFORM_IDS = []
 
-
-def _batched(iterable, n):
-    it = iter(iterable)
-    while batch := list(islice(it, n)):
-        yield batch
-
-
-def _find_over_cap_completed_works():
-    """Yield (claim_limit, [over_cap_cw_id, ...], [over_cap_visit_id, ...])
-    for every claim limit whose worker has more active CompletedWork rows than
-    the per-payment-unit cap allows.
-    """
-    qs = OpportunityClaimLimit.objects.select_related(
-        "opportunity_claim__opportunity_access__opportunity",
-        "payment_unit",
-    ).filter(
-        opportunity_claim__opportunity_access__opportunity__active=True,
-        opportunity_claim__opportunity_access__opportunity__is_test=False,
+visit_rows = list(
+    UserVisit.objects.filter(xform_id__in=XFORM_IDS).values(
+        "user_id", "completed_work_id", "opportunity_id"
     )
-    if OPP_UUID:
-        qs = qs.filter(
-            opportunity_claim__opportunity_access__opportunity__opportunity_id=OPP_UUID
-        )
-    for cl in qs.iterator():
-        access = cl.opportunity_claim.opportunity_access
-        active_cw_ids = list(
-            CompletedWork.objects.filter(
-                opportunity_access=access,
-                payment_unit=cl.payment_unit,
-            )
-            .exclude(status=CompletedWorkStatus.over_limit)
-            .order_by("date_created")
-            .values_list("id", flat=True)
-        )
-        if len(active_cw_ids) > cl.max_visits:
-            over_cap_cw_ids = active_cw_ids[cl.max_visits :]
-            # All non-over_limit/trial visits attached to those CWs need flipping too.
-            over_cap_visit_ids = list(
-                UserVisit.objects.filter(completed_work_id__in=over_cap_cw_ids)
-                .exclude(
-                    status__in=[
-                        VisitValidationStatus.over_limit,
-                        VisitValidationStatus.trial,
-                    ]
-                )
-                .values_list("id", flat=True)
-            )
-            yield cl, over_cap_cw_ids, over_cap_visit_ids
-
-
-def _accrued_delta_by_access(plan):
-    """Return {access_id: {"worker": int, "org": int}} totals across the over-cap
-    CWs so the operator can see the projected payment_accrued reduction before
-    applying. Both values are >= 0; the corresponding accrued figures will
-    *decrease* by these amounts. The "org" total is only meaningful on managed
-    opportunities (zero on unmanaged ones)."""
-    deltas = defaultdict(lambda: {"worker": 0, "org": 0})
-    for cl, cw_ids, _ in plan:
-        if not cw_ids:
-            continue
-        agg = CompletedWork.objects.filter(id__in=cw_ids).aggregate(
-            worker=Sum("saved_payment_accrued"),
-            org=Sum("saved_org_payment_accrued"),
-        )
-        access_id = cl.opportunity_claim.opportunity_access_id
-        deltas[access_id]["worker"] += agg.get("worker") or 0
-        deltas[access_id]["org"] += agg.get("org") or 0
-    return deltas
-
-
-def main():
-    plan = list(_find_over_cap_completed_works())
-
-    if not plan:
-        print("Nothing to remediate.")
-        return
-
-    total_cws = sum(len(cw_ids) for _, cw_ids, _ in plan)
-    total_visits = sum(len(visit_ids) for _, _, visit_ids in plan)
-    print(
-        f"Found {total_cws} over-cap CompletedWork rows "
-        f"({total_visits} associated UserVisit rows) across {len(plan)} claim limits."
-    )
-
-    accrued_deltas = _accrued_delta_by_access(plan)
-    total_worker_drop = sum(d["worker"] for d in accrued_deltas.values())
-    total_org_drop = sum(d["org"] for d in accrued_deltas.values())
-
-    if DRY_RUN:
-        print("\n--- DRY RUN — printing breakdown ---")
-        per_access = defaultdict(lambda: {"cws": 0, "visits": 0})
-        for cl, cw_ids, visit_ids in plan:
-            access_id = cl.opportunity_claim.opportunity_access_id
-            per_access[access_id]["cws"] += len(cw_ids)
-            per_access[access_id]["visits"] += len(visit_ids)
-        for access_id, counts in sorted(per_access.items()):
-            delta = accrued_deltas.get(access_id, {"worker": 0, "org": 0})
-            print(
-                f"  access {access_id}: {counts['cws']} CW(s), "
-                f"{counts['visits']} visit(s) -> over_limit; "
-                f"worker payment_accrued -{delta['worker']}, "
-                f"org payment_accrued -{delta['org']}"
-            )
-        print(
-            f"\nProjected total reduction across all affected accesses: "
-            f"worker -{total_worker_drop}, org -{total_org_drop}"
-        )
-        print("Re-run with DRY_RUN = False to apply.")
-        return
-
-    affected_access_ids = sorted({cl.opportunity_claim.opportunity_access_id for cl, _, _ in plan})
-    affected_visit_ids = [vid for _, _, visit_ids in plan for vid in visit_ids]
-    affected_cw_ids = [cw_id for _, cw_ids, _ in plan for cw_id in cw_ids]
+)
+if not visit_rows:
+    print("No matching visits. Check XFORM_IDS.")
+else:
+    user_ids = list({v["user_id"] for v in visit_rows})
+    cw_ids = [v["completed_work_id"] for v in visit_rows if v["completed_work_id"]]
+    opp_id = visit_rows[0]["opportunity_id"]
 
     with transaction.atomic():
-        # bulk_update persists status_modified_date because __setattr__ stamps
-        # it in memory when status is assigned, and we list both fields below.
-        for batch in _batched(affected_visit_ids, BATCH_SIZE):
-            visits = list(UserVisit.objects.select_for_update().filter(id__in=batch))
-            for v in visits:
-                v.status = VisitValidationStatus.over_limit
-            UserVisit.objects.bulk_update(visits, fields=["status", "status_modified_date"])
-
-        for batch in _batched(affected_cw_ids, BATCH_SIZE):
-            cws = list(CompletedWork.objects.select_for_update().filter(id__in=batch))
-            for cw in cws:
-                cw.status = CompletedWorkStatus.over_limit
-            CompletedWork.objects.bulk_update(cws, fields=["status", "status_modified_date"])
-
-    # Recompute happens outside the atomic block because update_payment_accrued_for_user
-    # acquires its own Redis lock per access. If this loop is interrupted, the status
-    # flips are already committed but payment_accrued is stale for the unfinished
-    # accesses; the WARNING below prints the remaining ids so an operator can re-run
-    # update_payment_accrued_for_user(access, incremental=False) manually.
-    accesses_by_id = OpportunityAccess.objects.in_bulk(affected_access_ids)
-    recomputed = []
-    try:
-        for access_id in affected_access_ids:
-            update_payment_accrued_for_user(accesses_by_id[access_id], incremental=False)
-            recomputed.append(access_id)
-    finally:
-        if len(recomputed) != len(affected_access_ids):
-            remaining = [a for a in affected_access_ids if a not in recomputed]
-            print(
-                f"WARNING: recompute interrupted. {len(recomputed)} done, "
-                f"{len(remaining)} remaining: {remaining}"
-            )
-
+        UserVisit.objects.filter(xform_id__in=XFORM_IDS).update(
+            status=VisitValidationStatus.over_limit,
+            status_modified_date=now(),
+        )
+        CompletedWork.objects.filter(id__in=cw_ids).update(
+            status=CompletedWorkStatus.over_limit,
+            status_modified_date=now(),
+        )
+    bulk_update_payment_accrued.delay(opp_id, user_ids)
     print(
-        f"Done. Flipped {len(affected_visit_ids)} UserVisit rows and "
-        f"{len(affected_cw_ids)} CompletedWork rows. "
-        f"Recomputed payment_accrued for {len(recomputed)}/{len(affected_access_ids)} accesses. "
-        f"Projected reduction: worker -{total_worker_drop}, org -{total_org_drop}."
+        f"Flipped {len(visit_rows)} UserVisits and {len(cw_ids)} CompletedWorks; "
+        f"recompute queued for {len(user_ids)} worker(s)."
     )

--- a/docs/plans/script.py
+++ b/docs/plans/script.py
@@ -1,7 +1,18 @@
 """
-Identify and remediate UserVisit rows that exceed the per-worker cap configured
-on their OpportunityClaimLimit. Caused by the over_limit status-reset bug fixed
-in processor.py:280 (commit <fix-sha>).
+Identify and remediate CompletedWork (and their UserVisit) rows that exceed
+the per-worker cap configured on their OpportunityClaimLimit. Caused by the
+over_limit status-reset bug fixed in processor.py:280 (PR https://github.com/dimagi/commcare-connect/pull/1151).
+
+The cap (claim_limit.max_visits) is on EARNED PAYMENT UNITS, not on raw
+UserVisits. A payment unit can have multiple deliver units (e.g. registration
++ service delivery), so counting visits double-counts in those cases. We count
+CompletedWork rows instead — each CW is unique per (access, entity, payment_unit)
+and represents one earned payment unit regardless of how many deliver-unit
+forms it took to satisfy.
+
+For each over-cap CompletedWork we flip the CW *and all its UserVisits* to
+over_limit as a unit. This avoids any partial-flip inconsistency between a
+CW and its visits.
 
 Usage:
     Edit OPP_UUID and DRY_RUN below, then:
@@ -35,10 +46,13 @@ def _batched(iterable, n):
         yield batch
 
 
-def _find_over_cap_visit_ids():
-    """Yield (claim_limit, [over_cap_visit_id, ...]) for every claim limit with extras."""
+def _find_over_cap_completed_works():
+    """Yield (claim_limit, [over_cap_cw_id, ...], [over_cap_visit_id, ...])
+    for every claim limit whose worker has more active CompletedWork rows than
+    the per-payment-unit cap allows.
+    """
     qs = OpportunityClaimLimit.objects.select_related(
-        "opportunity_claim__opportunity_access",
+        "opportunity_claim__opportunity_access__opportunity",
         "payment_unit",
     ).filter(
         opportunity_claim__opportunity_access__opportunity__active=True,
@@ -50,107 +64,89 @@ def _find_over_cap_visit_ids():
         )
     for cl in qs.iterator():
         access = cl.opportunity_claim.opportunity_access
-        active_visit_ids = list(
-            UserVisit.objects.filter(
+        active_cw_ids = list(
+            CompletedWork.objects.filter(
                 opportunity_access=access,
-                deliver_unit__payment_unit=cl.payment_unit,
+                payment_unit=cl.payment_unit,
             )
-            .exclude(
-                status__in=[
-                    VisitValidationStatus.over_limit,
-                    VisitValidationStatus.trial,
-                ]
-            )
+            .exclude(status=CompletedWorkStatus.over_limit)
             .order_by("date_created")
             .values_list("id", flat=True)
         )
-        if len(active_visit_ids) > cl.max_visits:
-            yield cl, active_visit_ids[cl.max_visits :]
-
-
-def _completed_works_safe_to_flip(over_cap_visit_ids):
-    """Return CompletedWork ids whose every linked visit is in the over-cap set.
-
-    A CompletedWork that has at least one visit OUTSIDE the over-cap set is left
-    alone and reported as a warning — those need manual review.
-    """
-    over_cap_set = set(over_cap_visit_ids)
-    cw_ids = (
-        UserVisit.objects.filter(id__in=over_cap_set)
-        .exclude(completed_work__isnull=True)
-        .values_list("completed_work_id", flat=True)
-        .distinct()
-    )
-    safe, mixed = [], []
-    for cw_id in cw_ids:
-        all_visit_ids = set(
-            UserVisit.objects.filter(completed_work_id=cw_id).values_list("id", flat=True)
-        )
-        if all_visit_ids.issubset(over_cap_set):
-            safe.append(cw_id)
-        else:
-            mixed.append(cw_id)
-    return safe, mixed
+        if len(active_cw_ids) > cl.max_visits:
+            over_cap_cw_ids = active_cw_ids[cl.max_visits :]
+            # All non-over_limit/trial visits attached to those CWs need flipping too.
+            over_cap_visit_ids = list(
+                UserVisit.objects.filter(completed_work_id__in=over_cap_cw_ids)
+                .exclude(
+                    status__in=[
+                        VisitValidationStatus.over_limit,
+                        VisitValidationStatus.trial,
+                    ]
+                )
+                .values_list("id", flat=True)
+            )
+            yield cl, over_cap_cw_ids, over_cap_visit_ids
 
 
 def main():
-    plan = []  # list of (claim_limit, over_cap_ids)
-    for cl, over_cap_ids in _find_over_cap_visit_ids():
-        plan.append((cl, over_cap_ids))
+    plan = list(_find_over_cap_completed_works())
 
     if not plan:
         print("Nothing to remediate.")
         return
 
-    total = sum(len(ids) for _, ids in plan)
-    print(f"Found {total} over-cap UserVisit rows across {len(plan)} claim limits.")
-    affected_visit_ids = [vid for _, ids in plan for vid in ids]
-    safe_cw_ids, mixed_cw_ids = _completed_works_safe_to_flip(affected_visit_ids)
-    print(f"  CompletedWork rows to flip: {len(safe_cw_ids)}")
-    if mixed_cw_ids:
-        print(
-            f"  WARNING: {len(mixed_cw_ids)} CompletedWork rows are linked to BOTH "
-            f"in-cap and over-cap visits. They will NOT be flipped automatically. "
-            f"Manual review needed: {mixed_cw_ids}"
-        )
+    total_cws = sum(len(cw_ids) for _, cw_ids, _ in plan)
+    total_visits = sum(len(visit_ids) for _, _, visit_ids in plan)
+    print(
+        f"Found {total_cws} over-cap CompletedWork rows "
+        f"({total_visits} associated UserVisit rows) across {len(plan)} claim limits."
+    )
 
     if DRY_RUN:
         print("\n--- DRY RUN — printing breakdown ---")
-        per_access = defaultdict(int)
-        for cl, ids in plan:
-            per_access[cl.opportunity_claim.opportunity_access_id] += len(ids)
-        for access_id, n in sorted(per_access.items()):
-            print(f"  access {access_id}: {n} over-cap visit(s) -> over_limit")
-        print("\nRe-run with DRY_RUN = False to apply.")
+        per_access = defaultdict(lambda: {"cws": 0, "visits": 0})
+        for cl, cw_ids, visit_ids in plan:
+            access_id = cl.opportunity_claim.opportunity_access_id
+            per_access[access_id]["cws"] += len(cw_ids)
+            per_access[access_id]["visits"] += len(visit_ids)
+        for access_id, counts in sorted(per_access.items()):
+            print(
+                f"  access {access_id}: {counts['cws']} CW(s), "
+                f"{counts['visits']} visit(s) -> over_limit"
+            )
+        print("Re-run with DRY_RUN = False to apply.")
         return
 
     affected_access_ids = set()
+    affected_visit_ids = [vid for _, _, visit_ids in plan for vid in visit_ids]
+    affected_cw_ids = [cw_id for _, cw_ids, _ in plan for cw_id in cw_ids]
+
     with transaction.atomic():
-        # Flip UserVisit.status
+        # bulk_update persists status_modified_date because __setattr__ stamps
+        # it in memory when status is assigned, and we list both fields below.
         for batch in _batched(affected_visit_ids, BATCH_SIZE):
-            visits = list(
-                UserVisit.objects.select_for_update().filter(id__in=batch)
-            )
+            visits = list(UserVisit.objects.select_for_update().filter(id__in=batch))
             for v in visits:
-                v.status = VisitValidationStatus.over_limit  # __setattr__ updates status_modified_date
+                v.status = VisitValidationStatus.over_limit
                 affected_access_ids.add(v.opportunity_access_id)
-            UserVisit.objects.bulk_update(
-                visits, fields=["status", "status_modified_date"]
-            )
+            UserVisit.objects.bulk_update(visits, fields=["status", "status_modified_date"])
 
-        # Flip CompletedWork.status (only for completed works fully covered by over-cap visits)
-        if safe_cw_ids:
-            CompletedWork.objects.filter(id__in=safe_cw_ids).update(
-                status=CompletedWorkStatus.over_limit
-            )
+        for batch in _batched(affected_cw_ids, BATCH_SIZE):
+            cws = list(CompletedWork.objects.select_for_update().filter(id__in=batch))
+            for cw in cws:
+                cw.status = CompletedWorkStatus.over_limit
+            CompletedWork.objects.bulk_update(cws, fields=["status", "status_modified_date"])
 
-    # Recompute payment_accrued for each affected access (full recompute, not incremental)
+    # Recompute payment_accrued for each affected access (full recompute, not incremental).
+    # Outside the atomic block because update_payment_accrued_for_user acquires its own
+    # Redis lock per access.
     for access_id in sorted(affected_access_ids):
         access = OpportunityAccess.objects.get(id=access_id)
         update_payment_accrued_for_user(access, incremental=False)
 
     print(
-        f"Done. Flipped {len(affected_visit_ids)} UserVisit rows, "
-        f"{len(safe_cw_ids)} CompletedWork rows, recomputed payment_accrued for "
-        f"{len(affected_access_ids)} accesses."
+        f"Done. Flipped {len(affected_visit_ids)} UserVisit rows and "
+        f"{len(affected_cw_ids)} CompletedWork rows. "
+        f"Recomputed payment_accrued for {len(affected_access_ids)} accesses."
     )

--- a/docs/plans/script.py
+++ b/docs/plans/script.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 from itertools import islice
 
 from django.db import transaction
+from django.db.models import Sum
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
@@ -89,6 +90,26 @@ def _find_over_cap_completed_works():
             yield cl, over_cap_cw_ids, over_cap_visit_ids
 
 
+def _accrued_delta_by_access(plan):
+    """Return {access_id: {"worker": int, "org": int}} totals across the over-cap
+    CWs so the operator can see the projected payment_accrued reduction before
+    applying. Both values are >= 0; the corresponding accrued figures will
+    *decrease* by these amounts. The "org" total is only meaningful on managed
+    opportunities (zero on unmanaged ones)."""
+    deltas = defaultdict(lambda: {"worker": 0, "org": 0})
+    for cl, cw_ids, _ in plan:
+        if not cw_ids:
+            continue
+        agg = CompletedWork.objects.filter(id__in=cw_ids).aggregate(
+            worker=Sum("saved_payment_accrued"),
+            org=Sum("saved_org_payment_accrued"),
+        )
+        access_id = cl.opportunity_claim.opportunity_access_id
+        deltas[access_id]["worker"] += agg.get("worker") or 0
+        deltas[access_id]["org"] += agg.get("org") or 0
+    return deltas
+
+
 def main():
     plan = list(_find_over_cap_completed_works())
 
@@ -103,6 +124,10 @@ def main():
         f"({total_visits} associated UserVisit rows) across {len(plan)} claim limits."
     )
 
+    accrued_deltas = _accrued_delta_by_access(plan)
+    total_worker_drop = sum(d["worker"] for d in accrued_deltas.values())
+    total_org_drop = sum(d["org"] for d in accrued_deltas.values())
+
     if DRY_RUN:
         print("\n--- DRY RUN — printing breakdown ---")
         per_access = defaultdict(lambda: {"cws": 0, "visits": 0})
@@ -111,10 +136,17 @@ def main():
             per_access[access_id]["cws"] += len(cw_ids)
             per_access[access_id]["visits"] += len(visit_ids)
         for access_id, counts in sorted(per_access.items()):
+            delta = accrued_deltas.get(access_id, {"worker": 0, "org": 0})
             print(
                 f"  access {access_id}: {counts['cws']} CW(s), "
-                f"{counts['visits']} visit(s) -> over_limit"
+                f"{counts['visits']} visit(s) -> over_limit; "
+                f"worker payment_accrued -{delta['worker']}, "
+                f"org payment_accrued -{delta['org']}"
             )
+        print(
+            f"\nProjected total reduction across all affected accesses: "
+            f"worker -{total_worker_drop}, org -{total_org_drop}"
+        )
         print("Re-run with DRY_RUN = False to apply.")
         return
 
@@ -148,5 +180,6 @@ def main():
     print(
         f"Done. Flipped {len(affected_visit_ids)} UserVisit rows and "
         f"{len(affected_cw_ids)} CompletedWork rows. "
-        f"Recomputed payment_accrued for {len(affected_access_ids)} accesses."
+        f"Recomputed payment_accrued for {len(affected_access_ids)} accesses. "
+        f"Projected reduction: worker -{total_worker_drop}, org -{total_org_drop}."
     )

--- a/docs/plans/script.py
+++ b/docs/plans/script.py
@@ -150,7 +150,7 @@ def main():
         print("Re-run with DRY_RUN = False to apply.")
         return
 
-    affected_access_ids = set()
+    affected_access_ids = sorted({cl.opportunity_claim.opportunity_access_id for cl, _, _ in plan})
     affected_visit_ids = [vid for _, _, visit_ids in plan for vid in visit_ids]
     affected_cw_ids = [cw_id for _, cw_ids, _ in plan for cw_id in cw_ids]
 
@@ -161,7 +161,6 @@ def main():
             visits = list(UserVisit.objects.select_for_update().filter(id__in=batch))
             for v in visits:
                 v.status = VisitValidationStatus.over_limit
-                affected_access_ids.add(v.opportunity_access_id)
             UserVisit.objects.bulk_update(visits, fields=["status", "status_modified_date"])
 
         for batch in _batched(affected_cw_ids, BATCH_SIZE):
@@ -170,16 +169,28 @@ def main():
                 cw.status = CompletedWorkStatus.over_limit
             CompletedWork.objects.bulk_update(cws, fields=["status", "status_modified_date"])
 
-    # Recompute payment_accrued for each affected access (full recompute, not incremental).
-    # Outside the atomic block because update_payment_accrued_for_user acquires its own
-    # Redis lock per access.
-    for access_id in sorted(affected_access_ids):
-        access = OpportunityAccess.objects.get(id=access_id)
-        update_payment_accrued_for_user(access, incremental=False)
+    # Recompute happens outside the atomic block because update_payment_accrued_for_user
+    # acquires its own Redis lock per access. If this loop is interrupted, the status
+    # flips are already committed but payment_accrued is stale for the unfinished
+    # accesses; the WARNING below prints the remaining ids so an operator can re-run
+    # update_payment_accrued_for_user(access, incremental=False) manually.
+    accesses_by_id = OpportunityAccess.objects.in_bulk(affected_access_ids)
+    recomputed = []
+    try:
+        for access_id in affected_access_ids:
+            update_payment_accrued_for_user(accesses_by_id[access_id], incremental=False)
+            recomputed.append(access_id)
+    finally:
+        if len(recomputed) != len(affected_access_ids):
+            remaining = [a for a in affected_access_ids if a not in recomputed]
+            print(
+                f"WARNING: recompute interrupted. {len(recomputed)} done, "
+                f"{len(remaining)} remaining: {remaining}"
+            )
 
     print(
         f"Done. Flipped {len(affected_visit_ids)} UserVisit rows and "
         f"{len(affected_cw_ids)} CompletedWork rows. "
-        f"Recomputed payment_accrued for {len(affected_access_ids)} accesses. "
+        f"Recomputed payment_accrued for {len(recomputed)}/{len(affected_access_ids)} accesses. "
         f"Projected reduction: worker -{total_worker_drop}, org -{total_org_drop}."
     )

--- a/docs/plans/script.py
+++ b/docs/plans/script.py
@@ -40,6 +40,9 @@ def _find_over_cap_visit_ids():
     qs = OpportunityClaimLimit.objects.select_related(
         "opportunity_claim__opportunity_access",
         "payment_unit",
+    ).filter(
+        opportunity_claim__opportunity_access__opportunity__active=True,
+        opportunity_claim__opportunity_access__opportunity__is_test=False,
     )
     if OPP_UUID:
         qs = qs.filter(

--- a/docs/plans/script.py
+++ b/docs/plans/script.py
@@ -37,8 +37,8 @@ else:
             status=CompletedWorkStatus.over_limit,
             status_modified_date=now(),
         )
-    bulk_update_payment_accrued.delay(opp_id, user_ids)
+    bulk_update_payment_accrued(opp_id, user_ids)
     print(
         f"Flipped {len(visit_rows)} UserVisits and {len(cw_ids)} CompletedWorks; "
-        f"recompute queued for {len(user_ids)} worker(s)."
+        f"recompute completed for {len(user_ids)} worker(s)."
     )

--- a/docs/plans/test_script.py
+++ b/docs/plans/test_script.py
@@ -28,7 +28,7 @@ def run_script(xform_ids):
 
 @pytest.fixture
 def mock_recompute():
-    with patch("commcare_connect.opportunity.tasks.bulk_update_payment_accrued.delay") as m:
+    with patch("commcare_connect.opportunity.tasks.bulk_update_payment_accrued") as m:
         yield m
 
 

--- a/docs/plans/test_script.py
+++ b/docs/plans/test_script.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.utils.timezone import now
+
+from commcare_connect.opportunity.models import (
+    CompletedWork,
+    CompletedWorkStatus,
+    UserVisit,
+    VisitValidationStatus,
+)
+from commcare_connect.opportunity.tests.factories import (
+    CompletedWorkFactory,
+    OpportunityAccessFactory,
+    UserVisitFactory,
+)
+
+SCRIPT_PATH = Path(__file__).parent / "script.py"
+SCRIPT_SRC = SCRIPT_PATH.read_text()
+
+
+def run_script(xform_ids):
+    """Exec docs/plans/script.py with XFORM_IDS substituted."""
+    src = SCRIPT_SRC.replace("XFORM_IDS = []", f"XFORM_IDS = {list(xform_ids)!r}", 1)
+    exec(compile(src, str(SCRIPT_PATH), "exec"), {"__name__": "_test_script"})
+
+
+@pytest.fixture
+def mock_recompute():
+    with patch("commcare_connect.opportunity.tasks.bulk_update_payment_accrued.delay") as m:
+        yield m
+
+
+def _make_visits(num_visits=1, **visit_kwargs):
+    access = OpportunityAccessFactory()
+    cw = CompletedWorkFactory(opportunity_access=access, status=CompletedWorkStatus.approved)
+    visits = UserVisitFactory.create_batch(
+        num_visits,
+        opportunity=access.opportunity,
+        opportunity_access=access,
+        user=access.user,
+        completed_work=cw,
+        status=VisitValidationStatus.approved,
+        **visit_kwargs,
+    )
+    return access, cw, visits
+
+
+@pytest.mark.django_db
+def test_flips_visits_and_completed_work_to_over_limit(mock_recompute):
+    access, cw, visits = _make_visits(num_visits=2)
+
+    run_script([v.xform_id for v in visits])
+
+    cw.refresh_from_db()
+    assert cw.status == CompletedWorkStatus.over_limit
+    for v in visits:
+        v.refresh_from_db()
+        assert v.status == VisitValidationStatus.over_limit
+    mock_recompute.assert_called_once_with(access.opportunity_id, [access.user_id])
+
+
+@pytest.mark.django_db
+def test_status_modified_date_is_stamped(mock_recompute):
+    """`.update()` bypasses the model's __setattr__, so the script must pass
+    status_modified_date explicitly. Verify it does."""
+    access, cw, [visit] = _make_visits(num_visits=1)
+    before = now()
+
+    run_script([visit.xform_id])
+
+    visit.refresh_from_db()
+    cw.refresh_from_db()
+    assert visit.status_modified_date >= before
+    assert cw.status_modified_date >= before
+
+
+@pytest.mark.django_db
+def test_empty_xform_ids_is_a_noop(mock_recompute):
+    _, _, [visit] = _make_visits(num_visits=1)
+
+    run_script([])
+
+    visit.refresh_from_db()
+    assert visit.status == VisitValidationStatus.approved
+    mock_recompute.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_unknown_xform_ids_makes_no_changes(mock_recompute):
+    _, _, [visit] = _make_visits(num_visits=1)
+
+    run_script(["00000000-0000-0000-0000-000000000000"])
+
+    visit.refresh_from_db()
+    assert visit.status == VisitValidationStatus.approved
+    mock_recompute.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_visit_without_completed_work_still_flips(mock_recompute):
+    """Trial-style visit (completed_work=None): visit flips, no CW touched."""
+    access = OpportunityAccessFactory()
+    visit = UserVisitFactory(
+        opportunity=access.opportunity,
+        opportunity_access=access,
+        user=access.user,
+        completed_work=None,
+        status=VisitValidationStatus.trial,
+    )
+
+    run_script([visit.xform_id])
+
+    visit.refresh_from_db()
+    assert visit.status == VisitValidationStatus.over_limit
+    mock_recompute.assert_called_once_with(access.opportunity_id, [access.user_id])
+
+
+@pytest.mark.django_db
+def test_user_dedupe_across_multiple_visits_same_user(mock_recompute):
+    """Three visits for one worker should yield a single user_id in the
+    recompute call, not three duplicates."""
+    access, cw, visits = _make_visits(num_visits=3)
+
+    run_script([v.xform_id for v in visits])
+
+    opp_id, user_ids = mock_recompute.call_args.args
+    assert opp_id == access.opportunity_id
+    assert user_ids == [access.user_id]
+
+
+@pytest.mark.django_db
+def test_atomicity_rolls_back_visit_flip_when_cw_update_fails(mock_recompute, monkeypatch):
+    """If the CW update raises, the visit flip in the same transaction must
+    roll back (otherwise we land in the misleading visits=over_limit /
+    CW=approved state)."""
+    access, cw, [visit] = _make_visits(num_visits=1)
+
+    failing_qs = MagicMock()
+    failing_qs.update.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(CompletedWork.objects, "filter", lambda **kw: failing_qs)
+
+    with pytest.raises(RuntimeError):
+        run_script([visit.xform_id])
+
+    visit.refresh_from_db()
+    assert visit.status == VisitValidationStatus.approved
+    mock_recompute.assert_not_called()


### PR DESCRIPTION
## Product Description

No user-facing changes. **This PR will not be merged** — it exists solely to give reviewers a clean diff to comment on for the one-off remediation script that will be executed manually via `./manage.py shell` in production. The script targets `UserVisit` rows that were silently auto-approved past their per-worker cap by the bug fixed in [`ze/fix-cap-bypass-when-duplicate-flag-off`](#) (CI-639), flipping them to `over_limit`, propagating the status to their `CompletedWork`, and recomputing `payment_accrued` for the affected workers.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-639) — companion to the code fix on `ze/fix-cap-bypass-when-duplicate-flag-off`.

This is a release path 1 feature — Improvements to existing features & quick wins

The script reproduces the cap-check the buggy submission path failed to honour: for each `OpportunityClaimLimit`, it loads active visits (status ∉ {`over_limit`, `trial`}) for that `(opportunity_access, payment_unit)` ordered by `date_created`, treats the first `max_visits` as legitimate, and treats the tail as the over-cap set that requires correction. The default scope is a single opportunity (set via `OPP_UUID`); pass `None` for a global scan once the targeted run is verified. `DRY_RUN = True` is the default so a reviewer can confirm the breakdown before any write happens.

- **Identification (`_find_over_cap_visit_ids`)**: ordering by `date_created` (server-received timestamp) ensures that earlier in-cap submissions are kept and only the chronological tail is flipped. Excludes already-`over_limit` and `trial` rows so re-runs are idempotent.
- **`CompletedWork` safety (`_completed_works_safe_to_flip`)**: a `CompletedWork` is only flipped to `over_limit` if **every** linked `UserVisit` is in the over-cap set. Mixed completed-works (linked to both in-cap and over-cap visits) are *not* touched and are reported as a warning for manual review — this matches the in-flight behaviour at `processor.py:427-429`, which also gates the completed-work flip per visit.
- **Status mutation**: visits are flipped via Python attribute assignment (`v.status = over_limit`) so the `UserVisit.__setattr__` override updates `status_modified_date` automatically. `bulk_update` then writes both fields in batches of `BATCH_SIZE = 500` inside a single `transaction.atomic()` block.
- **Locking**: `select_for_update()` per batch protects against concurrent submissions touching the same rows mid-script.
- **Payment recompute**: after the status writes commit, `update_payment_accrued_for_user(access, incremental=False)` is called for each affected access. The `incremental=False` recompute is required because flipping a visit *down* from `approved` to `over_limit` is the opposite of what the incremental path is designed for (it skips already-approved completed-works).
- **Output**: dry-run prints a per-access count of visits that would flip; non-dry-run prints final counts of visits/completed-works/accesses touched.

## Safety Assurance

### Safety story

- **Will not be merged.** This PR is a review surface only; the script is intended to be invoked manually (`./manage.py shell < scripts/remediate_over_cap_visits.py`) on a pre-arranged production window. No CI deploy, no scheduled job.
- **Default is dry-run.** `DRY_RUN = True` at the top means the first invocation prints the plan without writing. A reviewer should require the actual production run to be witnessed (or executed) by a second operator after the dry-run output has been sanity-checked.
- **Atomic.** All status writes happen inside a single `transaction.atomic()` block; if the run is killed mid-flight or any constraint is violated, nothing commits.
- **Reversible at the row level.** A `UserVisit` flipped from `approved` to `over_limit` can be flipped back via the same import/admin paths that already exist (`bulk_update_visit_status` in `visit_import.py`). The `status_modified_date` is updated, so the audit trail records when the remediation ran.
- **Idempotent.** Re-running excludes rows already at `over_limit`/`trial` from the "active" count, so a second run finds nothing to do.
- **Conservative on `CompletedWork`.** Mixed completed-works are never touched automatically; the warning lists them by id for human review. This avoids the failure mode where a completed-work shared between an in-cap and out-of-cap visit would have its status incorrectly flipped.
- **Money already paid out is not reversed.** The `payment_accrued` recompute reduces the *future* accrual but does not undo prior payouts. Operator must confirm the agreed financial treatment with finance (absorb / deduct / adjust) before the non-dry-run execution.
- **Suspended workers are not skipped.** The per-access call to `update_payment_accrued_for_user` does not gate on `access.suspended`. If the production data has any suspended-but-affected workers, decide before running whether to skip them or include them.

### Automated test coverage

No automated tests are added in this PR. The script is a one-shot remediation — its correctness is validated by:

- The companion code fix's regression test `test_over_limit_status_preserved_when_duplicate_flag_disabled` (in `ze/fix-cap-bypass-when-duplicate-flag-off`), which guarantees the bug cannot reproduce after deploy.
- The dry-run output, reviewed before each non-dry-run execution.

If reviewers want it as a defensible test, the suggested approach would be: build a fixture with one access at the cap and one access two visits over, run the script in-process with `DRY_RUN = False`, and assert (a) the in-cap access is untouched, (b) the over-cap access has exactly two visits flipped to `over_limit`, (c) the completed-works are flipped where every linked visit is over-cap, (d) `payment_accrued` is recomputed downward. Happy to add this if desired.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Reviewer reads the script end-to-end, confirms the identification logic in `_find_over_cap_visit_ids` matches the intent (chronological tail beyond `max_visits`).
- [ ] Reviewer confirms `_completed_works_safe_to_flip` correctly leaves mixed completed-works alone.
- [ ] On staging (or a prod replica), run with `OPP_UUID = "21bca9f7-00f9-4804-a7c0-e77c6139e579"` and `DRY_RUN = True`. Confirm the output reports exactly two over-cap visits across two distinct accesses, matching the prod-data we already audited.
- [ ] On staging, set `DRY_RUN = False` and re-run. Verify the two `UserVisit` rows are now `over_limit`, the two `CompletedWork` rows are `over_limit`, and the two affected workers' `payment_accrued` reflects the recompute.
- [ ] Re-run with `DRY_RUN = True` again — should report "Nothing to remediate" (idempotency check).
- [ ] **Production execution gate**: confirm with finance how prior payouts to the over-cap workers will be reconciled before running the non-dry-run script in prod.
- [ ] Production execution: run with `OPP_UUID` set to the affected opportunity, `DRY_RUN = True` first, then `DRY_RUN = False` only after the dry-run is reviewed. Capture the output.
- [ ] Optional follow-up: set `OPP_UUID = None` and `DRY_RUN = True` to scan for any other opportunities silently affected by the same bug. Decide per-opportunity remediation with finance.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
