### PR TITLE
Update work_ares status to visited on visit

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -14,7 +14,7 @@ from commcare_connect.commcarehq.models import HQServer
 from commcare_connect.form_receiver.const import CCC_LEARN_XMLNS
 from commcare_connect.form_receiver.exceptions import ProcessingError
 from commcare_connect.form_receiver.serializers import XForm
-from commcare_connect.microplanning.models import WorkArea
+from commcare_connect.microplanning.models import WorkArea, WorkAreaStatus
 from commcare_connect.opportunity.models import (
     Assessment,
     AssignedTask,
@@ -433,7 +433,11 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
         if work_area_case_id := deliver_unit_block.get("work_area_id"):
             if is_a_uuid(work_area_case_id):
                 try:
-                    user_visit.work_area = WorkArea.objects.get(case_id=work_area_case_id, opportunity=opportunity)
+                    work_area = WorkArea.objects.get(case_id=work_area_case_id, opportunity=opportunity)
+                    user_visit.work_area = work_area
+                    if work_area.status in (WorkAreaStatus.NOT_STARTED, WorkAreaStatus.NOT_VISITED):
+                        work_area.status = WorkAreaStatus.VISITED
+                        work_area.save(update_fields=["status"])
                 except WorkArea.DoesNotExist:
                     raise ProcessingError("Work area not found")
             else:

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -19,6 +19,7 @@ from commcare_connect.form_receiver.tests.xforms import (
     LearnModuleJsonFactory,
     get_form_json,
 )
+from commcare_connect.microplanning.models import WorkAreaStatus
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory
 from commcare_connect.opportunity.models import (
     Assessment,
@@ -986,3 +987,41 @@ def test_receiver_deliver_form_with_invalid_work_area_id(
         oauth_application=oauth_application,
     )
     assert not UserVisit.objects.filter(user=mobile_user_with_connect_link).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "initial_status,updated_status",
+    [
+        (WorkAreaStatus.NOT_STARTED, WorkAreaStatus.VISITED),
+        (WorkAreaStatus.NOT_VISITED, WorkAreaStatus.VISITED),
+        (WorkAreaStatus.VISITED, WorkAreaStatus.VISITED),
+        (WorkAreaStatus.EXPECTED_VISIT_REACHED, WorkAreaStatus.EXPECTED_VISIT_REACHED),
+        (WorkAreaStatus.UNASSIGNED, WorkAreaStatus.UNASSIGNED),
+        (WorkAreaStatus.REQUEST_FOR_INACCESSIBLE, WorkAreaStatus.REQUEST_FOR_INACCESSIBLE),
+        (WorkAreaStatus.INACCESSIBLE, WorkAreaStatus.INACCESSIBLE),
+        (WorkAreaStatus.EXCLUDED, WorkAreaStatus.EXCLUDED),
+    ],
+)
+def test_receiver_deliver_form_work_area_status(
+    mobile_user_with_connect_link: User,
+    api_client: APIClient,
+    opportunity: Opportunity,
+    initial_status,
+    updated_status,
+):
+    work_area = WorkAreaFactory(opportunity=opportunity, status=initial_status)
+    deliver_unit = DeliverUnitFactory(app=opportunity.deliver_app, payment_unit=opportunity.paymentunit_set.first())
+    oauth_application = opportunity.hq_server.oauth_application
+    stub = DeliverUnitStubFactory(id=deliver_unit.slug, work_area_id=work_area.case_id)
+
+    form_json = get_form_json(
+        form_block={**stub.json},
+        domain=deliver_unit.app.cc_domain,
+        app_id=deliver_unit.app.cc_app_id,
+    )
+
+    make_request(api_client, form_json, mobile_user_with_connect_link, oauth_application=oauth_application)
+
+    work_area.refresh_from_db()
+    assert work_area.status == updated_status


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2349
Backend change no UI change is involved

## Technical Summary

When a matching work-area is visited, it's marked as such

## Safety Assurance

### Safety story

Added tests

### Automated test coverage

Added tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA
### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
