### PR TITLE
Resolve Invoice Number Approved count Mismatches Actual Approved Visits

### DIFF
--- a/commcare_connect/opportunity/tests/test_completed_work.py
+++ b/commcare_connect/opportunity/tests/test_completed_work.py
@@ -32,6 +32,7 @@ class TestUninvoicedVisitItems:
         assert len(items) == 0
 
         completed_work = CompletedWorkFactory(status=CompletedWorkStatus.approved, opportunity_access=opp_access)
+        completed_work.saved_approved_count = 1
         completed_work.saved_payment_accrued = completed_work.payment_unit.amount
         completed_work.save()
 
@@ -59,6 +60,7 @@ class TestUninvoicedVisitItems:
             status=CompletedWorkStatus.approved,
             opportunity_access=opp_access,
         )
+        completed_work.saved_approved_count = 1
         completed_work.saved_payment_accrued = completed_work.payment_unit.amount
         completed_work.save()
 
@@ -207,6 +209,41 @@ class TestUninvoicedVisitItems:
             assert item["exchange_rate"] == expected_exchange_rate
             assert float(item["total_amount_usd"]) == round(total_local_amount / expected_exchange_rate, 2)
 
+    def test_number_approved_uses_saved_approved_count(self):
+        """A single CompletedWork can represent multiple approved visits.
+
+        number_approved must aggregate saved_approved_count, not row count, so it
+        stays consistent with total_amount_local (which sums saved_payment_accrued
+        = saved_approved_count * payment_unit.amount).
+        """
+        opp_access = OpportunityAccessFactory()
+        payment_unit = PaymentUnitFactory(opportunity=opp_access.opportunity, amount=100)
+
+        cw1 = CompletedWorkFactory(
+            status=CompletedWorkStatus.approved,
+            opportunity_access=opp_access,
+            payment_unit=payment_unit,
+        )
+        cw1.saved_approved_count = 2
+        cw1.saved_payment_accrued = 2 * payment_unit.amount
+        cw1.save()
+
+        cw2 = CompletedWorkFactory(
+            status=CompletedWorkStatus.approved,
+            opportunity_access=opp_access,
+            payment_unit=payment_unit,
+        )
+        cw2.saved_approved_count = 1
+        cw2.saved_payment_accrued = payment_unit.amount
+        cw2.save()
+
+        items = get_uninvoiced_visit_items(opp_access.opportunity)
+        assert len(items) == 1
+
+        item = items[0]
+        assert item["number_approved"] == 3
+        assert item["total_amount_local"] == 3 * payment_unit.amount
+
     def _create_completed_work(self, opp_access, status_modified_date, payment_unit, exchange_rate=1.0, n=1):
         for _ in range(n):
             cw = CompletedWorkFactory(
@@ -215,6 +252,7 @@ class TestUninvoicedVisitItems:
                 payment_unit=payment_unit,
             )
             cw.status_modified_date = status_modified_date
+            cw.saved_approved_count = 1
             cw.saved_payment_accrued = cw.payment_unit.amount
             cw.saved_payment_accrued_usd = cw.saved_payment_accrued / exchange_rate
             cw.save()

--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from django.db.models import Count, F, Sum
+from django.db.models import F, Sum
 from django.db.models.functions import TruncMonth
 
 from commcare_connect.opportunity.models import (
@@ -333,7 +333,7 @@ def get_invoice_items(completed_works_qs):
         .annotate(
             payment_unit_name=F("payment_unit__name"),
             payment_unit_amount=F("payment_unit__amount"),
-            record_count=Count("id"),
+            record_count=Sum("saved_approved_count"),
             currency=F("opportunity_access__opportunity__currency__code"),
             total_amount_usd=Sum("saved_payment_accrued_usd"),
             total_amount_local=Sum("saved_payment_accrued"),


### PR DESCRIPTION
## Product Description

The "Number approved" column in the Line Items table on the Review Service Delivery Invoice page now matches the Total Amount calculation. Previously, when a single `CompletedWork` represented multiple approved visits for the same entity, the count under-reported the actual number of approved visits, causing `Number approved × Payment Unit Amount` not to equal `Total Amount`. Network and Program Managers will now see arithmetically consistent line items.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-631)

This is a release path 1 feature — Improvements to existing features & quick wins

`get_invoice_items()` aggregated line items per `(payment_unit, month_approved)` and computed `total_amount_local = Sum("saved_payment_accrued")` but `record_count = Count("id")`. Since `saved_payment_accrued = saved_approved_count × payment_unit.amount` per `CompletedWork`, the totals were correct but the count counted rows instead of visits. A `CompletedWork` is keyed by `(opportunity_access, entity_id, payment_unit)` and can carry `saved_approved_count > 1`, so the two aggregates diverged whenever any record had more than one approved visit.

- **Fix:** Switched `record_count` from `Count("id")` to `Sum("saved_approved_count")` in [`completed_work.get_invoice_items`](commcare_connect/opportunity/utils/completed_work.py). This makes the count algebraically consistent with the total: `payment_unit.amount × Sum(saved_approved_count) == Sum(saved_payment_accrued)`.
- **No data migration needed:** `saved_approved_count` and `saved_payment_accrued` are written together in `CompletedWorkUpdater._update_payment`, so existing rows already have the right values.

## Safety Assurance

### Safety story

Read-only query change on the invoice review page. No schema changes, no data writes, no migrations. The new aggregate uses an already-populated cached column (`saved_approved_count`) that is written alongside `saved_payment_accrued` in the same `CompletedWorkUpdater._update_payment` call, so the two are guaranteed to be in sync for any record that has gone through the recompute path. If a stale row existed with `saved_payment_accrued > 0` but `saved_approved_count = 0`, the displayed count would be lower than before — but that condition implies an inconsistent record that would already mis-display elsewhere; spot-checking production data is straightforward (`WHERE saved_payment_accrued > 0 AND saved_approved_count = 0`).

The change is fully reversible — a one-line revert restores the prior behaviour.

### Automated test coverage

- `TestUninvoicedVisitItems.test_number_approved_uses_saved_approved_count` — regression test for the bug. Two `CompletedWork` rows in the same payment unit with `saved_approved_count` of 2 and 1 must produce `number_approved = 3` and `total_amount_local = 3 × payment_unit.amount`. This test fails on the prior implementation (`assert 2 == 3`) and passes after the fix.
- Updated existing `TestUninvoicedVisitItems` tests (`test_items_without_prior_invoice`, `test_items_with_prior_invoice`, and `_create_completed_work`) to set `saved_approved_count` alongside `saved_payment_accrued`, mirroring how the two fields are written together in production.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] On a managed opportunity that has at least one `CompletedWork` with `saved_approved_count > 1`, open the Review Service Delivery Invoice page.
- [ ] Verify the "Number approved" column for each line item equals `Total Amount / Payment Unit Amount` exactly.
- [ ] Verify line items where `saved_approved_count == 1` for every record (the common case) are unchanged.
- [ ] Verify the "Total Amount" column is unchanged from before the fix.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
