### PR TITLE
feat(audit): audit report list view with django-tables2

### DIFF
--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -1,0 +1,77 @@
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _l
+from django_tables2 import columns, tables
+
+from commcare_connect.audit.models import AuditReport
+
+
+class AuditReportTable(tables.Table):
+    audit_id = columns.Column(
+        accessor="serial",
+        verbose_name=_l("Audit ID"),
+        order_by=("period_end",),
+    )
+    date = columns.Column(
+        accessor="period_end",
+        verbose_name=_l("Date"),
+        orderable=True,
+    )
+    status = columns.Column(verbose_name=_l("Status"))
+    reviewer = columns.Column(
+        accessor="completed_by__name",
+        verbose_name=_l("Reviewer"),
+        default="—",
+        orderable=True,
+    )
+    view = columns.Column(
+        accessor="pk",
+        verbose_name="",
+        orderable=False,
+    )
+
+    class Meta:
+        model = AuditReport
+        fields = ("audit_id", "date", "status", "reviewer", "view")
+        empty_text = _l("No audits have been generated yet.")
+        order_by = ("-period_end",)
+        attrs = {"class": "table table-hover"}
+
+    def __init__(self, *args, opportunity=None, **kwargs):
+        self.opportunity = opportunity
+        super().__init__(*args, **kwargs)
+
+    def render_audit_id(self, record):
+        url = reverse(
+            "opportunity:audit:audit_report_detail",
+            kwargs={
+                "org_slug": self.opportunity.organization.slug,
+                "opportunity_id": self.opportunity.opportunity_id,
+                "audit_report_id": record.audit_report_id,
+            },
+        )
+        return format_html('<a class="text-brand-deep-purple hover:underline" href="{}">#{}</a>', url, record.serial)
+
+    def render_date(self, value):
+        return value.strftime("%b %-d, %Y")
+
+    def render_status(self, record):
+        if record.status == AuditReport.Status.COMPLETED:
+            modifier = "positive-dark"
+            label = _("Complete")
+        else:
+            modifier = "warning-dark"
+            label = _("Pending")
+        return format_html('<span class="badge badge-md {}">{}</span>', modifier, label)
+
+    def render_view(self, record):
+        url = reverse(
+            "opportunity:audit:audit_report_detail",
+            kwargs={
+                "org_slug": self.opportunity.organization.slug,
+                "opportunity_id": self.opportunity.opportunity_id,
+                "audit_report_id": record.audit_report_id,
+            },
+        )
+        return format_html('<a href="{}" aria-label="{}">&rsaquo;</a>', url, _("View audit"))

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -1,0 +1,68 @@
+import pytest
+from django.urls import reverse
+
+from commcare_connect.audit.models import AuditReport
+from commcare_connect.audit.tests.factories import AuditReportFactory
+from commcare_connect.flags.flag_names import WEEKLY_PERFORMANCE_REPORT
+from commcare_connect.flags.models import Flag
+from commcare_connect.opportunity.tests.factories import OpportunityFactory
+
+
+@pytest.fixture
+def audit_opp(program_manager_org):
+    opportunity = OpportunityFactory(organization=program_manager_org)
+    flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
+    flag.opportunities.add(opportunity)
+    return opportunity
+
+
+@pytest.mark.django_db
+def test_list_view_shows_reports(client, program_manager_org_user_admin, audit_opp):
+    client.force_login(program_manager_org_user_admin)
+    report = AuditReportFactory(opportunity=audit_opp)
+
+    url = reverse(
+        "opportunity:audit:audit_report_list",
+        kwargs={"org_slug": audit_opp.organization.slug, "opportunity_id": audit_opp.opportunity_id},
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    # Audit ID rendered as a 1-based serial number, not the pk.
+    assert "#1" in html
+    # Period end rendered in the Date column.
+    assert report.period_end.strftime("%b") in html
+
+
+@pytest.mark.django_db
+def test_list_view_header_counts(client, program_manager_org_user_admin, audit_opp):
+    client.force_login(program_manager_org_user_admin)
+    AuditReportFactory(opportunity=audit_opp, status=AuditReport.Status.PENDING)
+    AuditReportFactory(opportunity=audit_opp, status=AuditReport.Status.PENDING)
+    AuditReportFactory(opportunity=audit_opp, status=AuditReport.Status.COMPLETED)
+
+    url = reverse(
+        "opportunity:audit:audit_report_list",
+        kwargs={"org_slug": audit_opp.organization.slug, "opportunity_id": audit_opp.opportunity_id},
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["total_count"] == 3
+    assert ctx["pending_count"] == 2
+    assert ctx["completed_count"] == 1
+
+
+@pytest.mark.django_db
+def test_list_view_404_when_flag_disabled(client, program_manager_org_user_admin, audit_opp):
+    # Disable the flag for this opportunity; the request should still be permitted
+    # past the program-manager decorator but 404 from the flag-gating helper.
+    Flag.objects.get(name=WEEKLY_PERFORMANCE_REPORT).opportunities.remove(audit_opp)
+    client.force_login(program_manager_org_user_admin)
+
+    url = reverse(
+        "opportunity:audit:audit_report_list",
+        kwargs={"org_slug": audit_opp.organization.slug, "opportunity_id": audit_opp.opportunity_id},
+    )
+    response = client.get(url)
+    assert response.status_code == 404

--- a/commcare_connect/audit/urls.py
+++ b/commcare_connect/audit/urls.py
@@ -1,0 +1,18 @@
+from django.urls import path
+
+from commcare_connect.audit import views
+
+app_name = "audit"
+
+urlpatterns = [
+    path(
+        "<uuid:opportunity_id>/audit_reports/",
+        views.audit_report_list,
+        name="audit_report_list",
+    ),
+    path(
+        "<uuid:opportunity_id>/audit_reports/<uuid:audit_report_id>/",
+        views.audit_report_detail,
+        name="audit_report_detail",
+    ),
+]

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -1,0 +1,73 @@
+from django.contrib.auth.decorators import login_required
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
+from django.http import Http404
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django_tables2 import RequestConfig
+
+from commcare_connect.audit.models import AuditReport
+from commcare_connect.audit.tables import AuditReportTable
+from commcare_connect.flags.flag_names import WEEKLY_PERFORMANCE_REPORT
+from commcare_connect.flags.models import Flag
+from commcare_connect.opportunity.models import Opportunity
+from commcare_connect.organization.decorators import org_program_manager_required
+
+DEFAULT_PAGE_SIZE = 25
+
+
+def _require_flagged_opportunity(org_slug, opportunity_id):
+    opportunity = get_object_or_404(Opportunity, opportunity_id=opportunity_id, organization__slug=org_slug)
+    try:
+        flag = Flag.objects.get(name=WEEKLY_PERFORMANCE_REPORT)
+    except Flag.DoesNotExist:
+        raise Http404("Weekly performance report is not enabled.")
+    if not flag.opportunities.filter(pk=opportunity.pk).exists():
+        raise Http404("Weekly performance report is not enabled for this opportunity.")
+    return opportunity
+
+
+@login_required
+@org_program_manager_required
+def audit_report_list(request, org_slug, opportunity_id):
+    opportunity = _require_flagged_opportunity(org_slug, opportunity_id)
+    # Annotate each row with its chronological position
+    queryset = (
+        AuditReport.objects.filter(opportunity=opportunity)
+        .select_related("completed_by")
+        .annotate(serial=Window(expression=RowNumber(), order_by=F("period_end").asc()))
+    )
+
+    total_count = queryset.count()
+    pending_count = queryset.filter(status=AuditReport.Status.PENDING).count()
+    completed_count = queryset.filter(status=AuditReport.Status.COMPLETED).count()
+
+    table = AuditReportTable(queryset, opportunity=opportunity)
+    RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(table)
+
+    path = [
+        {"title": "Opportunities", "url": reverse("opportunity:list", args=(org_slug,))},
+        {
+            "title": opportunity.name,
+            "url": reverse("opportunity:detail", args=(org_slug, opportunity.opportunity_id)),
+        },
+        {"title": "Audits"},
+    ]
+
+    return render(
+        request,
+        "audit/audit_report_list.html",
+        {
+            "opportunity": opportunity,
+            "table": table,
+            "total_count": total_count,
+            "pending_count": pending_count,
+            "completed_count": completed_count,
+            "path": path,
+        },
+    )
+
+
+def audit_report_detail(request, org_slug, opportunity_id, audit_report_id):
+    # Stub — real implementation in Task 11.
+    raise Http404()

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -4,6 +4,7 @@ from django.db.models.functions import RowNumber
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.translation import gettext as _
 from django_tables2 import RequestConfig
 
 from commcare_connect.audit.models import AuditReport
@@ -46,12 +47,12 @@ def audit_report_list(request, org_slug, opportunity_id):
     RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(table)
 
     path = [
-        {"title": "Opportunities", "url": reverse("opportunity:list", args=(org_slug,))},
+        {"title": _("Opportunities"), "url": reverse("opportunity:list", args=(org_slug,))},
         {
             "title": opportunity.name,
             "url": reverse("opportunity:detail", args=(org_slug, opportunity.opportunity_id)),
         },
-        {"title": "Audits"},
+        {"title": _("Audits")},
     ]
 
     return render(

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import include, path
 
 from commcare_connect.opportunity import views
 from commcare_connect.opportunity.views import (
@@ -184,4 +184,5 @@ urlpatterns = [
     path("<slug:opp_id>/assigned_tasks/create/", create_task, name="create_task"),
     path("<slug:opp_id>/assigned_tasks/delete/", delete_tasks, name="delete_tasks"),
     path("<slug:opp_id>/assigned_tasks/<int:pk>/edit/", EditAssignedTask.as_view(), name="edit_assigned_task"),
+    path("", include("commcare_connect.audit.urls", namespace="audit")),
 ]

--- a/commcare_connect/templates/audit/audit_report_list.html
+++ b/commcare_connect/templates/audit/audit_report_list.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+{% block title %}{% blocktrans with name=opportunity.name %}Audits — {{ name }}{% endblocktrans %}{% endblock %}
+{% block content %}
+  <div class="container md:max-w-screen-2xl mx-auto flex flex-col gap-4">
+    {% include 'components/breadcrumbs.html' with path=path %}
+
+    <div class="metric-container flex items-center justify-between">
+      <div class="flex flex-col gap-2">
+        <h1 class="text-2xl font-medium text-white">{% trans "Audits" %}</h1>
+        <p class="text-sm text-gray-100">{% trans "Monitor Connect Worker performance." %}</p>
+      </div>
+      <div class="flex gap-4">
+        <div class="flex flex-col items-center justify-center min-w-32 px-4 py-3 metric-card">
+          <span class="text-2xl font-bold text-white">{{ total_count }}</span>
+          <span class="text-xs text-white mt-1">{% trans "Total Audits" %}</span>
+        </div>
+        <div class="flex flex-col items-center justify-center min-w-32 px-4 py-3 metric-card">
+          <span class="text-2xl font-bold text-white">{{ pending_count }}</span>
+          <span class="text-xs text-white mt-1">{% trans "Pending Audits" %}</span>
+        </div>
+        <div class="flex flex-col items-center justify-center min-w-32 px-4 py-3 metric-card">
+          <span class="text-2xl font-bold text-white">{{ completed_count }}</span>
+          <span class="text-xs text-white mt-1">{% trans "Complete" %}</span>
+        </div>
+      </div>
+    </div>
+
+    {% render_table table %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
https://dimagi.atlassian.net/browse/CCCT-2271

This implements the audit list page, showing each generated audit and its status.

Empty page
<img width="3834" height="1335" alt="Screenshot from 2026-05-01 18-29-25" src="https://github.com/user-attachments/assets/165d34c0-31d7-4c1c-bf36-16ab90799c52" />

With pending audits
<img width="3834" height="1335" alt="Screenshot from 2026-05-03 14-14-38" src="https://github.com/user-attachments/assets/43537529-a876-4f5c-a312-0d45df94b666" />


## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
It is a simple django table using the models generated by the celery task from https://github.com/dimagi/commcare-connect/pull/1156

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally, no changes to existing behavior

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
new behavior has tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
will be QAed as part of full audit QA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
