### PR TITLE
[EXEMPLAR — DO NOT MERGE] issue #1171: filter program-budget headroom by active

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -794,8 +794,10 @@ class OpportunityFinalizeForm(forms.ModelForm):
                 if not (program.start_date <= end_date <= program.end_date):
                     self.add_error("end_date", "End date must be within the program's start and end dates.")
 
+                # EXEMPLAR (issue #1171): only count active sibling opps. See PR description
+                # for the activation-time TOCTOU caveat.
                 total_budget_sum = (
-                    ManagedOpportunity.objects.filter(program=program)
+                    ManagedOpportunity.objects.filter(program=program, active=True)
                     .exclude(id=managed_opportunity.id)
                     .aggregate(total=Sum("total_budget"))["total"]
                     or 0

--- a/commcare_connect/program/api/serializers.py
+++ b/commcare_connect/program/api/serializers.py
@@ -166,8 +166,15 @@ class ManagedOpportunityCreateSerializer(serializers.Serializer):
                 {"end_date": _("End date must be within the program's start and end dates.")}
             )
 
+        # EXEMPLAR (issue #1171): only count active opps toward program-budget headroom so
+        # deactivated opps don't permanently consume budget. NOTE: managed opps are created
+        # with active=False (see ManagedOpportunityCreateSerializer.create), so the simple
+        # filter below introduces a TOCTOU at activation time — see PR description.
         other_budgets = (
-            ManagedOpportunity.objects.filter(program=program).aggregate(total=Sum("total_budget"))["total"] or 0
+            ManagedOpportunity.objects.filter(program=program, active=True).aggregate(total=Sum("total_budget"))[
+                "total"
+            ]
+            or 0
         )
         if other_budgets + data["total_budget"] > program.budget:
             raise serializers.ValidationError({"total_budget": _("Budget exceeds the program budget.")})


### PR DESCRIPTION
> **⚠️ This PR is an EXEMPLAR, not a merge candidate.**
>
> Its only purpose is to make the proposed fix in #1171 concrete enough
> to discuss. The change is illustrative, not vetted: there are no new
> tests, the existing test suite has not been run, and a real fix needs
> to address a TOCTOU concern called out below. **Please do not merge
> this PR.** Treat it as the diff equivalent of a comment on the issue.

Refs #1171.

## What this changes

Adds `active=True` to the program-budget headroom queries in two places:

- `commcare_connect/program/api/serializers.py` — `ManagedOpportunityCreateSerializer.validate` (the API path that triggered the issue).
- `commcare_connect/opportunity/forms.py` — `OpportunityChangeForm.clean` (the admin/edit path that uses the same rule).

So that `total_budget` from inactive sibling opportunities no longer counts toward program-budget consumption.

## Why this is *not* a real fix

Managed opportunities are **created with `active=False`** (see `ManagedOpportunityCreateSerializer.create`, line 267) and require a separate activation step. With the simple filter in this exemplar:

1. A user creates 30 managed opps under a \$3000 program at \$1000 each. All pass validation because each is checked while previous ones are still `active=False`.
2. The user then activates each one in turn. There is no budget re-check at activation time (none was found in `connect_activate_opportunity`'s code path).
3. Program budget goes to \$30,000, \$27,000 over cap.

So a real fix needs **either**:

- **(A)** filter by `active=True` *and* add a budget re-check inside the activation flow (and surface a clear error if the program is now over-cap), **or**
- **(B)** use a different signal that doesn't have the create-time-vs-activation-time gap — e.g. exclude opps whose `end_date < today`, which mirrors what `auto_deactivate_ended_opportunities` actually targets, **or**
- **(C)** treat program budget as a lifetime cap intentionally and update the error message + docs to say so (and provide a cleanup path — see issue).

I have a weak preference for **(A)** because it preserves the current "deactivated = released budget" mental model the issue assumes, but I'm not close enough to the product semantics to commit. Would value input from someone who owns this surface.

## Things this PR deliberately does not do

- No new tests. The exemplar would need at least: (i) an inactive-sibling test that currently fails the validator and would pass after this change; (ii) a TOCTOU repro that demonstrates the activation-time hole.
- `commcare_connect/program/tests/test_forms.py` already has a test pinning the *old* behaviour ("Budget exceeds the program budget") — it would need to be updated or split once we settle on the real fix.
- No migration to backfill or audit existing programs whose headroom would change interpretation under the new rule.

## Side-observations from the issue (intentionally out of scope)

The issue lists three side-observations about read-back serializer drift (`active` create-vs-list divergence, FLW-invite gating, list-endpoint payment-unit shape). I think at least #1 is likely an ACE-side reporting issue, not a server bug — `ManagedOpportunityResponseSerializer` reads `active` directly from the model, which is set to `False` on create. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)