### PR TITLE
Fix main test failure

### DIFF
--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -47,7 +47,7 @@ class AuditReportTable(tables.Table):
             "opportunity:audit:audit_report_detail",
             kwargs={
                 "org_slug": self.opportunity.organization.slug,
-                "opportunity_id": self.opportunity.opportunity_id,
+                "opp_id": self.opportunity.opportunity_id,
                 "audit_report_id": record.audit_report_id,
             },
         )
@@ -70,7 +70,7 @@ class AuditReportTable(tables.Table):
             "opportunity:audit:audit_report_detail",
             kwargs={
                 "org_slug": self.opportunity.organization.slug,
-                "opportunity_id": self.opportunity.opportunity_id,
+                "opp_id": self.opportunity.opportunity_id,
                 "audit_report_id": record.audit_report_id,
             },
         )

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -23,7 +23,7 @@ def test_list_view_shows_reports(client, program_manager_org_user_admin, audit_o
 
     url = reverse(
         "opportunity:audit:audit_report_list",
-        kwargs={"org_slug": audit_opp.organization.slug, "opportunity_id": audit_opp.opportunity_id},
+        kwargs={"org_slug": audit_opp.organization.slug, "opp_id": audit_opp.opportunity_id},
     )
     response = client.get(url)
     assert response.status_code == 200
@@ -43,7 +43,7 @@ def test_list_view_header_counts(client, program_manager_org_user_admin, audit_o
 
     url = reverse(
         "opportunity:audit:audit_report_list",
-        kwargs={"org_slug": audit_opp.organization.slug, "opportunity_id": audit_opp.opportunity_id},
+        kwargs={"org_slug": audit_opp.organization.slug, "opp_id": audit_opp.opportunity_id},
     )
     response = client.get(url)
     assert response.status_code == 200
@@ -62,7 +62,7 @@ def test_list_view_404_when_flag_disabled(client, program_manager_org_user_admin
 
     url = reverse(
         "opportunity:audit:audit_report_list",
-        kwargs={"org_slug": audit_opp.organization.slug, "opportunity_id": audit_opp.opportunity_id},
+        kwargs={"org_slug": audit_opp.organization.slug, "opp_id": audit_opp.opportunity_id},
     )
     response = client.get(url)
     assert response.status_code == 404

--- a/commcare_connect/audit/urls.py
+++ b/commcare_connect/audit/urls.py
@@ -6,12 +6,12 @@ app_name = "audit"
 
 urlpatterns = [
     path(
-        "<uuid:opportunity_id>/audit_reports/",
+        "<slug:opp_id>/audit_reports/",
         views.audit_report_list,
         name="audit_report_list",
     ),
     path(
-        "<uuid:opportunity_id>/audit_reports/<uuid:audit_report_id>/",
+        "<slug:opp_id>/audit_reports/<uuid:audit_report_id>/",
         views.audit_report_detail,
         name="audit_report_detail",
     ),

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
 from django.http import Http404
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django_tables2 import RequestConfig
@@ -11,27 +11,26 @@ from commcare_connect.audit.models import AuditReport
 from commcare_connect.audit.tables import AuditReportTable
 from commcare_connect.flags.flag_names import WEEKLY_PERFORMANCE_REPORT
 from commcare_connect.flags.models import Flag
-from commcare_connect.opportunity.models import Opportunity
-from commcare_connect.organization.decorators import org_program_manager_required
+from commcare_connect.organization.decorators import opportunity_required, org_program_manager_required
 
 DEFAULT_PAGE_SIZE = 25
 
 
-def _require_flagged_opportunity(org_slug, opportunity_id):
-    opportunity = get_object_or_404(Opportunity, opportunity_id=opportunity_id, organization__slug=org_slug)
+def _require_feature_flag(opportunity):
     try:
         flag = Flag.objects.get(name=WEEKLY_PERFORMANCE_REPORT)
     except Flag.DoesNotExist:
         raise Http404("Weekly performance report is not enabled.")
     if not flag.opportunities.filter(pk=opportunity.pk).exists():
         raise Http404("Weekly performance report is not enabled for this opportunity.")
-    return opportunity
 
 
 @login_required
 @org_program_manager_required
-def audit_report_list(request, org_slug, opportunity_id):
-    opportunity = _require_flagged_opportunity(org_slug, opportunity_id)
+@opportunity_required
+def audit_report_list(request, org_slug, opp_id):
+    opportunity = request.opportunity
+    _require_feature_flag(opportunity)
     # Annotate each row with its chronological position
     queryset = (
         AuditReport.objects.filter(opportunity=opportunity)
@@ -69,6 +68,7 @@ def audit_report_list(request, org_slug, opportunity_id):
     )
 
 
-def audit_report_detail(request, org_slug, opportunity_id, audit_report_id):
+@opportunity_required
+def audit_report_detail(request, org_slug, opp_id, audit_report_id):
     # Stub — real implementation in Task 11.
     raise Http404()


### PR DESCRIPTION
## Product Description

NA
Fixes a test

## Technical Summary

This fixes a test failure introduced in https://github.com/dimagi/commcare-connect/pull/1157

I think the reason it didn't fail on PR 1157 was because it was PRed on top of 1156. They were merged one after another immediately so 1157 was merged without CI running on it.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Fixes a test

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
