### PR TITLE
HQ Reset Case Property on Assigned Task Delete

### DIFF
--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -191,18 +191,25 @@ def bulk_update_cases(api_key: HQApiKey, domain: str, updates: list[dict[str, An
         raise CommCareHQAPIException(f"Failed to bulk-update {len(updates)} cases for {domain}. HQ Error: {e}") from e
 
 
-def update_usercase(opportunity_access: OpportunityAccess, data: dict[str, Any]) -> CommCareCase:
-    domain = opportunity_access.opportunity.deliver_app.cc_domain
-    api_key = opportunity_access.opportunity.api_key
+def bulk_update_usercases(updates: list[tuple[OpportunityAccess, dict[str, Any]]]) -> None:
+    if not updates:
+        return
+
+    first_access = updates[0][0]
+    domain = first_access.opportunity.deliver_app.cc_domain
+    api_key = first_access.opportunity.api_key
     hq_server = api_key.hq_server
 
-    link = ConnectIDUserLink.objects.get(user=opportunity_access.user, domain=domain, hq_server=hq_server)
-    if link.hq_case_id is None:
-        usercase = get_usercase(opportunity_access)
-        link.hq_case_id = usercase.case_id
-        link.save()
+    cases_data = []
+    for access, data in updates:
+        link = ConnectIDUserLink.objects.get(user=access.user, domain=domain, hq_server=hq_server)
+        if link.hq_case_id is None:
+            usercase = get_usercase(access)
+            link.hq_case_id = usercase.case_id
+            link.save()
+        cases_data.append({"case_id": link.hq_case_id, **data})
 
-    return create_or_update_case(api_key, domain, data, case_id=link.hq_case_id)
+    bulk_update_cases(api_key, domain, cases_data)
 
 
 def get_usercase(opportunity_access: OpportunityAccess) -> CommCareCase:

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -172,6 +172,11 @@ def create_or_update_case(
 
 
 def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> None:
+    """Update usercase properties on CommCare HQ for multiple users in a single bulk request.
+
+    All entries in `updates` must belong to the same opportunity. The domain, API key, and
+    HQ server are derived from the first entry and applied to the entire batch.
+    """
     if not updates:
         return
 

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -171,26 +171,6 @@ def create_or_update_case(
     return CommCareCase(**data.get("case", {}))
 
 
-def bulk_update_cases(api_key: HQApiKey, domain: str, updates: list[dict[str, Any]]) -> None:
-    """POST a JSON array of case updates to /api/case/v2/.
-
-    HQ's bulk endpoint requires each row to carry a create flag; this helper
-    only updates existing cases, so create=False is injected per item.
-
-    All-or-nothing: raises CommCareHQAPIException on any non-2xx response.
-    """
-    base_url = f"{api_key.hq_server.url}/a/{domain}/api/case/v2/"
-    headers = {"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"}
-    payload = [{**update, "create": False} for update in updates]
-
-    try:
-        with httpx.Client(base_url=base_url, headers=headers) as client:
-            response = client.post("", json=payload)
-        response.raise_for_status()
-    except (httpx.HTTPStatusError, httpx.RequestError) as e:
-        raise CommCareHQAPIException(f"Failed to bulk-update {len(updates)} cases for {domain}. HQ Error: {e}") from e
-
-
 def bulk_update_usercases(updates: list[tuple[OpportunityAccess, dict[str, Any]]]) -> None:
     if not updates:
         return
@@ -207,9 +187,9 @@ def bulk_update_usercases(updates: list[tuple[OpportunityAccess, dict[str, Any]]
             usercase = get_usercase(access)
             link.hq_case_id = usercase.case_id
             link.save()
-        cases_data.append({"case_id": link.hq_case_id, **data})
+        cases_data.append({"case_id": link.hq_case_id, "create": False, **data})
 
-    bulk_update_cases(api_key, domain, cases_data)
+    bulk_create_or_update_cases(api_key, domain, cases_data)
 
 
 def get_usercase(opportunity_access: OpportunityAccess) -> CommCareCase:

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -171,21 +171,21 @@ def create_or_update_case(
     return CommCareCase(**data.get("case", {}))
 
 
-def bulk_update_usercases(updates: list[tuple[OpportunityAccess, dict[str, Any]]]) -> None:
+def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> None:
     if not updates:
         return
 
-    first_access = updates[0][0]
+    first_access = next(iter(updates))
     domain = first_access.opportunity.deliver_app.cc_domain
     api_key = first_access.opportunity.api_key
     hq_server = api_key.hq_server
 
-    users = [access.user for access, _ in updates]
+    users = [access.user for access in updates]
     links = ConnectIDUserLink.objects.filter(user__in=users, domain=domain, hq_server=hq_server)
     links_by_user = {link.user_id: link for link in links}
 
     cases_data = []
-    for access, data in updates:
+    for access, data in updates.items():
         link = links_by_user[access.user_id]
         if link.hq_case_id is None:
             usercase = get_usercase(access)

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -191,12 +191,16 @@ def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> N
 
     cases_data = []
     for access, data in updates.items():
-        link = links_by_user[access.user_id]
-        if link.hq_case_id is None:
-            usercase = get_usercase(access)
-            link.hq_case_id = usercase.case_id
+        link = links_by_user.get(access.user_id)
+        if link is None:
+            hq_case_id = get_usercase(access).case_id
+        elif link.hq_case_id is None:
+            hq_case_id = get_usercase(access).case_id
+            link.hq_case_id = hq_case_id
             link.save()
-        cases_data.append({"case_id": link.hq_case_id, "create": False, **data})
+        else:
+            hq_case_id = link.hq_case_id
+        cases_data.append({"case_id": hq_case_id, "create": False, **data})
 
     bulk_create_or_update_cases(api_key, domain, cases_data)
 

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -180,9 +180,13 @@ def bulk_update_usercases(updates: list[tuple[OpportunityAccess, dict[str, Any]]
     api_key = first_access.opportunity.api_key
     hq_server = api_key.hq_server
 
+    users = [access.user for access, _ in updates]
+    links = ConnectIDUserLink.objects.filter(user__in=users, domain=domain, hq_server=hq_server)
+    links_by_user = {link.user_id: link for link in links}
+
     cases_data = []
     for access, data in updates:
-        link = ConnectIDUserLink.objects.get(user=access.user, domain=domain, hq_server=hq_server)
+        link = links_by_user[access.user_id]
         if link.hq_case_id is None:
             usercase = get_usercase(access)
             link.hq_case_id = usercase.case_id

--- a/commcare_connect/commcarehq/tests/test_api.py
+++ b/commcare_connect/commcarehq/tests/test_api.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from commcare_connect.commcarehq.api import CommCareCase, create_or_update_case_by_work_area
+from commcare_connect.commcarehq.api import CommCareCase, bulk_update_usercases, create_or_update_case_by_work_area
 from commcare_connect.commcarehq.tests.factories import HQServerFactory
 from commcare_connect.microplanning.const import WORK_AREA_CASE_TYPE
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
@@ -72,3 +72,23 @@ class TestCreateOrUpdateCaseByWorkArea:
 
         with pytest.raises(ValueError, match="Work Area must have an assigned Opportunity Access"):
             create_or_update_case_by_work_area(work_area)
+
+
+@pytest.mark.django_db
+class TestBulkUpdateUsercases:
+    def test_falls_back_to_get_usercase_when_link_missing(self):
+        api_key = HQApiKeyFactory(hq_server=HQServerFactory())
+        access = OpportunityAccessFactory(opportunity__api_key=api_key)
+        hq_case_id = str(uuid.uuid4())
+        user_case = make_commcare_case(case_id=hq_case_id, owner_id=hq_case_id)
+
+        with (
+            patch("commcare_connect.commcarehq.api.get_usercase", return_value=user_case) as mock_get_usercase,
+            patch("commcare_connect.commcarehq.api.bulk_create_or_update_cases") as mock_bulk,
+        ):
+            bulk_update_usercases({access: {"properties": {"prop": "value"}}})
+
+        mock_get_usercase.assert_called_once_with(access)
+        mock_bulk.assert_called_once()
+        cases_data = mock_bulk.call_args[0][2]
+        assert cases_data == [{"case_id": hq_case_id, "create": False, "properties": {"prop": "value"}}]

--- a/commcare_connect/commcarehq/tests/test_api.py
+++ b/commcare_connect/commcarehq/tests/test_api.py
@@ -1,15 +1,13 @@
-import json
 import uuid
 from unittest.mock import patch
 
 import pytest
 
-from commcare_connect.commcarehq.api import CommCareCase, bulk_update_cases, create_or_update_case_by_work_area
+from commcare_connect.commcarehq.api import CommCareCase, create_or_update_case_by_work_area
 from commcare_connect.commcarehq.tests.factories import HQServerFactory
 from commcare_connect.microplanning.const import WORK_AREA_CASE_TYPE
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 from commcare_connect.opportunity.tests.factories import HQApiKeyFactory, OpportunityAccessFactory
-from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 
 DOMAIN = "test-domain"
 
@@ -74,33 +72,3 @@ class TestCreateOrUpdateCaseByWorkArea:
 
         with pytest.raises(ValueError, match="Work Area must have an assigned Opportunity Access"):
             create_or_update_case_by_work_area(work_area)
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "status_code, expect_exception",
-    [(200, False), (500, True)],
-)
-def test_bulk_update_cases(httpx_mock, status_code, expect_exception):
-    api_key = HQApiKeyFactory(hq_server=HQServerFactory())
-    updates = [
-        {"case_id": "case-1", "owner_id": ""},
-        {"case_id": "case-2", "owner_id": ""},
-    ]
-    httpx_mock.add_response(
-        method="POST",
-        url=f"{api_key.hq_server.url}/a/{DOMAIN}/api/case/v2/",
-        status_code=status_code,
-        json={} if not expect_exception else None,
-    )
-
-    if expect_exception:
-        with pytest.raises(CommCareHQAPIException):
-            bulk_update_cases(api_key, DOMAIN, updates)
-    else:
-        bulk_update_cases(api_key, DOMAIN, updates)
-        request = httpx_mock.get_request()
-        assert request.method == "POST"
-        expected_payload = [{**update, "create": False} for update in updates]
-        assert json.loads(request.content) == expected_payload
-        assert request.headers["Authorization"] == f"ApiKey {api_key.user.email}:{api_key.api_key}"

--- a/commcare_connect/microplanning/helpers.py
+++ b/commcare_connect/microplanning/helpers.py
@@ -3,7 +3,7 @@ import logging
 import pghistory
 from django.db import transaction
 
-from commcare_connect.commcarehq.api import bulk_update_cases
+from commcare_connect.commcarehq.api import bulk_create_or_update_cases
 from commcare_connect.microplanning.const import HQ_BULK_CHUNK_SIZE
 from commcare_connect.microplanning.models import WorkArea, WorkAreaStatus
 from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
@@ -44,11 +44,11 @@ def exclude_work_areas_for_opportunity(opportunity, work_area_ids, user, exclusi
     for i in range(0, len(needs_hq), HQ_BULK_CHUNK_SIZE):
         chunk = needs_hq[i : i + HQ_BULK_CHUNK_SIZE]  # noqa: E203
         # HQ's "unassigned" convention is "-"; empty string falls back to the submitting user.
-        updates = [{"case_id": str(wa.case_id), "owner_id": "-"} for wa in chunk]
+        updates = [{"case_id": str(wa.case_id), "owner_id": "-", "create": False} for wa in chunk]
         try:
             with transaction.atomic(), pghistory.context(**pghistory_ctx):
                 _bulk_exclude(chunk, user, exclusion_reason)
-                bulk_update_cases(api_key, domain, updates)
+                bulk_create_or_update_cases(api_key, domain, updates)
         except CommCareHQAPIException as e:
             logger.warning("Failed to unassign HQ case chunk (size=%d): %s", len(chunk), e)
             failed += len(chunk)

--- a/commcare_connect/microplanning/tests/test_helpers.py
+++ b/commcare_connect/microplanning/tests/test_helpers.py
@@ -12,7 +12,7 @@ from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 
 @pytest.mark.django_db
 class TestExcludeWorkAreas:
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_happy_path_excludes_not_started_areas(self, mock_bulk_hq, org_user_admin, opportunity):
         access = OpportunityAccessFactory(opportunity=opportunity)
         group = WorkAreaGroupFactory(opportunity=opportunity)
@@ -41,7 +41,7 @@ class TestExcludeWorkAreas:
 
         assert mock_bulk_hq.call_count == 1
 
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_mixed_batch_only_not_started_is_excluded(self, mock_bulk_hq, org_user_admin, opportunity):
         wa_valid = WorkAreaFactory(opportunity=opportunity, status=WorkAreaStatus.NOT_STARTED)
         wa_inaccessible = WorkAreaFactory(opportunity=opportunity, status=WorkAreaStatus.INACCESSIBLE)
@@ -63,7 +63,7 @@ class TestExcludeWorkAreas:
         assert wa_inaccessible.status == WorkAreaStatus.INACCESSIBLE  # unchanged
         assert wa_excluded.status == WorkAreaStatus.EXCLUDED  # unchanged
 
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_hq_batch_failure_skips_local_exclusion_for_whole_chunk(self, mock_bulk_hq, org_user_admin, opportunity):
         """When the HQ bulk call fails, no work area in that chunk is excluded."""
         access = OpportunityAccessFactory(opportunity=opportunity)
@@ -90,7 +90,7 @@ class TestExcludeWorkAreas:
             assert wa.status == WorkAreaStatus.NOT_STARTED
             assert wa.work_area_group == group
 
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_no_case_id_excludes_locally_without_hq_call(self, mock_bulk_hq, org_user_admin, opportunity):
         wa = WorkAreaFactory(opportunity=opportunity, status=WorkAreaStatus.NOT_STARTED, case_id=None)
 
@@ -105,7 +105,7 @@ class TestExcludeWorkAreas:
         wa.refresh_from_db()
         assert wa.status == WorkAreaStatus.EXCLUDED
 
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_work_area_from_other_opportunity_is_ignored(self, mock_bulk_hq, org_user_admin, opportunity):
         other_wa = WorkAreaFactory(status=WorkAreaStatus.NOT_STARTED)  # different opportunity
 
@@ -130,7 +130,7 @@ class TestExcludeWorkAreas:
             WorkAreaStatus.EXPECTED_VISIT_REACHED,
         ],
     )
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_work_started_statuses_are_not_excluded(self, mock_bulk_hq, org_user_admin, opportunity, status):
         wa = WorkAreaFactory(opportunity=opportunity, status=status)
 
@@ -145,7 +145,7 @@ class TestExcludeWorkAreas:
         assert wa.status == status  # unchanged
         mock_bulk_hq.assert_not_called()
 
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_work_areas_over_chunk_size_are_split_into_batches(self, mock_bulk_hq, org_user_admin, opportunity):
         """125 work areas → 3 HQ calls (50, 50, 25); all excluded on success."""
         access = OpportunityAccessFactory(opportunity=opportunity)
@@ -174,7 +174,7 @@ class TestExcludeWorkAreas:
             wa.refresh_from_db()
             assert wa.status == WorkAreaStatus.EXCLUDED
 
-    @patch("commcare_connect.microplanning.helpers.bulk_update_cases")
+    @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_one_failed_chunk_does_not_block_other_chunks(self, mock_bulk_hq, org_user_admin, opportunity):
         """Chunk 2 fails; chunks 1 and 3 still excluded."""
         access = OpportunityAccessFactory(opportunity=opportunity)

--- a/commcare_connect/opportunity/exceptions.py
+++ b/commcare_connect/opportunity/exceptions.py
@@ -1,0 +1,2 @@
+class ListTooLongError(Exception):
+    """Raised when a list exceeds the maximum allowed size for a bulk operation."""

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -496,7 +496,9 @@ class AssignedTask(XFormBaseModel):
                 hq_updates.setdefault((task.opportunity_access_id, prop), task.opportunity_access)
 
         with transaction.atomic():
-            deleted_count, _ = cls.objects.filter(pk__in=[t.pk for t in tasks]).delete()
+            deleted_count, _ = (
+                cls.objects.filter(pk__in=[t.pk for t in tasks]).exclude(status=AssignedTaskStatus.COMPLETED).delete()
+            )
             if hq_updates:
                 still_assigned = set(
                     cls.objects.filter(
@@ -505,10 +507,10 @@ class AssignedTask(XFormBaseModel):
                         task_type__case_property__in={p for _, p in hq_updates},
                     ).values_list("opportunity_access_id", "task_type__case_property")
                 )
-                to_reset = {
-                    hq_updates[access_id, prop]: {"properties": {prop: ""}}
-                    for access_id, prop in hq_updates.keys() - still_assigned
-                }
+                to_reset: dict[OpportunityAccess, dict] = {}
+                for access_id, prop in hq_updates.keys() - still_assigned:
+                    access = hq_updates[access_id, prop]
+                    to_reset.setdefault(access, {"properties": {}})["properties"][prop] = ""
                 if len(to_reset) > HQ_CASE_BULK_CHUNK_SIZE:
                     raise ListTooLongError(
                         f"Too many HQ case property resets ({len(to_reset)}); "

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -472,6 +472,35 @@ class AssignedTask(XFormBaseModel):
             transaction.on_commit(lambda: send_task_assignment_notification.delay(assigned_task.pk))
         return assigned_task
 
+    @classmethod
+    def delete_and_reset_hq(cls, task_ids: list[int], opportunity: "Opportunity") -> int:
+        from commcare_connect.commcarehq.api import update_usercase
+
+        tasks = list(
+            cls.objects.filter(
+                pk__in=task_ids,
+                opportunity_access__opportunity=opportunity,
+            )
+            .exclude(status=AssignedTaskStatus.COMPLETED)
+            .select_related("task_type", "opportunity_access")
+        )
+        if not tasks:
+            return 0
+
+        hq_updates: dict[tuple[int, str], tuple["OpportunityAccess", str]] = {}
+        for task in tasks:
+            case_property = task.task_type.case_property
+            if case_property:
+                key = (task.opportunity_access_id, case_property)
+                hq_updates.setdefault(key, (task.opportunity_access, case_property))
+
+        with transaction.atomic():
+            deleted_count, _ = cls.objects.filter(pk__in=[t.pk for t in tasks]).delete()
+            for access, prop in hq_updates.values():
+                update_usercase(access, data={"properties": {prop: ""}})
+
+        return deleted_count
+
 
 class Assessment(XFormBaseModel):
     user = models.ForeignKey(

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -474,7 +474,7 @@ class AssignedTask(XFormBaseModel):
 
     @classmethod
     def delete_and_reset_hq(cls, task_ids: list[int], opportunity: "Opportunity") -> int:
-        from commcare_connect.commcarehq.api import bulk_update_usercases
+        from commcare_connect.commcarehq.api import HQ_CASE_BULK_CHUNK_SIZE, bulk_update_usercases
 
         tasks = list(
             cls.objects.filter(
@@ -506,6 +506,11 @@ class AssignedTask(XFormBaseModel):
                     (hq_updates[access_id, prop], {"properties": {prop: ""}})
                     for access_id, prop in hq_updates.keys() - still_assigned
                 ]
+                if len(to_reset) > HQ_CASE_BULK_CHUNK_SIZE:
+                    raise ValueError(
+                        f"Too many HQ case property resets ({len(to_reset)}); "
+                        "split the delete into smaller batches."
+                    )
                 if to_reset:
                     bulk_update_usercases(to_reset)
 

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -468,7 +468,7 @@ class AssignedTask(XFormBaseModel):
             )
             case_property = task_type.case_property
             if case_property:
-                bulk_update_usercases([(opportunity_access, {"properties": {case_property: "1"}})])
+                bulk_update_usercases({opportunity_access: {"properties": {case_property: "1"}}})
             transaction.on_commit(lambda: send_task_assignment_notification.delay(assigned_task.pk))
         return assigned_task
 
@@ -502,10 +502,10 @@ class AssignedTask(XFormBaseModel):
                         task_type__case_property__in={p for _, p in hq_updates},
                     ).values_list("opportunity_access_id", "task_type__case_property")
                 )
-                to_reset = [
-                    (hq_updates[access_id, prop], {"properties": {prop: ""}})
+                to_reset = {
+                    hq_updates[access_id, prop]: {"properties": {prop: ""}}
                     for access_id, prop in hq_updates.keys() - still_assigned
-                ]
+                }
                 if len(to_reset) > HQ_CASE_BULK_CHUNK_SIZE:
                     raise ValueError(
                         f"Too many HQ case property resets ({len(to_reset)}); "

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -455,7 +455,7 @@ class AssignedTask(XFormBaseModel):
 
     @classmethod
     def assign(cls, *, task_type, opportunity_access, due_date, assigned_by=None) -> "AssignedTask":
-        from commcare_connect.commcarehq.api import update_usercase
+        from commcare_connect.commcarehq.api import bulk_update_usercases
         from commcare_connect.opportunity.tasks import send_task_assignment_notification
 
         with transaction.atomic():
@@ -468,13 +468,13 @@ class AssignedTask(XFormBaseModel):
             )
             case_property = task_type.case_property
             if case_property:
-                update_usercase(opportunity_access, data={"properties": {case_property: "1"}})
+                bulk_update_usercases([(opportunity_access, {"properties": {case_property: "1"}})])
             transaction.on_commit(lambda: send_task_assignment_notification.delay(assigned_task.pk))
         return assigned_task
 
     @classmethod
     def delete_and_reset_hq(cls, task_ids: list[int], opportunity: "Opportunity") -> int:
-        from commcare_connect.commcarehq.api import update_usercase
+        from commcare_connect.commcarehq.api import bulk_update_usercases
 
         tasks = list(
             cls.objects.filter(
@@ -496,8 +496,8 @@ class AssignedTask(XFormBaseModel):
 
         with transaction.atomic():
             deleted_count, _ = cls.objects.filter(pk__in=[t.pk for t in tasks]).delete()
-            for access, prop in hq_updates.values():
-                update_usercase(access, data={"properties": {prop: ""}})
+            if hq_updates:
+                bulk_update_usercases([(access, {"properties": {prop: ""}}) for access, prop in hq_updates.values()])
 
         return deleted_count
 

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -17,6 +17,7 @@ from waffle import switch_is_active
 
 from commcare_connect.commcarehq.models import HQServer
 from commcare_connect.flags.switch_names import UPDATES_TO_MARK_AS_PAID_WORKFLOW
+from commcare_connect.opportunity.exceptions import ListTooLongError
 from commcare_connect.organization.models import Organization
 from commcare_connect.users.models import User, UserCredential
 from commcare_connect.utils.db import BaseModel, slugify_uniquely
@@ -475,7 +476,7 @@ class AssignedTask(XFormBaseModel):
         return assigned_task
 
     @classmethod
-    def delete_and_reset_hq(cls, task_ids: list[int], opportunity: Opportunity) -> int:
+    def bulk_delete(cls, task_ids: list[int], opportunity: Opportunity) -> int:
         from commcare_connect.commcarehq.api import HQ_CASE_BULK_CHUNK_SIZE, bulk_update_usercases
 
         tasks = list(
@@ -509,7 +510,7 @@ class AssignedTask(XFormBaseModel):
                     for access_id, prop in hq_updates.keys() - still_assigned
                 }
                 if len(to_reset) > HQ_CASE_BULK_CHUNK_SIZE:
-                    raise ValueError(
+                    raise ListTooLongError(
                         f"Too many HQ case property resets ({len(to_reset)}); "
                         "split the delete into smaller batches."
                     )

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from collections import Counter, defaultdict
 from decimal import Decimal
@@ -454,7 +456,7 @@ class AssignedTask(XFormBaseModel):
         ]
 
     @classmethod
-    def assign(cls, *, task_type, opportunity_access, due_date, assigned_by=None) -> "AssignedTask":
+    def assign(cls, *, task_type, opportunity_access, due_date, assigned_by=None) -> AssignedTask:
         from commcare_connect.commcarehq.api import bulk_update_usercases
         from commcare_connect.opportunity.tasks import send_task_assignment_notification
 
@@ -473,7 +475,7 @@ class AssignedTask(XFormBaseModel):
         return assigned_task
 
     @classmethod
-    def delete_and_reset_hq(cls, task_ids: list[int], opportunity: "Opportunity") -> int:
+    def delete_and_reset_hq(cls, task_ids: list[int], opportunity: Opportunity) -> int:
         from commcare_connect.commcarehq.api import HQ_CASE_BULK_CHUNK_SIZE, bulk_update_usercases
 
         tasks = list(
@@ -487,7 +489,7 @@ class AssignedTask(XFormBaseModel):
         if not tasks:
             return 0
 
-        hq_updates: dict[tuple[int, str], "OpportunityAccess"] = {}
+        hq_updates: dict[tuple[int, str], OpportunityAccess] = {}
         for task in tasks:
             if prop := task.task_type.case_property:
                 hq_updates.setdefault((task.opportunity_access_id, prop), task.opportunity_access)

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -487,17 +487,27 @@ class AssignedTask(XFormBaseModel):
         if not tasks:
             return 0
 
-        hq_updates: dict[tuple[int, str], tuple["OpportunityAccess", str]] = {}
+        hq_updates: dict[tuple[int, str], "OpportunityAccess"] = {}
         for task in tasks:
-            case_property = task.task_type.case_property
-            if case_property:
-                key = (task.opportunity_access_id, case_property)
-                hq_updates.setdefault(key, (task.opportunity_access, case_property))
+            if prop := task.task_type.case_property:
+                hq_updates.setdefault((task.opportunity_access_id, prop), task.opportunity_access)
 
         with transaction.atomic():
             deleted_count, _ = cls.objects.filter(pk__in=[t.pk for t in tasks]).delete()
             if hq_updates:
-                bulk_update_usercases([(access, {"properties": {prop: ""}}) for access, prop in hq_updates.values()])
+                still_assigned = set(
+                    cls.objects.filter(
+                        opportunity_access_id__in={access_id for access_id, _ in hq_updates},
+                        status=AssignedTaskStatus.ASSIGNED,
+                        task_type__case_property__in={p for _, p in hq_updates},
+                    ).values_list("opportunity_access_id", "task_type__case_property")
+                )
+                to_reset = [
+                    (hq_updates[access_id, prop], {"properties": {prop: ""}})
+                    for access_id, prop in hq_updates.keys() - still_assigned
+                ]
+                if to_reset:
+                    bulk_update_usercases(to_reset)
 
         return deleted_count
 

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -357,6 +357,29 @@ class TestAssignedTaskDeleteAndResetHQ:
         assert AssignedTask.objects.filter(pk=completed.pk).exists()
         mock_update.assert_not_called()
 
+    def test_skips_hq_when_other_assigned_task_remains(self):
+        access = OpportunityAccessFactory()
+        task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="needs_assessment")
+        task_to_delete = AssignedTaskFactory(
+            task_type=task_type,
+            opportunity_access=access,
+            status=AssignedTaskStatus.ASSIGNED,
+            due_date=date.today() + timedelta(days=7),
+        )
+        AssignedTaskFactory(
+            task_type=task_type,
+            opportunity_access=access,
+            status=AssignedTaskStatus.ASSIGNED,
+            due_date=date.today() + timedelta(days=7),
+        )
+
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
+            deleted = AssignedTask.delete_and_reset_hq([task_to_delete.pk], access.opportunity)
+
+        assert deleted == 1
+        assert not AssignedTask.objects.filter(pk=task_to_delete.pk).exists()
+        mock_update.assert_not_called()
+
     def test_deduplicates_hq_calls(self):
         access = OpportunityAccessFactory()
         task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="needs_assessment")

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -396,3 +396,20 @@ class TestAssignedTaskDeleteAndResetHQ:
             AssignedTask.bulk_delete([t.pk for t in tasks], access.opportunity)
 
         mock_update.assert_called_once_with({access: {"properties": {"needs_assessment": ""}}})
+
+    def test_merges_multiple_properties_per_user(self):
+        access = OpportunityAccessFactory()
+        due_date = date.today() + timedelta(days=7)
+        task_type_a = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="prop_a")
+        task_type_b = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="prop_b")
+        task_a = AssignedTaskFactory(
+            task_type=task_type_a, opportunity_access=access, status=AssignedTaskStatus.ASSIGNED, due_date=due_date
+        )
+        task_b = AssignedTaskFactory(
+            task_type=task_type_b, opportunity_access=access, status=AssignedTaskStatus.ASSIGNED, due_date=due_date
+        )
+
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
+            AssignedTask.bulk_delete([task_a.pk, task_b.pk], access.opportunity)
+
+        mock_update.assert_called_once_with({access: {"properties": {"prop_a": "", "prop_b": ""}}})

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -15,6 +15,7 @@ from commcare_connect.opportunity.models import (
     PaymentInvoice,
 )
 from commcare_connect.opportunity.tests.factories import (
+    AssignedTaskFactory,
     CompletedModuleFactory,
     CompletedWorkFactory,
     DeliverUnitFactory,
@@ -281,3 +282,94 @@ class TestAssignedTaskAssign:
                 )
 
         assert not AssignedTask.objects.filter(opportunity_access=access, task_type=task_type).exists()
+
+
+@pytest.mark.django_db
+class TestAssignedTaskDeleteAndResetHQ:
+    def test_deletes_rows_and_resets_hq(self):
+        access = OpportunityAccessFactory()
+        task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="needs_assessment")
+        due_date = date.today() + timedelta(days=7)
+        task = AssignedTaskFactory(
+            task_type=task_type,
+            opportunity_access=access,
+            status=AssignedTaskStatus.ASSIGNED,
+            due_date=due_date,
+        )
+
+        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+            deleted = AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
+
+        assert deleted == 1
+        assert not AssignedTask.objects.filter(pk=task.pk).exists()
+        mock_update.assert_called_once_with(access, data={"properties": {"needs_assessment": ""}})
+
+    @pytest.mark.parametrize("case_property", [None, ""])
+    def test_skips_hq_when_no_case_property(self, case_property):
+        access = OpportunityAccessFactory()
+        task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property=case_property)
+        task = AssignedTaskFactory(
+            task_type=task_type,
+            opportunity_access=access,
+            status=AssignedTaskStatus.ASSIGNED,
+            due_date=date.today() + timedelta(days=7),
+        )
+
+        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+            deleted = AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
+
+        assert deleted == 1
+        mock_update.assert_not_called()
+
+    def test_does_not_delete_when_hq_fails(self):
+        access = OpportunityAccessFactory()
+        task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="needs_assessment")
+        task = AssignedTaskFactory(
+            task_type=task_type,
+            opportunity_access=access,
+            status=AssignedTaskStatus.ASSIGNED,
+            due_date=date.today() + timedelta(days=7),
+        )
+
+        with mock.patch(
+            "commcare_connect.commcarehq.api.update_usercase",
+            side_effect=CommCareHQAPIException("boom"),
+        ):
+            with pytest.raises(CommCareHQAPIException):
+                AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
+
+        assert AssignedTask.objects.filter(pk=task.pk).exists()
+
+    def test_skips_completed_tasks(self):
+        access = OpportunityAccessFactory()
+        task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="needs_assessment")
+        completed = AssignedTaskFactory(
+            task_type=task_type,
+            opportunity_access=access,
+            status=AssignedTaskStatus.COMPLETED,
+            due_date=date.today() + timedelta(days=7),
+        )
+
+        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+            deleted = AssignedTask.delete_and_reset_hq([completed.pk], access.opportunity)
+
+        assert deleted == 0
+        assert AssignedTask.objects.filter(pk=completed.pk).exists()
+        mock_update.assert_not_called()
+
+    def test_deduplicates_hq_calls(self):
+        access = OpportunityAccessFactory()
+        task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property="needs_assessment")
+        due_date = date.today() + timedelta(days=7)
+        tasks = AssignedTaskFactory.create_batch(
+            2,
+            task_type=task_type,
+            opportunity_access=access,
+            status=AssignedTaskStatus.ASSIGNED,
+            due_date=due_date,
+        )
+
+        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+            AssignedTask.delete_and_reset_hq([t.pk for t in tasks], access.opportunity)
+
+        mock_update.assert_called_once_with(access, data={"properties": {"needs_assessment": ""}})

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -241,7 +241,7 @@ class TestAssignedTaskAssign:
                 assigned_by=assigner,
             )
 
-        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": "1"}})])
+        mock_update.assert_called_once_with({access: {"properties": {"needs_assessment": "1"}}})
         assert isinstance(assigned, AssignedTask)
         assert assigned.task_type == task_type
         assert assigned.opportunity_access == access
@@ -302,7 +302,7 @@ class TestAssignedTaskDeleteAndResetHQ:
 
         assert deleted == 1
         assert not AssignedTask.objects.filter(pk=task.pk).exists()
-        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": ""}})])
+        mock_update.assert_called_once_with({access: {"properties": {"needs_assessment": ""}}})
 
     @pytest.mark.parametrize("case_property", [None, ""])
     def test_skips_hq_when_no_case_property(self, case_property):
@@ -395,4 +395,4 @@ class TestAssignedTaskDeleteAndResetHQ:
         with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             AssignedTask.delete_and_reset_hq([t.pk for t in tasks], access.opportunity)
 
-        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": ""}})])
+        mock_update.assert_called_once_with({access: {"properties": {"needs_assessment": ""}}})

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -298,7 +298,7 @@ class TestAssignedTaskDeleteAndResetHQ:
         )
 
         with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
-            deleted = AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
+            deleted = AssignedTask.bulk_delete([task.pk], access.opportunity)
 
         assert deleted == 1
         assert not AssignedTask.objects.filter(pk=task.pk).exists()
@@ -316,7 +316,7 @@ class TestAssignedTaskDeleteAndResetHQ:
         )
 
         with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
-            deleted = AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
+            deleted = AssignedTask.bulk_delete([task.pk], access.opportunity)
 
         assert deleted == 1
         mock_update.assert_not_called()
@@ -336,7 +336,7 @@ class TestAssignedTaskDeleteAndResetHQ:
             side_effect=CommCareHQAPIException("boom"),
         ):
             with pytest.raises(CommCareHQAPIException):
-                AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
+                AssignedTask.bulk_delete([task.pk], access.opportunity)
 
         assert AssignedTask.objects.filter(pk=task.pk).exists()
 
@@ -351,7 +351,7 @@ class TestAssignedTaskDeleteAndResetHQ:
         )
 
         with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
-            deleted = AssignedTask.delete_and_reset_hq([completed.pk], access.opportunity)
+            deleted = AssignedTask.bulk_delete([completed.pk], access.opportunity)
 
         assert deleted == 0
         assert AssignedTask.objects.filter(pk=completed.pk).exists()
@@ -374,7 +374,7 @@ class TestAssignedTaskDeleteAndResetHQ:
         )
 
         with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
-            deleted = AssignedTask.delete_and_reset_hq([task_to_delete.pk], access.opportunity)
+            deleted = AssignedTask.bulk_delete([task_to_delete.pk], access.opportunity)
 
         assert deleted == 1
         assert not AssignedTask.objects.filter(pk=task_to_delete.pk).exists()
@@ -393,6 +393,6 @@ class TestAssignedTaskDeleteAndResetHQ:
         )
 
         with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
-            AssignedTask.delete_and_reset_hq([t.pk for t in tasks], access.opportunity)
+            AssignedTask.bulk_delete([t.pk for t in tasks], access.opportunity)
 
         mock_update.assert_called_once_with({access: {"properties": {"needs_assessment": ""}}})

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -233,7 +233,7 @@ class TestAssignedTaskAssign:
         due_date = date.today() + timedelta(days=7)
         assigner = access.user
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             assigned = AssignedTask.assign(
                 task_type=task_type,
                 opportunity_access=access,
@@ -241,7 +241,7 @@ class TestAssignedTaskAssign:
                 assigned_by=assigner,
             )
 
-        mock_update.assert_called_once_with(access, data={"properties": {"needs_assessment": "1"}})
+        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": "1"}})])
         assert isinstance(assigned, AssignedTask)
         assert assigned.task_type == task_type
         assert assigned.opportunity_access == access
@@ -255,7 +255,7 @@ class TestAssignedTaskAssign:
         task_type = TaskTypeFactory(app=access.opportunity.deliver_app, case_property=case_property)
         due_date = date.today() + timedelta(days=7)
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             assigned = AssignedTask.assign(
                 task_type=task_type,
                 opportunity_access=access,
@@ -271,7 +271,7 @@ class TestAssignedTaskAssign:
         due_date = date.today() + timedelta(days=7)
 
         with mock.patch(
-            "commcare_connect.commcarehq.api.update_usercase",
+            "commcare_connect.commcarehq.api.bulk_update_usercases",
             side_effect=CommCareHQAPIException("boom"),
         ):
             with pytest.raises(CommCareHQAPIException):
@@ -297,12 +297,12 @@ class TestAssignedTaskDeleteAndResetHQ:
             due_date=due_date,
         )
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             deleted = AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
 
         assert deleted == 1
         assert not AssignedTask.objects.filter(pk=task.pk).exists()
-        mock_update.assert_called_once_with(access, data={"properties": {"needs_assessment": ""}})
+        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": ""}})])
 
     @pytest.mark.parametrize("case_property", [None, ""])
     def test_skips_hq_when_no_case_property(self, case_property):
@@ -315,7 +315,7 @@ class TestAssignedTaskDeleteAndResetHQ:
             due_date=date.today() + timedelta(days=7),
         )
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             deleted = AssignedTask.delete_and_reset_hq([task.pk], access.opportunity)
 
         assert deleted == 1
@@ -332,7 +332,7 @@ class TestAssignedTaskDeleteAndResetHQ:
         )
 
         with mock.patch(
-            "commcare_connect.commcarehq.api.update_usercase",
+            "commcare_connect.commcarehq.api.bulk_update_usercases",
             side_effect=CommCareHQAPIException("boom"),
         ):
             with pytest.raises(CommCareHQAPIException):
@@ -350,7 +350,7 @@ class TestAssignedTaskDeleteAndResetHQ:
             due_date=date.today() + timedelta(days=7),
         )
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             deleted = AssignedTask.delete_and_reset_hq([completed.pk], access.opportunity)
 
         assert deleted == 0
@@ -369,7 +369,7 @@ class TestAssignedTaskDeleteAndResetHQ:
             due_date=due_date,
         )
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             AssignedTask.delete_and_reset_hq([t.pk for t in tasks], access.opportunity)
 
-        mock_update.assert_called_once_with(access, data={"properties": {"needs_assessment": ""}})
+        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": ""}})])

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2674,7 +2674,7 @@ class TestCreateTask:
         assert assigned.due_date == due_date
         assert assigned.status == AssignedTaskStatus.ASSIGNED
         assert assigned.assigned_by == org_user_member
-        mock_update.assert_called_once_with([(access, {"properties": {"some_prop": "1"}})])
+        mock_update.assert_called_once_with({access: {"properties": {"some_prop": "1"}}})
         msgs = list(get_messages(response.wsgi_request))
         assert any("successfully" in str(m) for m in msgs)
 
@@ -2842,7 +2842,7 @@ class TestDeleteTasks:
 
         assert response.status_code == HTTPStatus.OK
         assert not AssignedTask.objects.filter(pk=task.pk).exists()
-        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": ""}})])
+        mock_update.assert_called_once_with({access: {"properties": {"needs_assessment": ""}}})
 
     def test_delete_tasks_hq_failure_shows_error_and_keeps_tasks(self, client, org_user_member, opportunity):
         access = OpportunityAccessFactory(opportunity=opportunity)

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2826,3 +2826,42 @@ class TestDeleteTasks:
         client.force_login(user)
         response = client.post(self._url(opp), data={"task_ids": [1]})
         assert response.status_code == HTTPStatus.NOT_FOUND
+
+    def test_delete_tasks_resets_hq_case_property(self, client, org_user_member, opportunity):
+        access = OpportunityAccessFactory(opportunity=opportunity)
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property="needs_assessment")
+        task = AssignedTaskFactory(
+            opportunity_access=access,
+            task_type=task_type,
+            status=AssignedTaskStatus.ASSIGNED,
+        )
+        client.force_login(org_user_member)
+
+        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+            response = client.post(self._url(opportunity), data={"task_ids": [task.pk]})
+
+        assert response.status_code == HTTPStatus.OK
+        assert not AssignedTask.objects.filter(pk=task.pk).exists()
+        mock_update.assert_called_once_with(access, data={"properties": {"needs_assessment": ""}})
+
+    def test_delete_tasks_hq_failure_shows_error_and_keeps_tasks(self, client, org_user_member, opportunity):
+        access = OpportunityAccessFactory(opportunity=opportunity)
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property="needs_assessment")
+        task = AssignedTaskFactory(
+            opportunity_access=access,
+            task_type=task_type,
+            status=AssignedTaskStatus.ASSIGNED,
+        )
+        client.force_login(org_user_member)
+
+        with mock.patch(
+            "commcare_connect.commcarehq.api.update_usercase",
+            side_effect=CommCareHQAPIException("boom"),
+        ):
+            response = client.post(self._url(opportunity), data={"task_ids": [task.pk]})
+
+        assert response.status_code == HTTPStatus.OK
+        assert "HX-Redirect" in response
+        assert AssignedTask.objects.filter(pk=task.pk).exists()
+        msgs = list(get_messages(response.wsgi_request))
+        assert any("could not update CommCare HQ" in str(m) for m in msgs)

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2662,7 +2662,7 @@ class TestCreateTask:
         task = TaskTypeFactory(app=opportunity.deliver_app, case_property="some_prop")
         due_date = date.today() + timedelta(days=7)
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             response = client.post(
                 self._url(opportunity),
                 data={"task": task.pk, "access": access.pk, "due_date": due_date.isoformat()},
@@ -2674,7 +2674,7 @@ class TestCreateTask:
         assert assigned.due_date == due_date
         assert assigned.status == AssignedTaskStatus.ASSIGNED
         assert assigned.assigned_by == org_user_member
-        mock_update.assert_called_once_with(access, data={"properties": {"some_prop": "1"}})
+        mock_update.assert_called_once_with([(access, {"properties": {"some_prop": "1"}})])
         msgs = list(get_messages(response.wsgi_request))
         assert any("successfully" in str(m) for m in msgs)
 
@@ -2684,7 +2684,7 @@ class TestCreateTask:
         due_date = date.today() + timedelta(days=7)
 
         with mock.patch(
-            "commcare_connect.commcarehq.api.update_usercase",
+            "commcare_connect.commcarehq.api.bulk_update_usercases",
             side_effect=CommCareHQAPIException("boom"),
         ):
             response = client.post(
@@ -2837,12 +2837,12 @@ class TestDeleteTasks:
         )
         client.force_login(org_user_member)
 
-        with mock.patch("commcare_connect.commcarehq.api.update_usercase") as mock_update:
+        with mock.patch("commcare_connect.commcarehq.api.bulk_update_usercases") as mock_update:
             response = client.post(self._url(opportunity), data={"task_ids": [task.pk]})
 
         assert response.status_code == HTTPStatus.OK
         assert not AssignedTask.objects.filter(pk=task.pk).exists()
-        mock_update.assert_called_once_with(access, data={"properties": {"needs_assessment": ""}})
+        mock_update.assert_called_once_with([(access, {"properties": {"needs_assessment": ""}})])
 
     def test_delete_tasks_hq_failure_shows_error_and_keeps_tasks(self, client, org_user_member, opportunity):
         access = OpportunityAccessFactory(opportunity=opportunity)
@@ -2855,7 +2855,7 @@ class TestDeleteTasks:
         client.force_login(org_user_member)
 
         with mock.patch(
-            "commcare_connect.commcarehq.api.update_usercase",
+            "commcare_connect.commcarehq.api.bulk_update_usercases",
             side_effect=CommCareHQAPIException("boom"),
         ):
             response = client.post(self._url(opportunity), data={"task_ids": [task.pk]})

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3574,17 +3574,13 @@ def delete_tasks(request, org_slug, opp_id):
     except (TypeError, ValueError):
         return HttpResponseBadRequest()
 
-    deleted_count, _info = (
-        AssignedTask.objects.filter(
-            pk__in=task_ids,
-            opportunity_access__opportunity=request.opportunity,
-        )
-        .exclude(status=AssignedTaskStatus.COMPLETED)
-        .delete()
-    )
-
-    if deleted_count:
-        messages.success(request, _("Successfully deleted %(count)d task(s).") % {"count": deleted_count})
-
     redirect_url = _task_redirect_url(request, org_slug, opp_id)
+
+    try:
+        deleted_count = AssignedTask.delete_and_reset_hq(task_ids, request.opportunity)
+    except CommCareHQAPIException:
+        messages.error(request, _("Task deletion failed: could not update CommCare HQ. Please try again."))
+    else:
+        if deleted_count:
+            messages.success(request, _("Successfully deleted %(count)d task(s).") % {"count": deleted_count})
     return HttpResponse(headers={"HX-Redirect": redirect_url})

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -64,6 +64,7 @@ from commcare_connect.flags.utils import is_flag_active
 from commcare_connect.form_receiver.serializers import XFormSerializer
 from commcare_connect.opportunity.api.serializers.mobile import remove_opportunity_access_cache
 from commcare_connect.opportunity.app_xml import AppNoBuildException
+from commcare_connect.opportunity.exceptions import ListTooLongError
 from commcare_connect.opportunity.filters import (
     AssignedTaskFilterSet,
     DeliverFilterSet,
@@ -3580,11 +3581,11 @@ def delete_tasks(request, org_slug, opp_id):
     redirect_url = _task_redirect_url(request, org_slug, opp_id)
 
     try:
-        deleted_count = AssignedTask.delete_and_reset_hq(task_ids, request.opportunity)
+        deleted_count = AssignedTask.bulk_delete(task_ids, request.opportunity)
     except CommCareHQAPIException:
         logger.exception("Task deletion failed: could not update CommCare HQ for opportunity %s", opp_id)
         messages.error(request, _("Task deletion failed: could not update CommCare HQ. Please try again."))
-    except ValueError:
+    except ListTooLongError:
         logger.exception("Task deletion failed: too many tasks queued for opportunity %s", opp_id)
         messages.error(request, _("Too many tasks queued for deletion. Please select a smaller batch."))
     else:

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3580,6 +3580,8 @@ def delete_tasks(request, org_slug, opp_id):
         deleted_count = AssignedTask.delete_and_reset_hq(task_ids, request.opportunity)
     except CommCareHQAPIException:
         messages.error(request, _("Task deletion failed: could not update CommCare HQ. Please try again."))
+    except ValueError:
+        messages.error(request, _("Too many tasks queued for deletion. Please select a smaller batch."))
     else:
         if deleted_count:
             messages.success(request, _("Successfully deleted %(count)d task(s).") % {"count": deleted_count})

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from collections import Counter, defaultdict
 from datetime import timedelta
 from decimal import Decimal, InvalidOperation
@@ -221,6 +222,8 @@ from commcare_connect.utils.tables import (
     get_duration_min,
     get_validated_page_size,
 )
+
+logger = logging.getLogger(__name__)
 
 EXPORT_ROW_LIMIT = 10_000
 _NEXT_WORKER_TASKS = "worker_tasks"
@@ -3579,8 +3582,10 @@ def delete_tasks(request, org_slug, opp_id):
     try:
         deleted_count = AssignedTask.delete_and_reset_hq(task_ids, request.opportunity)
     except CommCareHQAPIException:
+        logger.exception("Task deletion failed: could not update CommCare HQ for opportunity %s", opp_id)
         messages.error(request, _("Task deletion failed: could not update CommCare HQ. Please try again."))
     except ValueError:
+        logger.exception("Task deletion failed: too many tasks queued for opportunity %s", opp_id)
         messages.error(request, _("Too many tasks queued for deletion. Please select a smaller batch."))
     else:
         if deleted_count:


### PR DESCRIPTION
## Product Description

When assigned tasks are deleted via the task management UI, CommCare HQ is now kept in sync: the case property set on the worker's user case at assignment time is cleared on deletion. If another assigned task for the same worker still references that same case property, the reset is skipped to avoid disrupting the active task.

This change has no visible UI difference for the happy path. On HQ API failure, the delete is now rolled back and an error banner is shown instead of silently succeeding.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2401)
This is a release path 3 feature — Experiments & early stage iterations of product area

Previously, deleting assigned tasks left stale case properties on the worker's HQ user case. This PR closes that gap with `AssignedTask.delete_and_reset_hq()`, which wraps the DB delete and HQ reset in a single `transaction.atomic()` block — a HQ failure rolls back the delete, ensuring tasks are never silently lost. HQ updates are sent as a single bulk POST via `bulk_update_usercases`, which delegates to the existing `bulk_create_or_update_cases` infrastructure (chunked at 100). A post-delete query + Python set subtraction determines which `(access, case_property)` pairs actually need resetting, avoiding unnecessary HQ calls when other tasks still hold the property.

As part of this work, `bulk_update_cases` was removed as a duplicate of `bulk_create_or_update_cases` — callers now inject `create: False` directly, giving all bulk case writes a single code path.

- **New classmethod — `AssignedTask.delete_and_reset_hq(task_ids, opportunity)`** (`opportunity/models.py`): Deduplicates `(access_id, case_property)` pairs, deletes within a transaction, runs one query to find still-active pairs, and resets only those that are now orphaned via `bulk_update_usercases`.
- **New API helper — `bulk_update_usercases(updates)`** (`commcarehq/api.py`): Accepts `list[tuple[OpportunityAccess, dict]]`, resolves `hq_case_id` per access (fetching from HQ and caching if missing), injects `create: False`, and calls `bulk_create_or_update_cases` for a single chunked POST.
- **`delete_tasks` view updated** (`opportunity/views.py`): Delegates to `delete_and_reset_hq()` and catches `CommCareHQAPIException`, showing a user-facing error and preserving tasks on HQ failure.
- **`bulk_update_cases` removed** (`commcarehq/api.py`): Was a thin wrapper around `bulk_create_or_update_cases` with `create: False` injected. Callers (`bulk_update_usercases`, `microplanning/helpers.py`) now call `bulk_create_or_update_cases` directly.

## Safety Assurance

### Safety story

The DB delete and HQ reset are wrapped in `transaction.atomic()` — a HQ failure rolls back the delete so tasks are never silently lost. The "still assigned" check runs inside the transaction after the delete, on the committed state, so it's correct under concurrent deletions. The function is scoped to the current opportunity and excludes `COMPLETED` tasks, matching existing delete behaviour. Manually integration-tested against a local HQ instance: assignment correctly set the case property to `"1"` via a bulk POST, and deletion cleared it to `""` in a second bulk POST.

### Automated test coverage

- **`TestAssignedTaskDeleteAndResetHQ`** (`test_models.py`):
  - `test_deletes_rows_and_resets_hq` — happy path: task deleted, HQ reset called with correct payload
  - `test_skips_hq_when_no_case_property` — no HQ call when task type has no `case_property`
  - `test_does_not_delete_when_hq_fails` — DB delete rolled back on `CommCareHQAPIException`
  - `test_skips_completed_tasks` — completed tasks excluded from deletion and reset
  - `test_skips_hq_when_other_assigned_task_remains` — reset skipped when another task still uses the property
  - `test_deduplicates_hq_calls` — multiple tasks sharing a property produce one `bulk_update_usercases` call
- **`TestAssignedTaskAssign`** (`test_models.py`): updated to assert `bulk_update_usercases` is called on assignment
- **`TestDeleteTasks`** (`test_views.py`):
  - `test_delete_tasks_resets_hq_case_property` — view triggers HQ reset on delete
  - `test_delete_tasks_hq_failure_shows_error_and_keeps_tasks` — error message shown and tasks preserved on HQ failure
- **`TestExcludeWorkAreas`** (`test_helpers.py`): updated mock patches for the `bulk_update_cases` → `bulk_create_or_update_cases` rename

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Assign a task to a worker where the task type has a `case_property` configured — verify the property is set to `"1"` on the worker's HQ user case
- [ ] Delete that task — verify the property is cleared (`""`) on the HQ user case and a success message appears
- [ ] Assign two tasks with the same `case_property` to the same worker, then delete only one — verify the HQ case property is **not** reset (the remaining task still references it)
- [ ] Delete the remaining task — verify the HQ case property is now cleared
- [ ] Simulate an HQ API failure (e.g. wrong API key) and attempt deletion — verify no tasks are deleted and an error message is shown
- [ ] Delete a task whose task type has no `case_property` — verify no HQ call is made and the task is deleted successfully
- [ ] Attempt to delete a `COMPLETED` task — verify it is excluded and no changes occur

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
