### PR TITLE
feat(data_export): add audit report and entry export endpoints

### DIFF
--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+from commcare_connect.audit.models import AuditReport, AuditReportEntry
 from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup
 from commcare_connect.opportunity.api.serializers.mobile import (
     CommCareAppSerializer,
@@ -386,3 +387,44 @@ class LLOEntityDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = LLOEntity
         fields = ["id", "name", "short_name"]
+
+
+class AuditReportDataSerializer(serializers.ModelSerializer):
+    completed_by_username = serializers.CharField(source="completed_by.username", read_only=True, default=None)
+
+    class Meta:
+        model = AuditReport
+        fields = [
+            "id",
+            "audit_report_id",
+            "opportunity",
+            "period_start",
+            "period_end",
+            "status",
+            "completed_by_username",
+            "completed_date",
+            "date_created",
+            "date_modified",
+        ]
+
+
+class AuditReportEntryDataSerializer(serializers.ModelSerializer):
+    audit_report_uuid = serializers.UUIDField(source="audit_report.audit_report_id", read_only=True)
+    username = serializers.CharField(source="opportunity_access.user.username", read_only=True)
+
+    class Meta:
+        model = AuditReportEntry
+        fields = [
+            "id",
+            "audit_report_entry_id",
+            "audit_report",
+            "audit_report_uuid",
+            "opportunity_access",
+            "username",
+            "results",
+            "flagged",
+            "reviewed",
+            "review_action",
+            "date_created",
+            "date_modified",
+        ]

--- a/commcare_connect/data_export/tests/test_views.py
+++ b/commcare_connect/data_export/tests/test_views.py
@@ -3,8 +3,10 @@ import datetime
 import pytest
 from django.contrib.auth.models import Permission
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.timezone import now
 
+from commcare_connect.audit.tests.factories import AuditReportEntryFactory, AuditReportFactory
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 from commcare_connect.opportunity.tests.factories import AssignedTaskFactory, OpportunityAccessFactory, TaskTypeFactory
 from commcare_connect.users.tests.factories import LLOEntityFactory
@@ -155,5 +157,125 @@ class TestLLOEntityDataView:
         _add_export_credentials(api_client, user)
         _add_v2_header(api_client)
         url = reverse("data_export:llo_entity_data")
+        response = api_client.get(url)
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestAuditReportDataView:
+    def test_returns_audit_reports_for_opportunity(self, v2_export_client, opportunity):
+        report = AuditReportFactory(opportunity=opportunity)
+        url = reverse("data_export:audit_report_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["results"]) == 1
+        result = data["results"][0]
+        assert result["id"] == report.id
+        assert result["audit_report_id"] == str(report.audit_report_id)
+        assert result["opportunity"] == opportunity.id
+        assert result["period_start"] == report.period_start.isoformat()
+        assert result["period_end"] == report.period_end.isoformat()
+        assert result["status"] == report.status
+        assert result["completed_by_username"] is None
+        assert result["completed_date"] is None
+
+    def test_includes_completed_metadata(self, v2_export_client, opportunity, org_user_member):
+        completed_at = timezone.now()
+        report = AuditReportFactory(
+            opportunity=opportunity,
+            status="completed",
+            completed_by=org_user_member,
+            completed_date=completed_at,
+        )
+        url = reverse("data_export:audit_report_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(url)
+        result = response.json()["results"][0]
+        assert result["id"] == report.id
+        assert result["status"] == "completed"
+        assert result["completed_by_username"] == org_user_member.username
+        assert result["completed_date"] is not None
+
+    def test_excludes_reports_from_other_opportunities(self, v2_export_client, opportunity):
+        AuditReportFactory(opportunity=opportunity)
+        AuditReportFactory()  # different opportunity (factory creates one)
+        url = reverse("data_export:audit_report_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(url)
+        assert len(response.json()["results"]) == 1
+
+    def test_returns_404_for_unauthorized_opportunity(self, api_client, opportunity, user):
+        _add_export_credentials(api_client, user)
+        _add_v2_header(api_client)
+        url = reverse("data_export:audit_report_data", kwargs={"opp_id": opportunity.id})
+        response = api_client.get(url)
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestAuditReportEntryDataView:
+    def test_returns_entries_for_opportunity(self, v2_export_client, opportunity):
+        report = AuditReportFactory(opportunity=opportunity)
+        opp_access = OpportunityAccessFactory(opportunity=opportunity)
+        entry = AuditReportEntryFactory(
+            audit_report=report,
+            opportunity_access=opp_access,
+            results={"hello": "world"},
+            flagged=True,
+            reviewed=False,
+        )
+        url = reverse("data_export:audit_report_entry_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(url)
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 1
+        result = results[0]
+        assert result["id"] == entry.id
+        assert result["audit_report_entry_id"] == str(entry.audit_report_entry_id)
+        assert result["audit_report"] == report.id
+        assert result["audit_report_uuid"] == str(report.audit_report_id)
+        assert result["opportunity_access"] == opp_access.id
+        assert result["username"] == opp_access.user.username
+        assert result["results"] == {"hello": "world"}
+        assert result["flagged"] is True
+        assert result["reviewed"] is False
+
+    def test_excludes_entries_from_other_opportunities(self, v2_export_client, opportunity):
+        report = AuditReportFactory(opportunity=opportunity)
+        AuditReportEntryFactory(audit_report=report)
+        AuditReportEntryFactory()
+        url = reverse("data_export:audit_report_entry_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(url)
+        assert len(response.json()["results"]) == 1
+
+    def test_filter_by_audit_report_id_returns_matching_entries(self, v2_export_client, opportunity):
+        report_a = AuditReportFactory(opportunity=opportunity)
+        report_b = AuditReportFactory(opportunity=opportunity)
+        entry_a = AuditReportEntryFactory(audit_report=report_a)
+        AuditReportEntryFactory(audit_report=report_b)
+        url = reverse("data_export:audit_report_entry_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(f"{url}?audit_report_id={report_a.audit_report_id}")
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["id"] == entry_a.id
+
+    def test_filter_by_invalid_uuid_returns_400(self, v2_export_client, opportunity):
+        url = reverse("data_export:audit_report_entry_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(f"{url}?audit_report_id=not-a-uuid")
+        assert response.status_code == 400
+
+    def test_filter_by_report_from_other_opportunity_returns_empty(self, v2_export_client, opportunity):
+        report_in_opp = AuditReportFactory(opportunity=opportunity)
+        AuditReportEntryFactory(audit_report=report_in_opp)
+        other_report = AuditReportFactory()
+        AuditReportEntryFactory(audit_report=other_report)
+        url = reverse("data_export:audit_report_entry_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(f"{url}?audit_report_id={other_report.audit_report_id}")
+        assert response.status_code == 200
+        assert response.json()["results"] == []
+
+    def test_returns_404_for_unauthorized_opportunity(self, api_client, opportunity, user):
+        _add_export_credentials(api_client, user)
+        _add_v2_header(api_client)
+        url = reverse("data_export:audit_report_entry_data", kwargs={"opp_id": opportunity.id})
         response = api_client.get(url)
         assert response.status_code == 404

--- a/commcare_connect/data_export/urls.py
+++ b/commcare_connect/data_export/urls.py
@@ -41,6 +41,12 @@ urlpatterns = [
         name="organization_program_data",
     ),
     path("opportunity/<int:opp_id>/task_types/", views.TaskTypeDataView.as_view(), name="task_type_data"),
+    path("opportunity/<int:opp_id>/audit_reports/", views.AuditReportDataView.as_view(), name="audit_report_data"),
+    path(
+        "opportunity/<int:opp_id>/audit_report_entries/",
+        views.AuditReportEntryDataView.as_view(),
+        name="audit_report_entry_data",
+    ),
     path("opportunity/<int:opp_id>/assigned_tasks/", views.AssignedTaskDataView.as_view(), name="assigned_task_data"),
     path(
         "opportunity/<int:opp_id>/work_area_groups/",

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -1,4 +1,5 @@
 import csv
+import uuid
 from collections import defaultdict
 
 from django.core.files.storage import storages
@@ -6,7 +7,7 @@ from django.db.models import Count, F, Q
 from django.http import FileResponse, JsonResponse, StreamingHttpResponse
 from drf_spectacular.utils import extend_schema, inline_serializer
 from oauth2_provider.contrib.rest_framework.permissions import TokenHasScope
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import ListCreateAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -14,6 +15,7 @@ from rest_framework.response import Response
 from rest_framework.versioning import AcceptHeaderVersioning
 from rest_framework.views import APIView
 
+from commcare_connect.audit.models import AuditReport, AuditReportEntry
 from commcare_connect.data_export.const import (
     APP_TYPE_BOTH,
     APP_TYPE_DELIVER,
@@ -26,6 +28,8 @@ from commcare_connect.data_export.pagination import IdKeysetPagination
 from commcare_connect.data_export.serializer import (
     AssessmentDataSerializer,
     AssignedTaskDataSerializer,
+    AuditReportDataSerializer,
+    AuditReportEntryDataSerializer,
     CompletedModuleDataSerializer,
     CompletedWorkDataSerializer,
     InvoiceDataSerializer,
@@ -518,6 +522,31 @@ class TaskTypeDataView(OpportunityDataExportView, BaseDataExportListViewV2):
 
     def get_queryset(self, *args, **kwargs):
         return TaskType.objects.filter(opportunity=self.opportunity)
+
+
+class AuditReportDataView(OpportunityDataExportView, BaseDataExportListViewV2):
+    serializer_class = AuditReportDataSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        return AuditReport.objects.filter(opportunity=self.opportunity).select_related("completed_by")
+
+
+class AuditReportEntryDataView(OpportunityDataExportView, BaseDataExportListViewV2):
+    serializer_class = AuditReportEntryDataSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        qs = AuditReportEntry.objects.filter(
+            audit_report__opportunity=self.opportunity,
+        ).select_related("audit_report", "opportunity_access__user")
+
+        audit_report_id = self.request.query_params.get("audit_report_id")
+        if audit_report_id:
+            try:
+                parsed_uuid = uuid.UUID(audit_report_id)
+            except ValueError:
+                raise serializers.ValidationError({"audit_report_id": "Must be a valid UUID."})
+            qs = qs.filter(audit_report__audit_report_id=parsed_uuid)
+        return qs
 
 
 class AssignedTaskDataView(OpportunityDataExportView, BaseDataExportListViewV2):


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This adds two new data export APIs for labs covering the two new audit models. They are v2 only, allowing only the new JSON paginated format.

**AI Summary**
Adds two paginated JSON export endpoints to the data_export app:
- GET /api/data_export/opportunity/<opp_id>/audit_reports/
- GET /api/data_export/opportunity/<opp_id>/audit_report_entries/?audit_report_id=<uuid>

Both follow the existing per-opportunity export pattern (OAuth2 export scope, V2 versioning, IdKeysetPagination, _get_opportunity_or_404 permission gate). The entries endpoint accepts an optional audit_report_id UUID filter.


## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
internal use only and new tests for the new behavior

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
new behavior is tested

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
