### PR TITLE
Add Work Area Group ID to HQ Case

### DIFF
--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -30,6 +30,7 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
             "wa_status": obj.status,
             "ward": obj.ward,
             "work_area_group": getattr(obj.work_area_group, "name", ""),
+            "work_area_group_id": str(obj.work_area_group_id) if obj.work_area_group_id else "",
             "max_wag": str(obj.case_properties.get("max_wag", "")),
             "wag_serial_number": str(obj.case_properties.get("wag_serial_number", "")),
             "lga": str(obj.case_properties.get("lga", "")),

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -35,6 +35,7 @@ def test_work_area_case_serializer():
             "wa_status": work_area.status,
             "ward": "ward-x",
             "work_area_group": "group-a",
+            "work_area_group_id": str(group.id),
             "max_wag": "3",
             "wag_serial_number": "WAG123",
             "lga": "LGA1",


### PR DESCRIPTION
## Product Description

When work area cases are created or updated on CommCare HQ, the `work_area_group_id` (the Connect-side database ID of the `WorkAreaGroup`) is now included as a case property alongside the existing `work_area_group` name. No UI changes.

## Technical Summary

[CCCT-2408](https://dimagi.atlassian.net/browse/CCCT-2408)
This is a release path 3 feature — Experiments & early stage iterations of product area

`WorkAreaCaseSerializer.get_properties` now includes `work_area_group_id` in the properties dict sent to HQ. This uses the Django FK field `work_area_group_id` directly (no extra DB query) and serialises it as a string (empty string when unassigned), consistent with the pattern used for all other case properties. Both the single-case path (`create_or_update_case_by_work_area`) and the bulk path (`bulk_create_or_update_cases_by_work_areas`) flow through this serializer, so both are covered by a single change.

- **Serializer change:** `work_area_group_id` added to `WorkAreaCaseSerializer.get_properties` in `commcare_connect/microplanning/serializers.py`
- **Coverage:** All HQ sync paths use `WorkAreaCaseSerializer`; no other call sites required changes

## Safety Assurance

### Safety story

This is an additive change — a new property is appended to the case properties dict. No existing properties are modified or removed, so there is no risk of data loss or regression for cases already on HQ. The new property is only populated when a `WorkAreaGroup` is assigned; unassigned work areas receive an empty string, matching the pattern for all other optional properties.

### Automated test coverage

- `test_work_area_case_serializer` in `commcare_connect/microplanning/tests/test_serializers.py` — asserts that `work_area_group_id` is present and equals the group's DB ID in the serialized output.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Create a work area and assign it to a work area group, then trigger assignment to a FLW and verify the resulting HQ case has both `work_area_group` (name) and `work_area_group_id` (integer ID as string) set correctly
- [ ] Verify a work area with no group assigned produces an empty string for `work_area_group_id` on HQ
- [ ] Verify the bulk assignment path sets `work_area_group_id` on all synced cases

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2408]: https://dimagi.atlassian.net/browse/CCCT-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ