### PR TITLE
[CI-660] catch CommCareHQAPIException in start_learn_app view

### DIFF
--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -31,6 +31,7 @@ from commcare_connect.flags.models import Flag
 from commcare_connect.opportunity.models import HQApiKey, Opportunity, OpportunityAccess, UserInvite, UserInviteStatus
 from commcare_connect.opportunity.tasks import update_user_and_send_invite
 from commcare_connect.users.forms import ManualUserOTPForm
+from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 from commcare_connect.utils.db import get_object_or_list_by_uuid_or_int
 from commcare_connect.utils.error_codes import ErrorCodes
 from commcare_connect.utils.permission_const import (
@@ -115,7 +116,20 @@ def start_learn_app(request):
     )
     app = opportunity.learn_app
     domain = app.cc_domain
-    user_created = create_hq_user_and_link(request.user, domain, opportunity)
+    try:
+        user_created = create_hq_user_and_link(request.user, domain, opportunity)
+    except CommCareHQAPIException as e:
+        # CCHQ rejected the mobile-worker create call. Without this catch, the
+        # exception bubbles as Django 500 with no actionable body, the Android
+        # client correctly logs the failed response and swallows it, and the
+        # opp-detail "Start" button appears to no-op silently from the FLW's
+        # point of view. Surface the underlying HQ error so callers can act
+        # on it. See CI-660. Same pattern as `ManagedOpportunityCreateView.post`
+        # in `commcare_connect/program/api/views.py`.
+        return Response(
+            {"error_code": ErrorCodes.FAILED_USER_CREATE, "hq_error": str(e)},
+            status=502,
+        )
     if not user_created:
         return Response({"error_code": ErrorCodes.FAILED_USER_CREATE}, status=400)
     try:


### PR DESCRIPTION
## Summary

When the CCHQ mobile-worker create call inside `start_learn_app` raises `CommCareHQAPIException`, the exception bubbles uncaught and Django renders a generic 500 page. The CommCare Connect Android client correctly logs the failed response and swallows it, so the opp-detail "Start" button appears to silently no-op from the FLW's point of view — a phantom client bug the calibration team chased for two weeks before tracing the actual server 500 in logcat.

This PR catches the exception and surfaces a structured 502 with the underlying HQ error text so the client can render an actionable error.

## Fixes
- **[CI-660](https://dimagi.atlassian.net/browse/CI-660)** (structural half)

## Reproduction

Against connect.dimagi.com prod, 2026-05-12:
- AVD `ACE_Pixel_API_34`, Connect APK 2.62.0
- Opp `4c2f7ca3-d536-46e3-b389-6dc189bc0d83` on `e62dcb06-...` / ai-demo-space / connect-ace-prod
- ACE test user `+74260000100` (ConnectID) pre-invited
- Tap `org.commcare.dalvik:id/btn_start` → logcat shows `Server Error: Response Code: 500 ... for url /users/start_learn_app/`

Direct curl repro confirms CCHQ returns 400 `{"error": "You don't have permission to use connect_username field"}` for our admin API key. `_create_hq_user` only treats 400 + "already taken" as success and re-raises everything else as `CommCareHQAPIException`.

## Same pattern, prior art

Same shape as `ManagedOpportunityCreateView.post` in `commcare_connect/program/api/views.py:102`. A general DRF exception handler that catches `CommCareHQAPIException` globally would close this entire class of bug (also fixed in CI-659 / jjackson/ace#246 — same root pattern) — out of scope for this PR but worth considering as a follow-up.

## Out of scope for this PR

The upstream CCHQ permission grant on the `connect_username` field (or the Connect-side change to omit it when the caller lacks permission) is the Fix B half in [CI-660](https://dimagi.atlassian.net/browse/CI-660) and remains pending. Once both halves land, the phantom-no-op disappears and the FLW client surfaces a real error or proceeds cleanly.

## Test plan
- [x] Manual repro of the 500 captured + traced
- [ ] Local Django test against `start_learn_app` with a mocked `create_hq_user_and_link` raising `CommCareHQAPIException` — verify 502 + structured body
- [ ] Re-test against the same AVD repro after deploy — should see structured 502 with `hq_error` payload in logcat instead of HTML 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CI-660]: https://dimagi.atlassian.net/browse/CI-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CI-660]: https://dimagi.atlassian.net/browse/CI-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ