### PR TITLE
Auto-discovered logical replication: CI-enforced table set + split bootstrap/refresh lifecycle

### DIFF
--- a/commcare_connect/multidb/constants.py
+++ b/commcare_connect/multidb/constants.py
@@ -43,8 +43,8 @@ SUBSCRIPTION_NAME = "tables_for_superset_sub"
 
 # Models whose tables are replicated to the secondary (Superset) database.
 # Every local app model must appear in exactly ONE of the two lists below;
-# a Django system check (see checks.py) fails otherwise. Adding a sensitive
-# model? Put it in REPLICATION_EXCLUDED_MODELS.
+# tests/test_replication.py::test_no_unclassified_local_models fails in CI
+# otherwise. Adding a sensitive model? Put it in REPLICATION_EXCLUDED_MODELS.
 REPLICATION_INCLUDED_MODELS = [
     Assessment,
     CommCareApp,

--- a/commcare_connect/multidb/constants.py
+++ b/commcare_connect/multidb/constants.py
@@ -1,13 +1,25 @@
+from commcare_connect.audit.models import AuditReport, AuditReportEntry
+from commcare_connect.commcarehq.models import HQServer
+from commcare_connect.flags.models import Flag
+from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup
 from commcare_connect.opportunity.models import (
     Assessment,
+    AssignedTask,
+    BlobMeta,
+    CatchmentArea,
     CommCareApp,
     CompletedModule,
     CompletedWork,
     Country,
+    CredentialConfiguration,
     Currency,
     DeliverUnit,
     DeliverUnitFlagRules,
     DeliveryType,
+    ExchangeRate,
+    FormJsonValidationRules,
+    HQApiKey,
+    LabsRecord,
     LearnModule,
     Opportunity,
     OpportunityAccess,
@@ -17,28 +29,33 @@ from commcare_connect.opportunity.models import (
     Payment,
     PaymentInvoice,
     PaymentUnit,
+    TaskType,
+    UserInvite,
     UserVisit,
 )
-from commcare_connect.organization.models import LLOEntity, Organization
-from commcare_connect.program.models import Program
+from commcare_connect.organization.models import LLOEntity, Organization, UserOrganizationMembership
+from commcare_connect.program.models import ManagedOpportunity, Program, ProgramApplication
 from commcare_connect.reports.models import UserAnalyticsData
 from commcare_connect.users.models import ConnectIDUserLink, User, UserCredential
 
 PUBLICATION_NAME = "tables_for_superset_pub"
 SUBSCRIPTION_NAME = "tables_for_superset_sub"
 
-# To add/remove more models, add/remove the model here and run setup_logical_replication command
-# Additional step to remove, manually drop all rows from the replica after running the command
-REPLICATION_ALLOWED_MODELS = [
+# Models whose tables are replicated to the secondary (Superset) database.
+# Every local app model must appear in exactly ONE of the two lists below;
+# a Django system check (see checks.py) fails otherwise. Adding a sensitive
+# model? Put it in REPLICATION_EXCLUDED_MODELS.
+REPLICATION_INCLUDED_MODELS = [
     Assessment,
+    CommCareApp,
     CompletedModule,
     CompletedWork,
     ConnectIDUserLink,
     Country,
     Currency,
     DeliverUnit,
-    DeliveryType,
     DeliverUnitFlagRules,
+    DeliveryType,
     LearnModule,
     LLOEntity,
     Opportunity,
@@ -47,13 +64,36 @@ REPLICATION_ALLOWED_MODELS = [
     OpportunityClaimLimit,
     OpportunityVerificationFlags,
     Organization,
-    CommCareApp,
     Payment,
+    PaymentInvoice,
     PaymentUnit,
     Program,
     User,
-    UserVisit,
     UserAnalyticsData,
     UserCredential,
-    PaymentInvoice,
+    UserVisit,
+]
+
+# Local app models deliberately NOT replicated (PII, secrets, operational
+# noise, or simply not needed in Superset).
+REPLICATION_EXCLUDED_MODELS = [
+    AuditReport,
+    AuditReportEntry,
+    HQServer,
+    Flag,
+    WorkArea,
+    WorkAreaGroup,
+    AssignedTask,
+    BlobMeta,
+    CatchmentArea,
+    CredentialConfiguration,
+    ExchangeRate,
+    FormJsonValidationRules,
+    HQApiKey,
+    LabsRecord,
+    TaskType,
+    UserInvite,
+    UserOrganizationMembership,
+    ManagedOpportunity,
+    ProgramApplication,
 ]

--- a/commcare_connect/multidb/management/commands/logical_replication_status.py
+++ b/commcare_connect/multidb/management/commands/logical_replication_status.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 
-from commcare_connect.multidb.constants import REPLICATION_ALLOWED_MODELS
+from commcare_connect.multidb.replication import get_replicated_models
 
 from .setup_logical_replication import PUBLICATION_NAME, SUBSCRIPTION_NAME
 
@@ -120,20 +120,20 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("Replication delay check completed."))
 
         self.stdout.write(self.style.SUCCESS("\nFetching table counts from both databases..."))
-        self.stdout.write(f"{'Table':<30}{'Primary DB Count':<20}{'Secondary DB Count'}")
+        self.stdout.write(f"{'Table':<30}{'Primary DB Count':<20}{'Secondary DB Count'}")  # noqa: E231
         self.stdout.write("-" * 70)
 
-        for model in REPLICATION_ALLOWED_MODELS:
+        for model in get_replicated_models():
             table_name = model._meta.db_table
             with default_conn.cursor() as cursor:
-                cursor.execute(f"SELECT COUNT(*) FROM {table_name};")
+                cursor.execute(f"SELECT COUNT(*) FROM {table_name};")  # noqa: E702,E231
                 primary_count = cursor.fetchone()[0]
 
             with secondary_conn.cursor() as cursor:
-                cursor.execute(f"SELECT COUNT(*) FROM {table_name};")
+                cursor.execute(f"SELECT COUNT(*) FROM {table_name};")  # noqa: E702,E231
                 secondary_count = cursor.fetchone()[0]
 
-            self.stdout.write(f"{table_name:<30}{primary_count:<20}{secondary_count}")
+            self.stdout.write(f"{table_name:<30}{primary_count:<20}{secondary_count}")  # noqa: E231
 
         self.stdout.write(self.style.SUCCESS("Table counts fetched successfully."))
         # Close the manually created connection

--- a/commcare_connect/multidb/management/commands/logical_replication_status.py
+++ b/commcare_connect/multidb/management/commands/logical_replication_status.py
@@ -1,6 +1,3 @@
-import getpass
-
-import psycopg2
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
@@ -8,6 +5,22 @@ from django.db import DEFAULT_DB_ALIAS, connections
 from commcare_connect.multidb.replication import get_replicated_models
 
 from .setup_logical_replication import PUBLICATION_NAME, SUBSCRIPTION_NAME
+
+
+def table_count_rows(primary_conn, secondary_conn):
+    """Return [(table_name, primary_count, secondary_count), ...] for all
+    replicated models."""
+    rows = []
+    for model in get_replicated_models():
+        table_name = model._meta.db_table
+        with primary_conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name};")  # noqa: E702,E231
+            primary_count = cursor.fetchone()[0]
+        with secondary_conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name};")  # noqa: E702,E231
+            secondary_count = cursor.fetchone()[0]
+        rows.append((table_name, primary_count, secondary_count))
+    return rows
 
 
 class Command(BaseCommand):
@@ -29,25 +42,7 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("Checking logical replication status...\n"))
 
         default_conn = connections[DEFAULT_DB_ALIAS]
-
-        secondary_db_settings = connections[secondary_db_alias].settings_dict
-        self.stdout.write(
-            self.style.SUCCESS("Enter the superuser credentials for the secondary (subscriber) database:")
-        )
-        secondary_user = input("Enter username: ")
-        secondary_password = getpass.getpass("Enter password: ")
-
-        try:
-            secondary_conn = psycopg2.connect(
-                host=secondary_db_settings["HOST"],
-                port=secondary_db_settings["PORT"],
-                dbname=secondary_db_settings["NAME"],
-                user=secondary_user,
-                password=secondary_password,
-            )
-            secondary_conn.autocommit = True
-        except Exception as e:
-            raise CommandError(f"Could not connect to the secondary database: {e}")
+        secondary_conn = connections[secondary_db_alias]
 
         # Check publication details
         self.stdout.write(self.style.SUCCESS("Publication Status (Primary Database):"))
@@ -123,18 +118,7 @@ class Command(BaseCommand):
         self.stdout.write(f"{'Table':<30}{'Primary DB Count':<20}{'Secondary DB Count'}")  # noqa: E231
         self.stdout.write("-" * 70)
 
-        for model in get_replicated_models():
-            table_name = model._meta.db_table
-            with default_conn.cursor() as cursor:
-                cursor.execute(f"SELECT COUNT(*) FROM {table_name};")  # noqa: E702,E231
-                primary_count = cursor.fetchone()[0]
-
-            with secondary_conn.cursor() as cursor:
-                cursor.execute(f"SELECT COUNT(*) FROM {table_name};")  # noqa: E702,E231
-                secondary_count = cursor.fetchone()[0]
-
+        for table_name, primary_count, secondary_count in table_count_rows(default_conn, secondary_conn):
             self.stdout.write(f"{table_name:<30}{primary_count:<20}{secondary_count}")  # noqa: E231
 
         self.stdout.write(self.style.SUCCESS("Table counts fetched successfully."))
-        # Close the manually created connection
-        secondary_conn.close()

--- a/commcare_connect/multidb/management/commands/refresh_replication.py
+++ b/commcare_connect/multidb/management/commands/refresh_replication.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import DEFAULT_DB_ALIAS, connections
+
+from commcare_connect.multidb import replication
+
+
+class Command(BaseCommand):
+    help = (
+        "Reconcile the logical-replication publication/subscription with the "
+        "models in REPLICATION_INCLUDED_MODELS. Non-interactive; safe to run on "
+        "every deploy after migrate_multi. Requires a one-time bootstrap "
+        "(setup_logical_replication) to have run for this environment."
+    )
+
+    def handle(self, *args, **options):
+        if not replication.replication_is_active():
+            self.stdout.write("Replication not enabled for this environment; skipping.")
+            return
+
+        primary = connections[DEFAULT_DB_ALIAS]
+
+        if not replication.publication_exists(primary):
+            self.stdout.write(
+                self.style.WARNING(
+                    "Publication does not exist — run the one-time bootstrap "
+                    "(setup_logical_replication) first. Skipping refresh."
+                )
+            )
+            return
+
+        if replication.is_publication_in_sync(primary):
+            self.stdout.write("Publication already in sync; nothing to do.")
+            return
+
+        desired = replication.get_replicated_tables()
+        self.stdout.write("Publication out of sync; reconciling...")
+        replication.refresh_publication(
+            primary,
+            desired_tables=desired,
+            repl_user=settings.REPLICATION_PRIMARY_REPL_USER,
+        )
+        self.stdout.write(self.style.SUCCESS("Primary publication updated."))
+
+        secondary = connections[settings.SECONDARY_DB_ALIAS]
+        replication.refresh_subscription(
+            secondary,
+            superset_user=settings.REPLICATION_SUPERSET_USER,
+        )
+        self.stdout.write(self.style.SUCCESS("Secondary subscription refreshed."))

--- a/commcare_connect/multidb/management/commands/setup_logical_replication.py
+++ b/commcare_connect/multidb/management/commands/setup_logical_replication.py
@@ -11,6 +11,19 @@ PUBLICATION_NAME = "tables_for_superset_pub"
 SUBSCRIPTION_NAME = "tables_for_superset_sub"
 
 
+def _quote_ident(name):
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def transfer_subscription_ownership(cursor, secondary_role):
+    """Hand subscription ownership to the app's secondary role so the
+    recurring refresh can REFRESH PUBLICATION without a superuser (PG16+)."""
+    cursor.execute(
+        f"ALTER SUBSCRIPTION {SUBSCRIPTION_NAME} OWNER TO {_quote_ident(secondary_role)}"
+    )  # noqa: E231,E702
+
+
 class Command(BaseCommand):
     help = "Create a publication for the default database and a subscription for the secondary database alias."
 
@@ -130,6 +143,12 @@ class Command(BaseCommand):
                 psycopg2.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA public TO {};").format(
                     psycopg2.sql.Identifier(superset_user)
                 )
+            )
+            self.stdout.write("Transferring subscription ownership to the app secondary role...")
+            secondary_role = secondary_db_settings["USER"]
+            transfer_subscription_ownership(cursor, secondary_role)
+            self.stdout.write(
+                self.style.SUCCESS(f"Subscription '{SUBSCRIPTION_NAME}' now owned by '{secondary_role}'.")
             )
 
         # Close the manually created connection

--- a/commcare_connect/multidb/management/commands/setup_logical_replication.py
+++ b/commcare_connect/multidb/management/commands/setup_logical_replication.py
@@ -5,23 +5,16 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 
-from commcare_connect.multidb.replication import get_replicated_models
+from commcare_connect.multidb.replication import get_replicated_models, quote_identifier
 
 PUBLICATION_NAME = "tables_for_superset_pub"
 SUBSCRIPTION_NAME = "tables_for_superset_sub"
 
 
-def _quote_ident(name):
-    escaped = name.replace('"', '""')
-    return f'"{escaped}"'
-
-
 def transfer_subscription_ownership(cursor, secondary_role):
     """Hand subscription ownership to the app's secondary role so the
     recurring refresh can REFRESH PUBLICATION without a superuser (PG16+)."""
-    cursor.execute(
-        f"ALTER SUBSCRIPTION {SUBSCRIPTION_NAME} OWNER TO {_quote_ident(secondary_role)}"
-    )  # noqa: E231,E702
+    cursor.execute(f"ALTER SUBSCRIPTION {SUBSCRIPTION_NAME} OWNER TO {quote_identifier(secondary_role)}")
 
 
 class Command(BaseCommand):

--- a/commcare_connect/multidb/management/commands/setup_logical_replication.py
+++ b/commcare_connect/multidb/management/commands/setup_logical_replication.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 
-from commcare_connect.multidb.constants import REPLICATION_ALLOWED_MODELS
+from commcare_connect.multidb.replication import get_replicated_models
 
 PUBLICATION_NAME = "tables_for_superset_pub"
 SUBSCRIPTION_NAME = "tables_for_superset_sub"
@@ -16,7 +16,7 @@ class Command(BaseCommand):
 
     def get_table_list(self):
         table_list = []
-        for model in REPLICATION_ALLOWED_MODELS:
+        for model in get_replicated_models():
             try:
                 table_list.append(model._meta.db_table)
             except Exception as e:
@@ -68,11 +68,11 @@ class Command(BaseCommand):
             tables = ", ".join([f'"{table}"' for table in table_list])
             if publication_exists:
                 self.stdout.write(f"Publication '{PUBLICATION_NAME}' already exists, refreshing it.")
-                cursor.execute(f"ALTER PUBLICATION {PUBLICATION_NAME} SET TABLE {tables};")
+                cursor.execute(f"ALTER PUBLICATION {PUBLICATION_NAME} SET TABLE {tables};")  # noqa: E702,E231
                 self.stdout.write(self.style.SUCCESS(f"Publication '{PUBLICATION_NAME}' altered successfully."))
             else:
                 self.stdout.write(f"Creating new publication '{PUBLICATION_NAME}'.")
-                cursor.execute(f"CREATE PUBLICATION {PUBLICATION_NAME} FOR TABLE {tables};")
+                cursor.execute(f"CREATE PUBLICATION {PUBLICATION_NAME} FOR TABLE {tables};")  # noqa: E702,E231
                 self.stdout.write(self.style.SUCCESS(f"Publication '{PUBLICATION_NAME}' created successfully."))
 
         self.stdout.write("Setting up subscription in the secondary database...")
@@ -100,7 +100,7 @@ class Command(BaseCommand):
                 self.stdout.write(
                     self.style.WARNING(f"Subscription '{SUBSCRIPTION_NAME}' already exists. Refreshing it.")
                 )
-                cursor.execute(f"ALTER SUBSCRIPTION {SUBSCRIPTION_NAME} REFRESH PUBLICATION;")
+                cursor.execute(f"ALTER SUBSCRIPTION {SUBSCRIPTION_NAME} REFRESH PUBLICATION;")  # noqa: E702,E231
                 self.stdout.write(self.style.SUCCESS(f"Subscription '{SUBSCRIPTION_NAME}' refreshed successfully."))
             else:
                 # Create new subscription
@@ -120,7 +120,7 @@ class Command(BaseCommand):
                     CREATE SUBSCRIPTION {SUBSCRIPTION_NAME}
                     CONNECTION '{primary_conn_info}'
                     PUBLICATION {PUBLICATION_NAME};
-                    """
+                    """  # noqa: E702,E231
                 )
                 self.stdout.write(self.style.SUCCESS(f"Subscription '{SUBSCRIPTION_NAME}' created successfully."))
             self.stdout.write("Granting select permissions to superset postgres user...")

--- a/commcare_connect/multidb/replication.py
+++ b/commcare_connect/multidb/replication.py
@@ -1,0 +1,11 @@
+from commcare_connect.multidb.constants import REPLICATION_INCLUDED_MODELS
+
+
+def get_replicated_models():
+    """Models whose tables should be present in the publication."""
+    return REPLICATION_INCLUDED_MODELS
+
+
+def get_replicated_tables() -> set[str]:
+    """The set of db_table names that should be replicated."""
+    return {model._meta.db_table for model in get_replicated_models()}

--- a/commcare_connect/multidb/replication.py
+++ b/commcare_connect/multidb/replication.py
@@ -2,7 +2,11 @@ import pghistory.models
 from django.apps import apps
 from django.conf import settings
 
-from commcare_connect.multidb.constants import REPLICATION_EXCLUDED_MODELS, REPLICATION_INCLUDED_MODELS
+from commcare_connect.multidb.constants import (
+    PUBLICATION_NAME,
+    REPLICATION_EXCLUDED_MODELS,
+    REPLICATION_INCLUDED_MODELS,
+)
 
 
 def get_replicated_models():
@@ -38,3 +42,30 @@ def get_models_requiring_classification() -> set:
 def get_unclassified_models() -> set:
     classified = set(REPLICATION_INCLUDED_MODELS) | set(REPLICATION_EXCLUDED_MODELS)
     return get_models_requiring_classification() - classified
+
+
+def replication_is_active() -> bool:
+    """Whether the deploy-time refresh should run in this environment."""
+    return bool(settings.REPLICATION_ENABLED and settings.SECONDARY_DB_ALIAS)
+
+
+def publication_exists(connection) -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT pubname FROM pg_publication WHERE pubname = %s",
+            [PUBLICATION_NAME],
+        )
+        return cursor.fetchone() is not None
+
+
+def _current_publication_tables(connection) -> set[str]:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT tablename FROM pg_publication_tables WHERE pubname = %s",
+            [PUBLICATION_NAME],
+        )
+        return {row[0] for row in cursor.fetchall()}
+
+
+def is_publication_in_sync(connection) -> bool:
+    return get_replicated_tables() == _current_publication_tables(connection)

--- a/commcare_connect/multidb/replication.py
+++ b/commcare_connect/multidb/replication.py
@@ -92,7 +92,13 @@ def refresh_publication(connection, *, desired_tables: set[str], repl_user: str)
 
 def refresh_subscription(connection, *, superset_user: str):
     """On the secondary: re-read the publication (COPY new tables, drop
-    removed) and let the Superset reader see the newly arrived tables."""
+    removed) and let the Superset reader see the newly arrived tables.
+
+    Must run in autocommit (no surrounding transaction): Postgres rejects
+    ALTER SUBSCRIPTION ... REFRESH PUBLICATION inside a transaction block.
+    Safe today because management commands run without an implicit atomic
+    block and the secondary alias has no ATOMIC_REQUESTS — keep it that way.
+    """
     with connection.cursor() as cursor:
         cursor.execute(f"ALTER SUBSCRIPTION {quote_identifier(SUBSCRIPTION_NAME)} REFRESH PUBLICATION")
         _grant_select_all(cursor, superset_user)

--- a/commcare_connect/multidb/replication.py
+++ b/commcare_connect/multidb/replication.py
@@ -6,6 +6,7 @@ from commcare_connect.multidb.constants import (
     PUBLICATION_NAME,
     REPLICATION_EXCLUDED_MODELS,
     REPLICATION_INCLUDED_MODELS,
+    SUBSCRIPTION_NAME,
 )
 
 
@@ -69,3 +70,29 @@ def _current_publication_tables(connection) -> set[str]:
 
 def is_publication_in_sync(connection) -> bool:
     return get_replicated_tables() == _current_publication_tables(connection)
+
+
+def _quote_ident(name: str) -> str:
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _grant_select_all(cursor, role: str):
+    cursor.execute(f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {_quote_ident(role)}")  # noqa: E231,E702
+
+
+def refresh_publication(connection, *, desired_tables: set[str], repl_user: str):
+    """On the primary: make the publication's table set match `desired_tables`
+    and let the replication role read the (possibly new) tables."""
+    tables = ", ".join(_quote_ident(t) for t in sorted(desired_tables))
+    with connection.cursor() as cursor:
+        cursor.execute(f"ALTER PUBLICATION {_quote_ident(PUBLICATION_NAME)} SET TABLE {tables}")  # noqa: E231,E702
+        _grant_select_all(cursor, repl_user)
+
+
+def refresh_subscription(connection, *, superset_user: str):
+    """On the secondary: re-read the publication (COPY new tables, drop
+    removed) and let the Superset reader see the newly arrived tables."""
+    with connection.cursor() as cursor:
+        cursor.execute(f"ALTER SUBSCRIPTION {_quote_ident(SUBSCRIPTION_NAME)} REFRESH PUBLICATION")  # noqa: E231,E702
+        _grant_select_all(cursor, superset_user)

--- a/commcare_connect/multidb/replication.py
+++ b/commcare_connect/multidb/replication.py
@@ -78,7 +78,7 @@ def quote_identifier(name: str) -> str:
 
 
 def _grant_select_all(cursor, role: str):
-    cursor.execute(f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {quote_identifier(role)}")  # noqa: E231,E702
+    cursor.execute(f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {quote_identifier(role)}")
 
 
 def refresh_publication(connection, *, desired_tables: set[str], repl_user: str):
@@ -86,7 +86,7 @@ def refresh_publication(connection, *, desired_tables: set[str], repl_user: str)
     and let the replication role read the (possibly new) tables."""
     tables = ", ".join(quote_identifier(t) for t in sorted(desired_tables))
     with connection.cursor() as cursor:
-        cursor.execute(f"ALTER PUBLICATION {quote_identifier(PUBLICATION_NAME)} SET TABLE {tables}")  # noqa: E231,E702
+        cursor.execute(f"ALTER PUBLICATION {quote_identifier(PUBLICATION_NAME)} SET TABLE {tables}")
         _grant_select_all(cursor, repl_user)
 
 
@@ -94,7 +94,5 @@ def refresh_subscription(connection, *, superset_user: str):
     """On the secondary: re-read the publication (COPY new tables, drop
     removed) and let the Superset reader see the newly arrived tables."""
     with connection.cursor() as cursor:
-        cursor.execute(
-            f"ALTER SUBSCRIPTION {quote_identifier(SUBSCRIPTION_NAME)} REFRESH PUBLICATION"
-        )  # noqa: E231,E501,E702
+        cursor.execute(f"ALTER SUBSCRIPTION {quote_identifier(SUBSCRIPTION_NAME)} REFRESH PUBLICATION")
         _grant_select_all(cursor, superset_user)

--- a/commcare_connect/multidb/replication.py
+++ b/commcare_connect/multidb/replication.py
@@ -1,4 +1,8 @@
-from commcare_connect.multidb.constants import REPLICATION_INCLUDED_MODELS
+import pghistory.models
+from django.apps import apps
+from django.conf import settings
+
+from commcare_connect.multidb.constants import REPLICATION_EXCLUDED_MODELS, REPLICATION_INCLUDED_MODELS
 
 
 def get_replicated_models():
@@ -9,3 +13,28 @@ def get_replicated_models():
 def get_replicated_tables() -> set[str]:
     """The set of db_table names that should be replicated."""
     return {model._meta.db_table for model in get_replicated_models()}
+
+
+def _local_app_labels() -> set[str]:
+    return {app_config.label for app_config in apps.get_app_configs() if app_config.name in settings.LOCAL_APPS}
+
+
+def get_models_requiring_classification() -> set:
+    """Local, concrete, non-history models that must appear in one list.
+
+    Excludes pghistory Event models and auto-created m2m through tables —
+    these are never replicated and never need classifying.
+    """
+    local_labels = _local_app_labels()
+    return {
+        model
+        for model in apps.get_models()
+        if model._meta.app_label in local_labels
+        and not model._meta.auto_created
+        and not issubclass(model, pghistory.models.Event)
+    }
+
+
+def get_unclassified_models() -> set:
+    classified = set(REPLICATION_INCLUDED_MODELS) | set(REPLICATION_EXCLUDED_MODELS)
+    return get_models_requiring_classification() - classified

--- a/commcare_connect/multidb/replication.py
+++ b/commcare_connect/multidb/replication.py
@@ -72,21 +72,21 @@ def is_publication_in_sync(connection) -> bool:
     return get_replicated_tables() == _current_publication_tables(connection)
 
 
-def _quote_ident(name: str) -> str:
+def quote_identifier(name: str) -> str:
     escaped = name.replace('"', '""')
     return f'"{escaped}"'
 
 
 def _grant_select_all(cursor, role: str):
-    cursor.execute(f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {_quote_ident(role)}")  # noqa: E231,E702
+    cursor.execute(f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {quote_identifier(role)}")  # noqa: E231,E702
 
 
 def refresh_publication(connection, *, desired_tables: set[str], repl_user: str):
     """On the primary: make the publication's table set match `desired_tables`
     and let the replication role read the (possibly new) tables."""
-    tables = ", ".join(_quote_ident(t) for t in sorted(desired_tables))
+    tables = ", ".join(quote_identifier(t) for t in sorted(desired_tables))
     with connection.cursor() as cursor:
-        cursor.execute(f"ALTER PUBLICATION {_quote_ident(PUBLICATION_NAME)} SET TABLE {tables}")  # noqa: E231,E702
+        cursor.execute(f"ALTER PUBLICATION {quote_identifier(PUBLICATION_NAME)} SET TABLE {tables}")  # noqa: E231,E702
         _grant_select_all(cursor, repl_user)
 
 
@@ -94,5 +94,7 @@ def refresh_subscription(connection, *, superset_user: str):
     """On the secondary: re-read the publication (COPY new tables, drop
     removed) and let the Superset reader see the newly arrived tables."""
     with connection.cursor() as cursor:
-        cursor.execute(f"ALTER SUBSCRIPTION {_quote_ident(SUBSCRIPTION_NAME)} REFRESH PUBLICATION")  # noqa: E231,E702
+        cursor.execute(
+            f"ALTER SUBSCRIPTION {quote_identifier(SUBSCRIPTION_NAME)} REFRESH PUBLICATION"
+        )  # noqa: E231,E501,E702
         _grant_select_all(cursor, superset_user)

--- a/commcare_connect/multidb/tests/test_bootstrap.py
+++ b/commcare_connect/multidb/tests/test_bootstrap.py
@@ -1,0 +1,11 @@
+from commcare_connect.multidb.management.commands import setup_logical_replication
+from commcare_connect.multidb.tests.test_gating import FakeCursor
+
+
+def test_transfer_subscription_ownership_issues_alter_owner():
+    cursor = FakeCursor()
+    setup_logical_replication.transfer_subscription_ownership(cursor, "app_secondary_role")
+    sql = " ".join(s for s, _ in cursor.executed)
+    assert "ALTER SUBSCRIPTION" in sql
+    assert "OWNER TO" in sql
+    assert '"app_secondary_role"' in sql

--- a/commcare_connect/multidb/tests/test_gating.py
+++ b/commcare_connect/multidb/tests/test_gating.py
@@ -1,0 +1,70 @@
+from contextlib import contextmanager
+
+from django.test import override_settings
+
+from commcare_connect.multidb import replication
+
+
+class FakeCursor:
+    """Captures executed SQL and returns canned fetch results."""
+
+    def __init__(self, fetchall_result=None):
+        self.executed = []
+        self._fetchall_result = fetchall_result or []
+
+    def execute(self, sql, params=None):
+        self.executed.append((str(sql), params))
+
+    def fetchall(self):
+        return self._fetchall_result
+
+    def fetchone(self):
+        return self._fetchall_result[0] if self._fetchall_result else None
+
+
+class FakeConnection:
+    def __init__(self, fetchall_result=None):
+        self.cursor_obj = FakeCursor(fetchall_result)
+
+    @contextmanager
+    def cursor(self):
+        yield self.cursor_obj
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS="secondary")
+def test_replication_is_active_when_enabled_and_secondary_configured():
+    assert replication.replication_is_active() is True
+
+
+@override_settings(REPLICATION_ENABLED=False, SECONDARY_DB_ALIAS="secondary")
+def test_replication_inactive_when_disabled():
+    assert replication.replication_is_active() is False
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS=None)
+def test_replication_inactive_without_secondary():
+    assert replication.replication_is_active() is False
+
+
+def test_publication_exists_true_when_row_returned():
+    conn = FakeConnection(fetchall_result=[("tables_for_superset_pub",)])
+    assert replication.publication_exists(conn) is True
+
+
+def test_publication_exists_false_when_no_row():
+    conn = FakeConnection(fetchall_result=[])
+    assert replication.publication_exists(conn) is False
+
+
+def test_is_publication_in_sync_true_when_tables_match(monkeypatch):
+    desired = {"opportunity_opportunity", "users_user"}
+    monkeypatch.setattr(replication, "get_replicated_tables", lambda: desired)
+    rows = [(t,) for t in desired]
+    conn = FakeConnection(fetchall_result=rows)
+    assert replication.is_publication_in_sync(conn) is True
+
+
+def test_is_publication_in_sync_false_when_table_missing(monkeypatch):
+    monkeypatch.setattr(replication, "get_replicated_tables", lambda: {"a", "b"})
+    conn = FakeConnection(fetchall_result=[("a",)])  # missing "b"
+    assert replication.is_publication_in_sync(conn) is False

--- a/commcare_connect/multidb/tests/test_refresh.py
+++ b/commcare_connect/multidb/tests/test_refresh.py
@@ -1,0 +1,59 @@
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import override_settings
+
+from commcare_connect.multidb import replication
+from commcare_connect.multidb.tests.test_gating import FakeConnection
+
+
+def _executed_sql(conn):
+    return " | ".join(sql for sql, _ in conn.cursor_obj.executed)
+
+
+def test_refresh_publication_sets_tables_and_grants():
+    conn = FakeConnection()
+    replication.refresh_publication(
+        conn, desired_tables={"users_user", "opportunity_opportunity"}, repl_user="postgres_repl"
+    )
+    sql = _executed_sql(conn)
+    assert "ALTER PUBLICATION" in sql
+    assert "SET TABLE" in sql
+    assert '"opportunity_opportunity"' in sql
+    assert '"users_user"' in sql
+    assert "GRANT SELECT ON ALL TABLES IN SCHEMA public" in sql
+    assert '"postgres_repl"' in sql
+
+
+def test_refresh_subscription_refreshes_and_grants():
+    conn = FakeConnection()
+    replication.refresh_subscription(conn, superset_user="superset_readonly")
+    sql = _executed_sql(conn)
+    assert "ALTER SUBSCRIPTION" in sql
+    assert "REFRESH PUBLICATION" in sql
+    assert "GRANT SELECT ON ALL TABLES IN SCHEMA public" in sql
+    assert '"superset_readonly"' in sql
+
+
+@override_settings(REPLICATION_ENABLED=False, SECONDARY_DB_ALIAS=None)
+def test_command_noops_when_replication_inactive():
+    out = StringIO()
+    call_command("refresh_replication", stdout=out)
+    assert "skipping" in out.getvalue().lower()
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS="secondary")
+def test_command_noops_when_bootstrap_not_run(monkeypatch):
+    monkeypatch.setattr(replication, "publication_exists", lambda conn: False)
+    out = StringIO()
+    call_command("refresh_replication", stdout=out)
+    assert "bootstrap" in out.getvalue().lower()
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS="secondary")
+def test_command_noops_when_already_in_sync(monkeypatch):
+    monkeypatch.setattr(replication, "publication_exists", lambda conn: True)
+    monkeypatch.setattr(replication, "is_publication_in_sync", lambda conn: True)
+    out = StringIO()
+    call_command("refresh_replication", stdout=out)
+    assert "in sync" in out.getvalue().lower()

--- a/commcare_connect/multidb/tests/test_replication.py
+++ b/commcare_connect/multidb/tests/test_replication.py
@@ -1,0 +1,17 @@
+from commcare_connect.multidb import replication
+from commcare_connect.multidb.constants import REPLICATION_EXCLUDED_MODELS, REPLICATION_INCLUDED_MODELS
+
+
+def test_get_replicated_models_returns_included_list():
+    assert replication.get_replicated_models() == REPLICATION_INCLUDED_MODELS
+
+
+def test_get_replicated_tables_returns_db_table_names():
+    tables = replication.get_replicated_tables()
+    assert "opportunity_opportunity" in tables
+    assert tables == {m._meta.db_table for m in REPLICATION_INCLUDED_MODELS}
+
+
+def test_included_and_excluded_are_disjoint():
+    overlap = set(REPLICATION_INCLUDED_MODELS) & set(REPLICATION_EXCLUDED_MODELS)
+    assert overlap == set(), f"models in both lists: {overlap}"

--- a/commcare_connect/multidb/tests/test_replication.py
+++ b/commcare_connect/multidb/tests/test_replication.py
@@ -15,3 +15,19 @@ def test_get_replicated_tables_returns_db_table_names():
 def test_included_and_excluded_are_disjoint():
     overlap = set(REPLICATION_INCLUDED_MODELS) & set(REPLICATION_EXCLUDED_MODELS)
     assert overlap == set(), f"models in both lists: {overlap}"
+
+
+def test_no_unclassified_local_models():
+    # Every local model is in exactly one list; this set must be empty.
+    assert replication.get_unclassified_models() == set()
+
+
+def test_unclassified_excludes_pghistory_events_and_m2m():
+    # The "must classify" set never includes pghistory Event models or
+    # auto-created through tables.
+    import pghistory.models
+
+    must_classify = replication.get_models_requiring_classification()
+    for model in must_classify:
+        assert not model._meta.auto_created
+        assert not issubclass(model, pghistory.models.Event)

--- a/commcare_connect/multidb/tests/test_replication.py
+++ b/commcare_connect/multidb/tests/test_replication.py
@@ -31,3 +31,36 @@ def test_unclassified_excludes_pghistory_events_and_m2m():
     for model in must_classify:
         assert not model._meta.auto_created
         assert not issubclass(model, pghistory.models.Event)
+
+
+def test_table_count_rows_uses_replicated_models():
+    from commcare_connect.multidb.management.commands import logical_replication_status
+
+    class C:
+        def __init__(self, n):
+            self.n = n
+            self.executed = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, sql, params=None):
+            self.executed.append(sql)
+
+        def fetchone(self):
+            return (self.n,)
+
+    class Conn:
+        def __init__(self, n):
+            self.n = n
+
+        def cursor(self):
+            return C(self.n)
+
+    rows = logical_replication_status.table_count_rows(Conn(5), Conn(3))
+    tables = {r[0] for r in rows}
+    assert "opportunity_opportunity" in tables
+    assert all(r[1] == 5 and r[2] == 3 for r in rows)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -54,6 +54,14 @@ if env("SECONDARY_DATABASE_URL", default=None):
     DATABASES[SECONDARY_DB_ALIAS]["ENGINE"] = "django.contrib.gis.db.backends.postgis"
     DATABASE_ROUTERS = ["commcare_connect.multidb.db_router.ConnectDatabaseRouter"]
 
+# Logical replication to the secondary (Superset) database.
+# Gates whether `refresh_replication` does anything on deploy. Keep False
+# until the secondary is bootstrapped AND running Postgres 16+.
+REPLICATION_ENABLED = env.bool("REPLICATION_ENABLED", default=False)
+# Roles the refresh grants SELECT to (must already exist; created at bootstrap).
+REPLICATION_PRIMARY_REPL_USER = env("REPLICATION_PRIMARY_REPL_USER", default="postgres_repl")
+REPLICATION_SUPERSET_USER = env("REPLICATION_SUPERSET_USER", default="superset_readonly")
+
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/docker/start_migrate
+++ b/docker/start_migrate
@@ -7,5 +7,7 @@ set -o nounset
 
 echo "Django migrate"
 python manage.py migrate_multi --noinput
+echo "Refresh logical replication"
+python manage.py refresh_replication
 echo "Run Gunicorn"
 gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 450 -w 10

--- a/docs/replication-redesign-recommendation.md
+++ b/docs/replication-redesign-recommendation.md
@@ -1,0 +1,189 @@
+# Auto-discovered logical replication — recommended design (detailed)
+
+This document expands on the recommendation reached in
+[`replication-redesign.md`](./replication-redesign.md).
+
+## Recommended options (recap)
+
+- **D1.B — maintain 2 lists defining replicated and non-replicated tables.** `REPLICATION_INCLUDED_MODELS` and
+  `REPLICATION_EXCLUDED_MODELS` in `commcare_connect/multidb/constants.py`;
+  a Django system check or pytest fails if any model is in neither list.
+- **D2 — deploy-pipeline refresh.** A non-interactive `refresh_replication`
+  command runs in the deploy pipeline, sequenced *after* `migrate_multi`
+  returns (the only race-safe trigger — see D2 in the main doc).
+- **D3.B — split lifecycle.** A one-time, privileged, operator-run
+  **bootstrap** establishes the publication, subscription, roles, and
+  *object ownership*; a recurring, non-interactive **refresh** reconciles
+  the table set using only the ordinary app roles — no superuser in the
+  recurring path.
+
+> ⚠️ **Prerequisite:** A no-superuser refresh requires the secondary
+> to run **Postgres 16+**. Production currently runs Postgres 15. See
+> [Postgres version prerequisite](#postgres-version-prerequisite) below.
+
+## The roles involved
+
+The following table outlines *which role owns what and where*.
+
+| Role | Where | Configured as | Purpose |
+|------|-------|---------------|---------|
+| **App primary role** | primary | `DATABASES["default"]["USER"]` (`RDS_USERNAME`) | The role Django/`migrate_multi` uses on the primary. Creates and therefore **owns** the app tables on the primary. After bootstrap, **owns the publication**. |
+| **App secondary role** | secondary | `DATABASES["secondary"]["USER"]` (from `SECONDARY_DATABASE_URL`) | The role `migrate_multi` uses on the secondary. Creates and **owns** the app tables on the secondary. After bootstrap (PG16+), **owns the subscription**. |
+| **`postgres_repl`** | primary | replication login role | The role the secondary's Postgres server connects *as* to pull changes. Needs `REPLICATION` attribute and `SELECT` on every published table. Its credentials are embedded in the subscription's `CONNECTION` string at bootstrap. |
+| **`superset_readonly`** | secondary | read-only login role | The role Superset queries the secondary with. Needs `SELECT` on every replicated table. |
+| **Secondary superuser** | secondary | operator-supplied at bootstrap | Used **only** at bootstrap to `CREATE SUBSCRIPTION` and transfer subscription ownership. Never persisted; never used by the refresh. |
+
+
+## Split-lifecycle overview
+
+| | **Bootstrap** | **Refresh** |
+|---|---|---|
+| Frequency | Once per environment | Every deploy |
+| Invocation | Interactive, operator-run | Non-interactive, deploy pipeline |
+| Privilege | Secondary superuser (primary half runs as the app role) | Ordinary app roles only |
+| Creates objects? | Yes (`CREATE PUBLICATION`/`SUBSCRIPTION`, grants, subscription ownership transfer) | No — only `ALTER`s membership and grants `SELECT` on new tables |
+| Credentials needed | Secondary superuser + `postgres_repl` creds for the subscription connection string | None beyond what Django already has |
+| Command | Extend the existing `setup_logical_replication` | `refresh_replication` (new, extracted from it) |
+
+---
+
+## Phase 1 — Bootstrap (one-time, interactive, operator-run)
+
+Runs once when an environment first turns on replication. It is allowed to
+be privileged and interactive because it happens rarely and is performed by
+an operator. Its job is to leave the system in a state where the **refresh
+can run unprivileged forever after**.
+
+### Reuse the existing command
+
+Bootstrap is essentially **the existing
+[`setup_logical_replication`](../commcare_connect/multidb/management/commands/setup_logical_replication.py)
+command, extended with one new statement**: the transfer of subscription
+ownership to the app secondary role. The existing command already
+
+1. Creates the publication (using the same role as `migrate_multi`)
+2. Creates the subscription (using superuser role)
+3. Creates the subscription connection
+
+
+The [`setup_logical_replication`](../commcare_connect/multidb/management/commands/setup_logical_replication.py) command will need to be updated to transfer ownership of the subscription object to the app secondary role (i.e. the role used for running `migrate_multi` on secondary DB).
+
+```sql
+ALTER SUBSCRIPTION tables_for_superset_sub OWNER TO <app_secondary_role>;
+```
+
+**Ownership outcome after bootstrap**
+
+| Object | Owner | How |
+|--------|-------|-----|
+| `tables_for_superset_pub` (primary) | app primary role | already owned — `CREATE PUBLICATION` ran as the app role |
+| `tables_for_superset_sub` (secondary) | app secondary role *(PG16+)* | **new** `ALTER SUBSCRIPTION ... OWNER TO` |
+| app tables (primary) | app primary role | created by `migrate_multi` |
+| app tables (secondary) | app secondary role | created by `migrate_multi` |
+
+---
+
+## Phase 2 — Refresh (recurring, non-interactive, deploy pipeline)
+
+Runs on **every deploy**, after `migrate_multi` returns. It reconciles the
+live publication/subscription with the desired table set computed from
+`REPLICATION_INCLUDED_MODELS`. It uses **only the connections Django
+already has**.
+
+**Preconditions**
+
+- `migrate_multi` has returned, so the new tables exist on **both** DBs.
+- Bootstrap has been run once for this environment.
+
+**Step 0 — in-sync short-circuit**
+
+```python
+if not settings.SECONDARY_DATABASE_URL:
+  # no-op if no secondary database
+  return
+
+desired = {m._meta.db_table for m in get_replicated_models()}
+# SELECT tablename FROM pg_publication_tables WHERE pubname = 'tables_for_superset_pub'
+if desired == actual_publication_tables:
+    return  # nothing changed this deploy
+```
+
+Most deploys don't touch models, so this exits immediately.
+
+Note: the `setup_logical_replication` command is already able to decide whether a setup or a refresh should happen, so we could simply reuse this mechanism as well.
+
+
+**Step 1 — publisher (primary, as the app primary role)**
+
+```sql
+-- Reconcile membership. SET TABLE is a full replace: adds new, drops removed.
+ALTER PUBLICATION tables_for_superset_pub SET TABLE "t1", "t2", "t_new", ... ;
+
+-- Let postgres_repl read the newly added tables (needed for the initial COPY).
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO postgres_repl;
+```
+
+**Step 2 — subscriber (secondary, as the app secondary role)**
+
+```sql
+-- Re-read the publication's table list: COPY+stream new tables, drop removed.
+ALTER SUBSCRIPTION tables_for_superset_sub REFRESH PUBLICATION;
+
+-- Let Superset read the newly arrived tables.
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO superset_readonly;
+```
+
+## Example flow for adding a new model
+
+1. Developer adds a new model in code.
+2. The Django system check / test fails locally and in CI unless the model
+   is listed in `REPLICATION_INCLUDED_MODELS` or `REPLICATION_EXCLUDED_MODELS`.
+3. On deploy, after `migrate_multi` returns, `refresh_replication` runs:
+   - no-op if `REPLICATION_ENABLED` is `False`;
+   - no-op if the publication is already in sync;
+   - otherwise: `ALTER PUBLICATION ... SET TABLE` + grant on the primary,
+     then `ALTER SUBSCRIPTION ... REFRESH PUBLICATION` + grant on the
+     secondary — all as the ordinary app roles.
+
+
+
+## Postgres version prerequisite
+
+The solution above, i.e. "no superuser in the recurring path", depends on the
+subscription being **owned by the non-superuser app secondary role**. That
+ownership is only legal on **Postgres 16+**:
+
+- **PG ≤15:** a subscription's owner *must* be a superuser, so
+  `ALTER SUBSCRIPTION ... OWNER TO <app_role>` cannot transfer ownership to
+  an ordinary role. The PG15
+  [`ALTER SUBSCRIPTION`](https://www.postgresql.org/docs/15/sql-altersubscription.html)
+  reference states it directly in its Description:
+
+  > You must own the subscription to use `ALTER SUBSCRIPTION`. To alter the
+  > owner, you must also be a direct or indirect member of the new owning
+  > role. **The new owner has to be a superuser.** (Currently, all
+  > subscription owners must be superusers, so the owner checks will be
+  > bypassed in practice. But this might change in the future.)
+
+- **PG 16+:** the "this might change in the future" above is exactly what
+  PG16 delivered — it introduced the
+  [`pg_create_subscription`](https://www.postgresql.org/docs/16/predefined-roles.html)
+  predefined role and non-superuser subscription ownership, so an ordinary
+  app role can own the subscription and drive `REFRESH`.
+
+
+**Current state:** the production secondary runs **Postgres 15** and is therefore
+**not implementable as-is today**.
+
+**Plan to unblock:** upgrade the secondary to Postgres 16+ via a
+**blue/green** approach — stand up the PG16 instance in parallel, validate
+replication against it, cut over once confirmed, and decommission the PG15
+instance. D3.B can only be rolled out *after* that cutover; until then the
+subscriber refresh still requires a superuser (D3.A behaviour).
+
+## Breakdown of implementation
+
+1. **Add parallel secondary postgres instance (16+)** - Stand up a new instance of Postgres (16+) in parallel as a new replication DB. Once replication is working correctly we can remove the older replication DB.
+2. **Update existing command** - Update the `setup_logical_replication` command:
+    - Transfer the secondary database ownership to the `SECONDARY_DATABASE_URL` role so steady-state refreshes can be made using this role.
+    - The `setup_logical_replication` already checks if there's replication set up and if so refreshes, otherwise create the replication. We should make sure the refresh path uses the secondary DB role to perform the refresh action.

--- a/docs/replication-redesign-recommendation.md
+++ b/docs/replication-redesign-recommendation.md
@@ -3,6 +3,17 @@
 This document expands on the recommendation reached in
 [`replication-redesign.md`](./replication-redesign.md).
 
+> **Implementation status (2026-06):** Code landed — twin lists
+> (`REPLICATION_INCLUDED_MODELS` / `REPLICATION_EXCLUDED_MODELS`) with a
+> test-enforced classification guard over local app models, the
+> non-interactive `refresh_replication` command, the bootstrap subscription
+> ownership transfer, and the deploy wiring (`docker/start_migrate` runs
+> `refresh_replication` after `migrate_multi`). Classification enforcement is
+> a pytest (fails in CI), not a Django system check. **Not yet rolled out to
+> production:** gated behind `REPLICATION_ENABLED=False` pending the
+> secondary's Postgres 15 → 16 blue/green upgrade (see
+> [Postgres version prerequisite](#postgres-version-prerequisite)).
+
 ## Recommended options (recap)
 
 - **D1.B — maintain 2 lists defining replicated and non-replicated tables.** `REPLICATION_INCLUDED_MODELS` and

--- a/docs/replication-redesign.md
+++ b/docs/replication-redesign.md
@@ -329,6 +329,41 @@ anywhere in the recurring path.
   and runs bootstrap; documenting "you must run bootstrap once" is
   a process risk. 
 
+#### ⚠️ Hard prerequisite — Postgres ≥ 16 on the secondary
+
+D3.B's "no superuser in the recurring path" property depends entirely on
+the secondary's subscription being **owned by an ordinary (non-superuser)
+role** — the app's secondary role that `migrate_multi` already connects
+as. However, that ownership is only legal on **Postgres 16+**; earlier
+versions do not allow non-superusers to own subscriptions. The PG15
+[`ALTER SUBSCRIPTION`](https://www.postgresql.org/docs/15/sql-altersubscription.html)
+reference says so directly in its Description:
+
+> The new owner has to be a superuser. (Currently, all subscription owners
+> must be superusers, so the owner checks will be bypassed in practice. But
+> this might change in the future.)
+
+So `ALTER SUBSCRIPTION ... OWNER TO <app_role>` cannot hand the subscription
+to an ordinary role on PG15, and `REFRESH PUBLICATION` (which requires
+ownership) stays superuser-only. PG16 is the "might change in the future"
+above: it added the
+[`pg_create_subscription`](https://www.postgresql.org/docs/16/predefined-roles.html)
+predefined role and non-superuser subscription ownership.
+
+The primary/publication leg (`ALTER PUBLICATION ... SET TABLE` via
+ownership transfer) works on any version; only the subscriber leg is
+gated by this.
+
+**Current state:** our **production secondary DB runs Postgres 15**, so
+D3.B is *not* implementable as-is today.
+
+**Plan to unblock:** upgrade the secondary to Postgres 16+ via a
+**blue/green** approach — stand up the PG16 instance in parallel,
+replicate/validate against it, cut over once it's confirmed working, and
+decommission the old PG15 instance. D3.B can only be rolled out *after*
+that cutover completes; until then the recurring subscriber refresh still
+requires a superuser (D3.A behaviour).
+
 ---
 
 ## Recommendation
@@ -350,7 +385,10 @@ The following options are recommended:
   recurring path**. The high-privilege secondary superuser credential is
   typed by an operator once at bootstrap and never persisted. The cost is
   two code paths to maintain and a documented "run bootstrap once per
-  environment" step.
+  environment" step. **Prerequisite:** the secondary must run Postgres
+  16+; our production secondary is currently Postgres 15, so this requires
+  a blue/green upgrade of the secondary first (see the D3.B prerequisite
+  note above).
 
 ### Out of scope
 

--- a/docs/replication-redesign.md
+++ b/docs/replication-redesign.md
@@ -234,6 +234,14 @@ def is_publication_in_sync() -> bool:
     return desired == actual
 ```
 
+#### Gating: an env flag for whether replication runs on deploy
+
+Since not all environments have replication set up we should gate when
+this happens. We can thus add a `REPLICATION_ENABLED = env.bool("REPLICATION_ENABLED",
+default=False)` in `base.py` — set to `True` only on the environment(s)
+that should replicate (via the per-environment `docker.env`). The refresh
+command checks it first and skips as a no-op when it's `False`.
+
 ---
 
 ### D3. How are credentials handled in a non-interactive context?
@@ -348,6 +356,7 @@ The following options are recommended:
 1. Developer adds a new model in the code.
 2. A Django system check (run by `manage.py check` locally and in CI) fails unless the new model is specified in either `REPLICATION_INCLUDED_MODELS` or `REPLICATION_EXCLUDED_MODELS`.
 3. On deploy, after `migrate_multi` has executed, a new command will be run which
+   - skips as a no-op if `REPLICATION_ENABLED` is `False`
    - checks to see if the publication is in sync with the codebase
    - if so: exit (noop)
    - if not: invoke `setup_logical_replication` command (which obtains credentials from django settings)

--- a/docs/replication-redesign.md
+++ b/docs/replication-redesign.md
@@ -237,10 +237,8 @@ def is_publication_in_sync() -> bool:
 #### Gating: an env flag for whether replication runs on deploy
 
 Since not all environments have replication set up we should gate when
-this happens. We can thus add a `REPLICATION_ENABLED = env.bool("REPLICATION_ENABLED",
-default=False)` in `base.py` — set to `True` only on the environment(s)
-that should replicate (via the per-environment `docker.env`). The refresh
-command checks it first and skips as a no-op when it's `False`.
+this happens. We can check the `SECONDARY_DATABASE_URL` value to decide if
+replication should happen. The refresh skips as a no-op when it's not populated.
 
 ---
 
@@ -340,7 +338,19 @@ The following options are recommended:
 - D2: deploy-pipeline command, sequenced after `migrate_multi` returns
   (the only safe trigger — see D2 background on the ordering constraint
   imposed by logical replication)
-- D3.A: Since we already have the command written, swapping the inputs for reading the necessary credentials should be minimum effort while accepting the trade-off that the secondary superuser password (and primary replication user password) stay in env on every deploy host, rather than doing the ownership-transfer work D3.B would require.
+- D3.B: split the lifecycle into a one-time **bootstrap** (interactive,
+  operator-run: `CREATE PUBLICATION` / `CREATE SUBSCRIPTION`, the GRANTs,
+  and the ownership transfers) and a fully non-interactive **refresh**
+  that the deploy pipeline runs after `migrate_multi`. Bootstrap transfers
+  ownership of `tables_for_superset_pub` to the app's primary role and
+  `tables_for_superset_sub` to the app's secondary role, so the recurring
+  refresh runs `ALTER PUBLICATION ... SET TABLE` and `ALTER SUBSCRIPTION
+  ... REFRESH PUBLICATION` using only the connections `migrate_multi`
+  already has — **no superuser and no new secrets anywhere in the
+  recurring path**. The high-privilege secondary superuser credential is
+  typed by an operator once at bootstrap and never persisted. The cost is
+  two code paths to maintain and a documented "run bootstrap once per
+  environment" step.
 
 ### Out of scope
 
@@ -349,16 +359,25 @@ The following options are recommended:
   silently flow to the secondary; this redesign does not address that.
 - **`logical_replication_status.py`.** This command also imports
   `REPLICATION_ALLOWED_MODELS` and prompts for secondary superuser
-  credentials. It will need the same rename and the same env-var
-  treatment as `setup_logical_replication` for consistency.
+  credentials. It will need the same auto-discovery rename; under D3.B its
+  read-only status checks can run on the app's existing connections
+  without the superuser prompt.
 
 ### Example flow for adding a new model
 1. Developer adds a new model in the code.
 2. A Django system check (run by `manage.py check` locally and in CI) fails unless the new model is specified in either `REPLICATION_INCLUDED_MODELS` or `REPLICATION_EXCLUDED_MODELS`.
-3. On deploy, after `migrate_multi` has executed, a new command will be run which
+3. On deploy, after `migrate_multi` has executed, the non-interactive
+   `refresh_replication` command runs, which
    - skips as a no-op if `REPLICATION_ENABLED` is `False`
-   - checks to see if the publication is in sync with the codebase
+   - checks whether the publication is in sync with the codebase
    - if so: exit (noop)
-   - if not: invoke `setup_logical_replication` command (which obtains credentials from django settings)
+   - if not: runs `ALTER PUBLICATION ... SET TABLE` on the primary and
+     `ALTER SUBSCRIPTION ... REFRESH PUBLICATION` on the secondary, using
+     the connections Django already has configured (no superuser, no new
+     credentials — ownership was transferred at bootstrap)
+
+The one-time `bootstrap` command (interactive, operator-run) is a
+prerequisite, run once per environment before the first deploy that
+enables replication.
 
 

--- a/docs/replication-redesign.md
+++ b/docs/replication-redesign.md
@@ -1,0 +1,355 @@
+# Auto-discovered logical replication — design options
+
+## Goal
+
+Replace the hand-maintained `REPLICATION_ALLOWED_MODELS` list with an
+auto-discovery mechanism so new tables are picked up without code changes,
+while preserving a clear, low-friction way to *exclude* tables that contain
+sensitive data. Setup should run automatically (likely tied to migrations)
+rather than via a developer-invoked interactive command.
+
+## Current state (one-page recap)
+
+- `commcare_connect/multidb/constants.py` holds an explicit allowlist of
+  ~25 Django model classes and the publication/subscription names.
+- `./manage.py setup_logical_replication` is interactive: it prompts for
+  primary-side replication credentials and secondary-side superuser
+  credentials, then issues `CREATE PUBLICATION` / `ALTER PUBLICATION SET
+  TABLE` on the primary and `CREATE SUBSCRIPTION` / `ALTER SUBSCRIPTION
+  REFRESH PUBLICATION` on the secondary.
+- A developer runs it after every model addition or removal.
+- `./manage.py migrate_multi` runs Django migrations on every configured
+  database in parallel (gevent), so the secondary keeps its schema.
+- Routing: `ConnectDatabaseRouter` forces all ORM reads/writes to the
+  default DB; the secondary is populated solely via Postgres logical
+  replication and consumed by Superset.
+
+## Decision dimensions
+
+The following 3 decision dimensions will be discussed:
+1. Where we define which models should be included/excluded from replication
+2. When we trigger the update to the replication object in postgres to add/remove tables
+3. Where we read the necessary credentials from   
+
+### D1. Where does the "exclude this table" marker live?
+
+This dimension is for deciding where we will specify which tables to replicate to superset.
+
+**Option A — Central denylist constant** (symmetric flip of today's list)
+
+```python
+# commcare_connect/multidb/constants.py
+REPLICATION_EXCLUDED_MODELS = [
+    SomePIIModel,       # PII
+    SomeSecretsModel,   # secrets
+]
+```
+
+Discovery: `[m for m in apps.get_models() if m not in EXCLUDED]`.
+
+- **Pros:** symmetrical with today's pattern; one place to audit all
+  excluded tables; trivially diff-able in PR review; no Django magic.
+- **Cons:** marker lives away from the model — adding a new sensitive
+  model means remembering to edit a file in another app; central file
+  becomes a magnet for merge conflicts; nothing physically prevents
+  forgetting.
+
+**Option B — Twin lists (included + excluded), CI-enforced membership**
+
+Maintain two central constants and require every model to appear in
+exactly one of them. A CI check (or `AppConfig.ready()` system check)
+fails if any model in `apps.get_models()` is missing from both lists.
+
+```python
+# commcare_connect/multidb/constants.py
+REPLICATION_INCLUDED_MODELS = [
+    Opportunity, OpportunityAccess, UserVisit, ...
+]
+REPLICATION_EXCLUDED_MODELS = [
+    SomePIIModel,       # PII
+    SomeSecretsModel,   # secrets
+]
+
+# Enforced via a Django system check (runs on `manage.py check`, in CI,
+# and on `runserver`):
+unclassified = set(apps.get_models()) - set(INCLUDED) - set(EXCLUDED)
+if unclassified:
+    raise SystemCheckError(unclassified)
+```
+
+- **Pros:** every model is *explicitly* classified — no implicit default,
+  so adding a new model without a deliberate decision fails a Django
+  system check (and therefore CI);
+  symmetric audit trail (both "what is replicated" and "what is
+  deliberately not" are visible in one place); reviewable as a single
+  diff on every PR that adds a model; uses plain class references (no
+  Django Meta magic, no per-model startup cost beyond one check);
+  naturally integrates with the existing
+  `commcare_connect/multidb/constants.py` layout.
+- **Cons:** maintains *two* lists instead of one — every model add/remove
+  touches the central file (merge-conflict magnet, scales linearly with
+  table count); marker still lives away from the model definition
+  (same con as Option A); developers must remember to update on rename
+  or move; only protects at the table level — adding a sensitive
+  *column* to an already-included model is invisible (same blind spot
+  as the other table-level options).
+
+**Option C — Base class / mixin**
+
+```python
+class SensitiveModel(BaseModel):  # marker base
+    class Meta:
+        abstract = True
+
+class SomePIIModel(SensitiveModel):
+    ...
+```
+
+Discovery: `issubclass(m, SensitiveModel)`.
+
+- **Pros:** strongly typed; very visible — the base class is right at
+  the top of the model definition; impossible to "forget the flag" if
+  the dev chooses the right base.
+- **Cons:** requires touching every sensitive model's method resolution order; awkward when
+  a model already has a deliberate base (e.g. `BaseModel`,
+  `AbstractUser`); creates a parallel base-class hierarchy that other
+  engineers may copy by accident; less ergonomic for one-off exceptions.
+
+**Option D — Decorator on the model class**
+
+```python
+@not_replicated
+class SomePIIModel(BaseModel):
+    ...
+```
+
+Discovery: decorator pushes the model into a module-level set.
+
+- **Pros:** lives with the model; explicit; cheap to implement.
+- **Cons:** non-idiomatic for Django (we don't decorate models
+  elsewhere); the set lives in module-import-order — fine in practice but
+  surprising; no enforcement that every model is classified (a developer
+  who forgets the decorator silently gets the default).
+
+**Option E — Per-app declaration in `AppConfig`**
+
+```python
+class UsersConfig(AppConfig):
+    excluded_from_replication = ["SomePIIModel", "SomeSecretsModel"]
+```
+
+- **Pros:** keeps the marker in the app that owns the model.
+- **Cons:** uses strings, not class refs (typo-prone); marker isn't
+  next to the model definition; least familiar of the options.
+
+---
+
+### D2. What triggers the publication refresh?
+
+This dimension is for deciding when the publication SQL actually runs.
+
+#### Background: ordering constraint imposed by logical replication
+
+Postgres logical replication only replicates row events — never DDL. For
+a newly-added model to start streaming to the secondary, four steps must
+happen in this order:
+
+1. `CREATE TABLE` on the **primary** (the model's Django migration).
+2. `CREATE TABLE` on the **secondary** (the same migration applied to
+   the secondary DB).
+3. `ALTER PUBLICATION tables_for_superset_pub SET TABLE ...` on the
+   **primary** — adds the new table to the publication.
+4. `ALTER SUBSCRIPTION tables_for_superset_sub REFRESH PUBLICATION` on
+   the **secondary** — triggers the initial `COPY` of the new table
+   from primary → secondary, then puts it into streaming mode.
+
+If step 4 runs before step 2, the initial `COPY` lands in a missing
+target table and errors. If step 4 runs before step 3, the table simply
+isn't in the publication yet and `REFRESH` is a no-op for that table.
+
+`migrate_multi` runs primary and secondary migrations **in parallel**
+(via `gevent.spawn` + `joinall`), so there is no ordering guarantee that
+either DB finishes first — only that both are done when `joinall`
+returns. Any trigger that fires *inside* the migration plan, or as soon
+as one DB's `migrate` finishes, races against the other DB. This rules
+out two otherwise-plausible designs:
+
+- A `post_migrate` signal that issues the publication/subscription SQL
+  fires per-database as each `migrate` finishes — so it can run on the
+  secondary before the primary's `ALTER PUBLICATION` (silent miss), or
+  cross-connect to the secondary before its `CREATE TABLE` has landed
+  (initial `COPY` errors). Making it safe means coordinating across two
+  `post_migrate` firings, effectively reinventing a join.
+- A `RunPython` data migration in the `multidb` app runs *inside* the
+  primary's migration plan while the secondary is still migrating in
+  parallel — same race, plus the additional problems that `RunPython`
+  can't cleanly reach across to a second database mid-plan and
+  `CREATE PUBLICATION` / `ALTER SUBSCRIPTION` aren't transactional in
+  the way Django data migrations expect.
+
+The only safe place to issue this SQL is **after `migrate_multi`'s
+`joinall` has returned**, i.e. after both DBs are known to be at the
+new schema.
+
+#### Trigger: separate management command, invoked by CI/CD
+
+Keep refresh as `./manage.py refresh_replication`, but make it
+non-interactive and call it explicitly in the deploy pipeline (Kamal),
+sequenced after `migrate_multi` returns:
+
+```
+1. migrate_multi          # both DBs reach the new schema after this returns
+2. refresh_replication    # ALTER PUBLICATION (primary), ALTER SUBSCRIPTION REFRESH (secondary)
+```
+
+By the time the command runs, `migrate_multi` has joined both parallel
+`migrate`s, so the schema is guaranteed to exist on both sides and the
+command can sequence the `ALTER PUBLICATION` → `ALTER SUBSCRIPTION
+REFRESH` steps internally. The deploy pipeline is also the *one* place
+that needs replication credentials.
+
+The main cost is that it runs on every deploy, mitigated by the
+short-circuit below.
+
+#### Short-circuit: skip the refresh when the publication is already in sync
+
+The refresh logic can cheaply check whether the publication's current
+table set already matches the desired set, and exit early when it does.
+Postgres exposes the live publication membership via
+`pg_publication_tables`:
+
+```python
+from django.apps import apps
+from django.db import connection
+from commcare_connect.multidb.constants import PUBLICATION_NAME
+
+def is_publication_in_sync() -> bool:
+    desired = {m._meta.db_table for m in get_replicated_models()}
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT tablename FROM pg_publication_tables WHERE pubname = %s",
+            [PUBLICATION_NAME],
+        )
+        actual = {row[0] for row in cursor.fetchall()}
+    return desired == actual
+```
+
+---
+
+### D3. How are credentials handled in a non-interactive context?
+
+This dimension is for deciding how replication and subscription credentials reach a non-interactive
+run.
+
+Today the `setup_logical_replication` command prompts for: 
+- primary DB replication user `username` (defaults to `postgres_repl`)
+- secondary DB superuser credential
+- primary DB user credentials with replication priviledge 
+- secondary DB superset username (defaults to `superset_readonly`).
+
+Most of these are needed only for initial subscription
+setup; a steady-state refresh has a smaller surface area.
+
+**Option A — All-in-one, creds from env / settings**
+
+Update the existing `setup_logical_replication` command to read the necessary
+credentials from the env file:
+- `REPL_PRIMARY_REPL_USER`
+- `REPL_PRIMARY_REPL_USER_PASSWORD` (embedded into the `CREATE
+  SUBSCRIPTION ... CONNECTION '...'` string)
+- `REPL_SECONDARY_SUPERUSER`
+- `REPL_SECONDARY_SUPERUSER_PASSWORD`
+- `REPL_SECONDARY_SUPERSET_USER`
+
+Let's evaluate some tradeoffs:
+- **Pros:** one command does everything (and already exists).
+- **Cons:** adds the secondary superuser password (and the primary
+  replication user's password) to the env file on every host that runs
+  deploys — strictly more secret exposure than Option B, which keeps
+  the superuser credential confined to one-time bootstrap.
+
+**Option B — Split lifecycle** (bootstrap vs. refresh)
+
+Today's single interactive command does two very different jobs:
+
+1. **Bootstrap (once per environment)** — `CREATE PUBLICATION` on the
+   primary, `CREATE SUBSCRIPTION` on the secondary, plus the GRANT
+   statements for the replication user (`postgres_repl`) and the
+   Superset reader (`superset_readonly`). This is the part that needs
+   cross-database superuser credentials, including one-time use of a
+   secondary superuser.
+2. **Refresh (every deploy / every model change)** — recompute the
+   desired table set and run `ALTER PUBLICATION ... SET TABLE` on the
+   primary, then `ALTER SUBSCRIPTION ... REFRESH PUBLICATION` on the
+   secondary. Postgres has no per-statement `GRANT` for these
+   commands; the right to run them comes from *owning* the object.
+   Bootstrap therefore transfers ownership of each object to the
+   role that will need to alter it during refresh:
+   - on the primary: `tables_for_superset_pub` is owned by the app's
+     existing primary DB role.
+   - on the secondary: `tables_for_superset_sub` is owned by the
+     app's existing secondary DB role (the same role `migrate_multi`
+     already uses). Subscription ownership is the minimum
+     authorisation required to call `ALTER SUBSCRIPTION ...
+     REFRESH PUBLICATION` and does not require superuser.
+
+This option keeps those two jobs on different lifecycles. The
+bootstrap stays a one-time operator action with the existing
+interactive prompts (or a separate, rarely-run command). The refresh
+becomes a fully automatic, non-interactive command the deploy
+pipeline runs, sequenced after `migrate_multi` returns. It reuses
+the same primary and secondary connections Django already has
+configured for `migrate_multi` — no new credentials and no superuser
+anywhere in the recurring path.
+
+
+- **Pros:** no superuser password lives outside the one-time
+  bootstrap — the secondary superuser is typed by an operator at
+  bootstrap and forgotten; the recurring path uses only the
+  connections `migrate_multi` already has, with two ownership
+  transfers established at bootstrap (the app's primary role owns
+  `tables_for_superset_pub`; the app's secondary role owns
+  `tables_for_superset_sub`); no new secrets in app config or the
+  deploy pipeline; deploys can't accidentally re-issue
+  `CREATE SUBSCRIPTION` or mutate GRANTs.
+- **Cons:** two code paths to maintain (bootstrap command + refresh
+  command); the app's secondary role gains subscription ownership
+  on top of its existing schema-migration privileges, so a
+  compromise of that role can also mutate the subscription (still
+  bounded — no superuser, no authority to grant privileges to other
+  roles); if an environment is rebuilt from scratch and the
+  operator forgets the bootstrap step, deploys will appear to
+  succeed but nothing will actually replicate until someone notices
+  and runs bootstrap; documenting "you must run bootstrap once" is
+  a process risk. 
+
+---
+
+## Recommendation
+The following options are recommended:
+
+- D1.B: Maintaining two lists makes it trivial to enforce explicit thinking about which models should be replicated and which ones not.
+- D2: deploy-pipeline command, sequenced after `migrate_multi` returns
+  (the only safe trigger — see D2 background on the ordering constraint
+  imposed by logical replication)
+- D3.A: Since we already have the command written, swapping the inputs for reading the necessary credentials should be minimum effort while accepting the trade-off that the secondary superuser password (and primary replication user password) stay in env on every deploy host, rather than doing the ownership-transfer work D3.B would require.
+
+### Out of scope
+
+- **Column-level sensitivity.** Every D1 option classifies at the table
+  level. Adding a sensitive *column* to an already-included model will
+  silently flow to the secondary; this redesign does not address that.
+- **`logical_replication_status.py`.** This command also imports
+  `REPLICATION_ALLOWED_MODELS` and prompts for secondary superuser
+  credentials. It will need the same rename and the same env-var
+  treatment as `setup_logical_replication` for consistency.
+
+### Example flow for adding a new model
+1. Developer adds a new model in the code.
+2. A Django system check (run by `manage.py check` locally and in CI) fails unless the new model is specified in either `REPLICATION_INCLUDED_MODELS` or `REPLICATION_EXCLUDED_MODELS`.
+3. On deploy, after `migrate_multi` has executed, a new command will be run which
+   - checks to see if the publication is in sync with the codebase
+   - if so: exit (noop)
+   - if not: invoke `setup_logical_replication` command (which obtains credentials from django settings)
+
+

--- a/docs/superpowers/plans/2026-06-12-auto-discovered-logical-replication.md
+++ b/docs/superpowers/plans/2026-06-12-auto-discovered-logical-replication.md
@@ -1,0 +1,1128 @@
+# Auto-discovered Logical Replication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-maintained `REPLICATION_ALLOWED_MODELS` list with CI-enforced twin lists, and split the interactive `setup_logical_replication` command into a one-time **bootstrap** plus a non-interactive **refresh** that runs on every deploy using only the connections Django already has.
+
+**Architecture:** Implements the three decisions in `docs/replication-redesign-recommendation.md`: **D1.B** (twin `REPLICATION_INCLUDED_MODELS` / `REPLICATION_EXCLUDED_MODELS` lists, enforced by a Django system check), **D2** (a `refresh_replication` management command wired into the deploy pipeline *after* `migrate_multi` returns — the only race-safe trigger), and **D3.B** (bootstrap transfers subscription ownership to the app's secondary role so the recurring refresh needs no superuser). Pure logic lives in a new testable `commcare_connect/multidb/replication.py`; the management commands stay thin orchestrators.
+
+**Tech Stack:** Django 4.2, PostgreSQL/PostGIS logical replication, psycopg2, pytest + pytest-django.
+
+**Scope note — local models only:** The system check enforces classification over **local app models** (`settings.LOCAL_APPS`) only, auto-excluding pghistory `Event` models and auto-created m2m through tables. Third-party tables (sessions, auth, oauth2 tokens, celery-beat, waffle, pghistory event tables) are never replicated — the safe default — without being enumerated.
+
+**Out of scope (do NOT do in this plan):**
+- The blue/green Postgres 15 → 16 upgrade of the production secondary. D3.B's "no superuser in the refresh path" is only *legal* on PG16+ (a non-superuser may own a subscription). This plan writes code that is correct on PG16+; rolling `REPLICATION_ENABLED=True` to production must wait for that upgrade. Until then the recurring refresh on the production secondary still needs a superuser-owned subscription (it will no-op safely while `REPLICATION_ENABLED=False`).
+- Column-level sensitivity (a sensitive *column* added to an included model still flows through).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `commcare_connect/multidb/constants.py` | Holds the two model lists + publication/subscription names | Modify (rename list, add second list) |
+| `commcare_connect/multidb/replication.py` | Pure, testable replication logic: model discovery, the classification check, in-sync detection, gating, and the publication/subscription refresh primitives | **Create** |
+| `commcare_connect/multidb/checks.py` | Django system check wrapping the pure classification function | **Create** |
+| `commcare_connect/multidb/apps.py` | Registers the system check in `AppConfig.ready()` | Modify |
+| `commcare_connect/multidb/management/commands/refresh_replication.py` | Non-interactive deploy-pipeline refresh command | **Create** |
+| `commcare_connect/multidb/management/commands/setup_logical_replication.py` | Bootstrap: now also transfers subscription ownership; uses new discovery | Modify |
+| `commcare_connect/multidb/management/commands/logical_replication_status.py` | Status command; switch to new discovery name | Modify |
+| `config/settings/base.py` | `REPLICATION_ENABLED`, `REPLICATION_PRIMARY_REPL_USER`, `REPLICATION_SUPERSET_USER` settings | Modify |
+| `docker/start_migrate` | Deploy wiring: run `refresh_replication` after `migrate_multi` | Modify |
+| `commcare_connect/multidb/tests/` | Tests for all of the above | **Create** |
+
+**Object-ownership target after bootstrap (PG16+):**
+
+| Object | Owner | Established by |
+|--------|-------|---------------|
+| `tables_for_superset_pub` (primary) | app primary role | already — `CREATE PUBLICATION` runs as the app role |
+| `tables_for_superset_sub` (secondary) | app secondary role | **new** `ALTER SUBSCRIPTION ... OWNER TO` in bootstrap |
+
+---
+
+## Task 1: Twin lists + discovery functions
+
+Rename `REPLICATION_ALLOWED_MODELS` → `REPLICATION_INCLUDED_MODELS`, add `REPLICATION_EXCLUDED_MODELS`, and create `replication.py` with the discovery functions. Both existing commands import the old name, so they are updated here to keep imports valid.
+
+**Files:**
+- Modify: `commcare_connect/multidb/constants.py`
+- Create: `commcare_connect/multidb/replication.py`
+- Modify: `commcare_connect/multidb/management/commands/setup_logical_replication.py:8,19`
+- Modify: `commcare_connect/multidb/management/commands/logical_replication_status.py:8,126`
+- Create: `commcare_connect/multidb/tests/__init__.py`
+- Create: `commcare_connect/multidb/tests/test_replication.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `commcare_connect/multidb/tests/__init__.py` (empty file), then create `commcare_connect/multidb/tests/test_replication.py`:
+
+```python
+from commcare_connect.multidb import replication
+from commcare_connect.multidb.constants import (
+    REPLICATION_EXCLUDED_MODELS,
+    REPLICATION_INCLUDED_MODELS,
+)
+
+
+def test_get_replicated_models_returns_included_list():
+    assert replication.get_replicated_models() == REPLICATION_INCLUDED_MODELS
+
+
+def test_get_replicated_tables_returns_db_table_names():
+    tables = replication.get_replicated_tables()
+    assert "opportunity_opportunity" in tables
+    assert tables == {m._meta.db_table for m in REPLICATION_INCLUDED_MODELS}
+
+
+def test_included_and_excluded_are_disjoint():
+    overlap = set(REPLICATION_INCLUDED_MODELS) & set(REPLICATION_EXCLUDED_MODELS)
+    assert overlap == set(), f"models in both lists: {overlap}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest commcare_connect/multidb/tests/test_replication.py -v`
+Expected: FAIL — `ImportError` (`REPLICATION_INCLUDED_MODELS` / `replication` do not exist yet).
+
+- [ ] **Step 3: Update `constants.py`**
+
+Replace the entire contents of `commcare_connect/multidb/constants.py` with:
+
+```python
+from commcare_connect.audit.models import AuditReport, AuditReportEntry
+from commcare_connect.commcarehq.models import HQServer
+from commcare_connect.flags.models import Flag
+from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup
+from commcare_connect.opportunity.models import (
+    Assessment,
+    AssignedTask,
+    BlobMeta,
+    CatchmentArea,
+    CommCareApp,
+    CompletedModule,
+    CompletedWork,
+    Country,
+    CredentialConfiguration,
+    Currency,
+    DeliverUnit,
+    DeliverUnitFlagRules,
+    DeliveryType,
+    ExchangeRate,
+    FormJsonValidationRules,
+    HQApiKey,
+    LabsRecord,
+    LearnModule,
+    Opportunity,
+    OpportunityAccess,
+    OpportunityClaim,
+    OpportunityClaimLimit,
+    OpportunityVerificationFlags,
+    Payment,
+    PaymentInvoice,
+    PaymentUnit,
+    TaskType,
+    UserInvite,
+    UserVisit,
+)
+from commcare_connect.organization.models import (
+    LLOEntity,
+    Organization,
+    UserOrganizationMembership,
+)
+from commcare_connect.program.models import (
+    ManagedOpportunity,
+    Program,
+    ProgramApplication,
+)
+from commcare_connect.reports.models import UserAnalyticsData
+from commcare_connect.users.models import ConnectIDUserLink, User, UserCredential
+
+PUBLICATION_NAME = "tables_for_superset_pub"
+SUBSCRIPTION_NAME = "tables_for_superset_sub"
+
+# Models whose tables are replicated to the secondary (Superset) database.
+# Every local app model must appear in exactly ONE of the two lists below;
+# a Django system check (see checks.py) fails otherwise. Adding a sensitive
+# model? Put it in REPLICATION_EXCLUDED_MODELS.
+REPLICATION_INCLUDED_MODELS = [
+    Assessment,
+    CommCareApp,
+    CompletedModule,
+    CompletedWork,
+    ConnectIDUserLink,
+    Country,
+    Currency,
+    DeliverUnit,
+    DeliverUnitFlagRules,
+    DeliveryType,
+    LearnModule,
+    LLOEntity,
+    Opportunity,
+    OpportunityAccess,
+    OpportunityClaim,
+    OpportunityClaimLimit,
+    OpportunityVerificationFlags,
+    Organization,
+    Payment,
+    PaymentInvoice,
+    PaymentUnit,
+    Program,
+    User,
+    UserAnalyticsData,
+    UserCredential,
+    UserVisit,
+]
+
+# Local app models deliberately NOT replicated (PII, secrets, operational
+# noise, or simply not needed in Superset).
+REPLICATION_EXCLUDED_MODELS = [
+    AuditReport,
+    AuditReportEntry,
+    HQServer,
+    Flag,
+    WorkArea,
+    WorkAreaGroup,
+    AssignedTask,
+    BlobMeta,
+    CatchmentArea,
+    CredentialConfiguration,
+    ExchangeRate,
+    FormJsonValidationRules,
+    HQApiKey,
+    LabsRecord,
+    TaskType,
+    UserInvite,
+    UserOrganizationMembership,
+    ManagedOpportunity,
+    ProgramApplication,
+]
+```
+
+- [ ] **Step 4: Create `replication.py`**
+
+Create `commcare_connect/multidb/replication.py`:
+
+```python
+from commcare_connect.multidb.constants import REPLICATION_INCLUDED_MODELS
+
+
+def get_replicated_models():
+    """Models whose tables should be present in the publication."""
+    return REPLICATION_INCLUDED_MODELS
+
+
+def get_replicated_tables() -> set[str]:
+    """The set of db_table names that should be replicated."""
+    return {model._meta.db_table for model in get_replicated_models()}
+```
+
+- [ ] **Step 5: Update the two commands' imports so nothing breaks**
+
+In `commcare_connect/multidb/management/commands/setup_logical_replication.py`, change line 8 and line 19:
+
+```python
+# line 8 — was: from commcare_connect.multidb.constants import REPLICATION_ALLOWED_MODELS
+from commcare_connect.multidb.replication import get_replicated_models
+```
+
+```python
+# in get_table_list(), line 19 — was: for model in REPLICATION_ALLOWED_MODELS:
+        for model in get_replicated_models():
+```
+
+In `commcare_connect/multidb/management/commands/logical_replication_status.py`, change line 8 and line 126:
+
+```python
+# line 8 — was: from commcare_connect.multidb.constants import REPLICATION_ALLOWED_MODELS
+from commcare_connect.multidb.replication import get_replicated_models
+```
+
+```python
+# line 126 — was: for model in REPLICATION_ALLOWED_MODELS:
+        for model in get_replicated_models():
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest commcare_connect/multidb/tests/test_replication.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 7: Verify no other references to the old name remain**
+
+Run: `grep -rn "REPLICATION_ALLOWED_MODELS" commcare_connect/ config/`
+Expected: no output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add commcare_connect/multidb/constants.py commcare_connect/multidb/replication.py \
+  commcare_connect/multidb/tests/__init__.py commcare_connect/multidb/tests/test_replication.py \
+  commcare_connect/multidb/management/commands/setup_logical_replication.py \
+  commcare_connect/multidb/management/commands/logical_replication_status.py
+git commit -m "Replace replication allowlist with CI-enforceable twin lists"
+```
+
+---
+
+## Task 2: CI-enforced classification (Django system check)
+
+Every local app model must be in exactly one list. A Django system check (runs on `manage.py check`, `runserver`, and CI) fails on any unclassified or double-classified model. pghistory `Event` models and auto-created m2m tables are auto-excluded from the requirement.
+
+**Files:**
+- Create: `commcare_connect/multidb/checks.py`
+- Modify: `commcare_connect/multidb/apps.py`
+- Modify: `commcare_connect/multidb/replication.py`
+- Modify: `commcare_connect/multidb/tests/test_replication.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `commcare_connect/multidb/tests/test_replication.py`:
+
+```python
+def test_no_unclassified_local_models():
+    # Every local model is in exactly one list; this set must be empty.
+    assert replication.get_unclassified_models() == set()
+
+
+def test_unclassified_excludes_pghistory_events_and_m2m():
+    # The "must classify" set never includes pghistory Event models or
+    # auto-created through tables.
+    import pghistory.models
+
+    must_classify = replication.get_models_requiring_classification()
+    for model in must_classify:
+        assert not model._meta.auto_created
+        assert not issubclass(model, pghistory.models.Event)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest commcare_connect/multidb/tests/test_replication.py -k unclassified -v`
+Expected: FAIL — `AttributeError: module 'replication' has no attribute 'get_unclassified_models'`.
+
+- [ ] **Step 3: Add the discovery + classification functions to `replication.py`**
+
+Append to `commcare_connect/multidb/replication.py`:
+
+```python
+import pghistory.models
+from django.apps import apps
+from django.conf import settings
+
+from commcare_connect.multidb.constants import (
+    REPLICATION_EXCLUDED_MODELS,
+    REPLICATION_INCLUDED_MODELS,
+)
+
+
+def _local_app_labels() -> set[str]:
+    return {
+        app_config.label
+        for app_config in apps.get_app_configs()
+        if app_config.name in settings.LOCAL_APPS
+    }
+
+
+def get_models_requiring_classification() -> set:
+    """Local, concrete, non-history models that must appear in one list.
+
+    Excludes pghistory Event models and auto-created m2m through tables —
+    these are never replicated and never need classifying.
+    """
+    local_labels = _local_app_labels()
+    return {
+        model
+        for model in apps.get_models()
+        if model._meta.app_label in local_labels
+        and not model._meta.auto_created
+        and not issubclass(model, pghistory.models.Event)
+    }
+
+
+def get_unclassified_models() -> set:
+    classified = set(REPLICATION_INCLUDED_MODELS) | set(REPLICATION_EXCLUDED_MODELS)
+    return get_models_requiring_classification() - classified
+
+
+def get_doubly_classified_models() -> set:
+    return set(REPLICATION_INCLUDED_MODELS) & set(REPLICATION_EXCLUDED_MODELS)
+```
+
+Note: keep the existing top-of-file import of `REPLICATION_INCLUDED_MODELS` (from Task 1); the new block re-imports both list names — consolidate into the single existing import line so there is only one import of the constants module.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `pytest commcare_connect/multidb/tests/test_replication.py -k unclassified -v`
+Expected: PASS (2 passed). If `test_no_unclassified_local_models` fails, the failure message lists models missing from both lists — add each to `REPLICATION_INCLUDED_MODELS` or `REPLICATION_EXCLUDED_MODELS` in `constants.py`.
+
+- [ ] **Step 5: Create the system check**
+
+Create `commcare_connect/multidb/checks.py`:
+
+```python
+from django.core.checks import Error, register
+
+from commcare_connect.multidb import replication
+
+
+@register()
+def check_all_models_classified_for_replication(app_configs, **kwargs):
+    errors = []
+
+    unclassified = replication.get_unclassified_models()
+    if unclassified:
+        names = ", ".join(sorted(m._meta.label for m in unclassified))
+        errors.append(
+            Error(
+                "Models are not classified for logical replication: " + names,
+                hint=(
+                    "Add each model to REPLICATION_INCLUDED_MODELS or "
+                    "REPLICATION_EXCLUDED_MODELS in "
+                    "commcare_connect/multidb/constants.py."
+                ),
+                id="multidb.E001",
+            )
+        )
+
+    doubly = replication.get_doubly_classified_models()
+    if doubly:
+        names = ", ".join(sorted(m._meta.label for m in doubly))
+        errors.append(
+            Error(
+                "Models appear in BOTH replication lists: " + names,
+                hint="Each model must be in exactly one list.",
+                id="multidb.E002",
+            )
+        )
+
+    return errors
+```
+
+- [ ] **Step 6: Register the check in `apps.py`**
+
+In `commcare_connect/multidb/apps.py`, add a `ready()` method to `MultidbConfig` (the class at the bottom of the file):
+
+```python
+class MultidbConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "commcare_connect.multidb"
+
+    def ready(self):
+        from commcare_connect.multidb import checks  # noqa: F401  (registers system checks)
+```
+
+- [ ] **Step 7: Verify the check passes against the real registry**
+
+Run: `python manage.py check`
+Expected: `System check identified no issues` (no `multidb.E001` / `multidb.E002`).
+
+- [ ] **Step 8: Run the full multidb test module**
+
+Run: `pytest commcare_connect/multidb/tests/test_replication.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add commcare_connect/multidb/checks.py commcare_connect/multidb/apps.py \
+  commcare_connect/multidb/replication.py commcare_connect/multidb/tests/test_replication.py
+git commit -m "Enforce replication model classification via system check"
+```
+
+---
+
+## Task 3: Gating settings + in-sync / bootstrap-state detection
+
+Add the settings that gate whether the refresh runs, plus the pure helpers the refresh command uses to decide whether to act: `replication_is_active()`, `publication_exists()`, and `is_publication_in_sync()`.
+
+**Files:**
+- Modify: `config/settings/base.py:50-55` (the secondary-DB block)
+- Modify: `commcare_connect/multidb/replication.py`
+- Create: `commcare_connect/multidb/tests/test_gating.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `commcare_connect/multidb/tests/test_gating.py`:
+
+```python
+from contextlib import contextmanager
+
+from django.test import override_settings
+
+from commcare_connect.multidb import replication
+
+
+class FakeCursor:
+    """Captures executed SQL and returns canned fetch results."""
+
+    def __init__(self, fetchall_result=None):
+        self.executed = []
+        self._fetchall_result = fetchall_result or []
+
+    def execute(self, sql, params=None):
+        self.executed.append((str(sql), params))
+
+    def fetchall(self):
+        return self._fetchall_result
+
+    def fetchone(self):
+        return self._fetchall_result[0] if self._fetchall_result else None
+
+
+class FakeConnection:
+    def __init__(self, fetchall_result=None):
+        self.cursor_obj = FakeCursor(fetchall_result)
+
+    @contextmanager
+    def cursor(self):
+        yield self.cursor_obj
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS="secondary")
+def test_replication_is_active_when_enabled_and_secondary_configured():
+    assert replication.replication_is_active() is True
+
+
+@override_settings(REPLICATION_ENABLED=False, SECONDARY_DB_ALIAS="secondary")
+def test_replication_inactive_when_disabled():
+    assert replication.replication_is_active() is False
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS=None)
+def test_replication_inactive_without_secondary():
+    assert replication.replication_is_active() is False
+
+
+def test_publication_exists_true_when_row_returned():
+    conn = FakeConnection(fetchall_result=[("tables_for_superset_pub",)])
+    assert replication.publication_exists(conn) is True
+
+
+def test_publication_exists_false_when_no_row():
+    conn = FakeConnection(fetchall_result=[])
+    assert replication.publication_exists(conn) is False
+
+
+def test_is_publication_in_sync_true_when_tables_match(monkeypatch):
+    desired = {"opportunity_opportunity", "users_user"}
+    monkeypatch.setattr(replication, "get_replicated_tables", lambda: desired)
+    rows = [(t,) for t in desired]
+    conn = FakeConnection(fetchall_result=rows)
+    assert replication.is_publication_in_sync(conn) is True
+
+
+def test_is_publication_in_sync_false_when_table_missing(monkeypatch):
+    monkeypatch.setattr(
+        replication, "get_replicated_tables", lambda: {"a", "b"}
+    )
+    conn = FakeConnection(fetchall_result=[("a",)])  # missing "b"
+    assert replication.is_publication_in_sync(conn) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest commcare_connect/multidb/tests/test_gating.py -v`
+Expected: FAIL — `AttributeError` (`replication_is_active` / `publication_exists` / `is_publication_in_sync` not defined).
+
+- [ ] **Step 3: Add the settings**
+
+In `config/settings/base.py`, the secondary-DB block currently reads (lines ~50-55):
+
+```python
+SECONDARY_DB_ALIAS = None
+if env("SECONDARY_DATABASE_URL", default=None):
+    SECONDARY_DB_ALIAS = "secondary"
+    DATABASES[SECONDARY_DB_ALIAS] = env.db("SECONDARY_DATABASE_URL")
+    DATABASES[SECONDARY_DB_ALIAS]["ENGINE"] = "django.contrib.gis.db.backends.postgis"
+    DATABASE_ROUTERS = ["commcare_connect.multidb.db_router.ConnectDatabaseRouter"]
+```
+
+Immediately after that block, add:
+
+```python
+# Logical replication to the secondary (Superset) database.
+# Gates whether `refresh_replication` does anything on deploy. Keep False
+# until the secondary is bootstrapped AND running Postgres 16+.
+REPLICATION_ENABLED = env.bool("REPLICATION_ENABLED", default=False)
+# Roles the refresh grants SELECT to (must already exist; created at bootstrap).
+REPLICATION_PRIMARY_REPL_USER = env("REPLICATION_PRIMARY_REPL_USER", default="postgres_repl")
+REPLICATION_SUPERSET_USER = env("REPLICATION_SUPERSET_USER", default="superset_readonly")
+```
+
+- [ ] **Step 4: Add the helpers to `replication.py`**
+
+Append to `commcare_connect/multidb/replication.py`:
+
+```python
+from commcare_connect.multidb.constants import PUBLICATION_NAME
+
+
+def replication_is_active() -> bool:
+    """Whether the deploy-time refresh should run in this environment."""
+    return bool(settings.REPLICATION_ENABLED and settings.SECONDARY_DB_ALIAS)
+
+
+def publication_exists(connection) -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT pubname FROM pg_publication WHERE pubname = %s",
+            [PUBLICATION_NAME],
+        )
+        return cursor.fetchone() is not None
+
+
+def _current_publication_tables(connection) -> set[str]:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT tablename FROM pg_publication_tables WHERE pubname = %s",
+            [PUBLICATION_NAME],
+        )
+        return {row[0] for row in cursor.fetchall()}
+
+
+def is_publication_in_sync(connection) -> bool:
+    return get_replicated_tables() == _current_publication_tables(connection)
+```
+
+Note: `PUBLICATION_NAME` may already be importable; ensure it is imported once at the top of the module alongside the other `constants` imports rather than mid-file.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest commcare_connect/multidb/tests/test_gating.py -v`
+Expected: PASS (7 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add config/settings/base.py commcare_connect/multidb/replication.py \
+  commcare_connect/multidb/tests/test_gating.py
+git commit -m "Add replication gating settings and in-sync detection helpers"
+```
+
+---
+
+## Task 4: `refresh_replication` command (D2 + D3.B recurring path)
+
+The non-interactive deploy command. It gates on `replication_is_active()`, no-ops if bootstrap hasn't run (no publication) or the publication is already in sync, and otherwise reconciles the publication (primary) and refreshes the subscription (secondary) using only Django's existing connections. The SQL primitives are extracted as functions so they are unit-testable with a fake connection.
+
+**Files:**
+- Modify: `commcare_connect/multidb/replication.py`
+- Create: `commcare_connect/multidb/management/commands/refresh_replication.py`
+- Create: `commcare_connect/multidb/tests/test_refresh.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `commcare_connect/multidb/tests/test_refresh.py`:
+
+```python
+from commcare_connect.multidb import replication
+from commcare_connect.multidb.tests.test_gating import FakeConnection
+
+
+def _executed_sql(conn):
+    return " | ".join(sql for sql, _ in conn.cursor_obj.executed)
+
+
+def test_refresh_publication_sets_tables_and_grants():
+    conn = FakeConnection()
+    replication.refresh_publication(
+        conn, desired_tables={"users_user", "opportunity_opportunity"}, repl_user="postgres_repl"
+    )
+    sql = _executed_sql(conn)
+    assert "ALTER PUBLICATION" in sql
+    assert "SET TABLE" in sql
+    assert '"opportunity_opportunity"' in sql
+    assert '"users_user"' in sql
+    assert "GRANT SELECT ON ALL TABLES IN SCHEMA public" in sql
+    assert '"postgres_repl"' in sql
+
+
+def test_refresh_subscription_refreshes_and_grants():
+    conn = FakeConnection()
+    replication.refresh_subscription(conn, superset_user="superset_readonly")
+    sql = _executed_sql(conn)
+    assert "ALTER SUBSCRIPTION" in sql
+    assert "REFRESH PUBLICATION" in sql
+    assert "GRANT SELECT ON ALL TABLES IN SCHEMA public" in sql
+    assert '"superset_readonly"' in sql
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest commcare_connect/multidb/tests/test_refresh.py -v`
+Expected: FAIL — `AttributeError` (`refresh_publication` / `refresh_subscription` not defined).
+
+- [ ] **Step 3: Add the SQL primitives to `replication.py`**
+
+Append to `commcare_connect/multidb/replication.py` (psycopg2 `sql` composition matches the style already used in `setup_logical_replication.py`):
+
+```python
+from psycopg2 import sql
+
+from commcare_connect.multidb.constants import SUBSCRIPTION_NAME
+
+
+def _grant_select_all(cursor, role: str):
+    cursor.execute(
+        sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA public TO {role}").format(
+            role=sql.Identifier(role)
+        )
+    )
+
+
+def refresh_publication(connection, *, desired_tables: set[str], repl_user: str):
+    """On the primary: make the publication's table set match `desired_tables`
+    and let the replication role read the (possibly new) tables."""
+    tables = sql.SQL(", ").join(sql.Identifier(t) for t in sorted(desired_tables))
+    with connection.cursor() as cursor:
+        cursor.execute(
+            sql.SQL("ALTER PUBLICATION {pub} SET TABLE {tables}").format(
+                pub=sql.Identifier(PUBLICATION_NAME), tables=tables
+            )
+        )
+        _grant_select_all(cursor, repl_user)
+
+
+def refresh_subscription(connection, *, superset_user: str):
+    """On the secondary: re-read the publication (COPY new tables, drop
+    removed) and let the Superset reader see the newly arrived tables."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            sql.SQL("ALTER SUBSCRIPTION {sub} REFRESH PUBLICATION").format(
+                sub=sql.Identifier(SUBSCRIPTION_NAME)
+            )
+        )
+        _grant_select_all(cursor, superset_user)
+```
+
+Note: consolidate the `SUBSCRIPTION_NAME` / `PUBLICATION_NAME` imports into the single `constants` import at the top of the module.
+
+- [ ] **Step 4: Run primitive tests to verify they pass**
+
+Run: `pytest commcare_connect/multidb/tests/test_refresh.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Write the failing command-orchestration test**
+
+Append to `commcare_connect/multidb/tests/test_refresh.py`:
+
+```python
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import override_settings
+
+
+@override_settings(REPLICATION_ENABLED=False, SECONDARY_DB_ALIAS=None)
+def test_command_noops_when_replication_inactive():
+    out = StringIO()
+    call_command("refresh_replication", stdout=out)
+    assert "skipping" in out.getvalue().lower()
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS="secondary")
+def test_command_noops_when_bootstrap_not_run(monkeypatch):
+    monkeypatch.setattr(replication, "publication_exists", lambda conn: False)
+    out = StringIO()
+    call_command("refresh_replication", stdout=out)
+    assert "bootstrap" in out.getvalue().lower()
+
+
+@override_settings(REPLICATION_ENABLED=True, SECONDARY_DB_ALIAS="secondary")
+def test_command_noops_when_already_in_sync(monkeypatch):
+    monkeypatch.setattr(replication, "publication_exists", lambda conn: True)
+    monkeypatch.setattr(replication, "is_publication_in_sync", lambda conn: True)
+    out = StringIO()
+    call_command("refresh_replication", stdout=out)
+    assert "in sync" in out.getvalue().lower()
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `pytest commcare_connect/multidb/tests/test_refresh.py -k command -v`
+Expected: FAIL — `CommandError: Unknown command: 'refresh_replication'`.
+
+- [ ] **Step 7: Create the command**
+
+Create `commcare_connect/multidb/management/commands/refresh_replication.py`:
+
+```python
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import DEFAULT_DB_ALIAS, connections
+
+from commcare_connect.multidb import replication
+
+
+class Command(BaseCommand):
+    help = (
+        "Reconcile the logical-replication publication/subscription with the "
+        "models in REPLICATION_INCLUDED_MODELS. Non-interactive; safe to run on "
+        "every deploy after migrate_multi. Requires a one-time bootstrap "
+        "(setup_logical_replication) to have run for this environment."
+    )
+
+    def handle(self, *args, **options):
+        if not replication.replication_is_active():
+            self.stdout.write("Replication not enabled for this environment; skipping.")
+            return
+
+        primary = connections[DEFAULT_DB_ALIAS]
+
+        if not replication.publication_exists(primary):
+            self.stdout.write(
+                self.style.WARNING(
+                    "Publication does not exist — run the one-time bootstrap "
+                    "(setup_logical_replication) first. Skipping refresh."
+                )
+            )
+            return
+
+        if replication.is_publication_in_sync(primary):
+            self.stdout.write("Publication already in sync; nothing to do.")
+            return
+
+        desired = replication.get_replicated_tables()
+        self.stdout.write("Publication out of sync; reconciling...")
+        replication.refresh_publication(
+            primary,
+            desired_tables=desired,
+            repl_user=settings.REPLICATION_PRIMARY_REPL_USER,
+        )
+        self.stdout.write(self.style.SUCCESS("Primary publication updated."))
+
+        secondary = connections[settings.SECONDARY_DB_ALIAS]
+        replication.refresh_subscription(
+            secondary,
+            superset_user=settings.REPLICATION_SUPERSET_USER,
+        )
+        self.stdout.write(self.style.SUCCESS("Secondary subscription refreshed."))
+```
+
+- [ ] **Step 8: Run the command tests to verify they pass**
+
+Run: `pytest commcare_connect/multidb/tests/test_refresh.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add commcare_connect/multidb/replication.py \
+  commcare_connect/multidb/management/commands/refresh_replication.py \
+  commcare_connect/multidb/tests/test_refresh.py
+git commit -m "Add non-interactive refresh_replication command"
+```
+
+---
+
+## Task 5: Extend bootstrap to transfer subscription ownership (D3.B)
+
+`setup_logical_replication` stays the interactive, operator-run bootstrap, but after creating/refreshing the subscription it transfers subscription ownership to the app's secondary role (the role from `SECONDARY_DATABASE_URL`), so the recurring `refresh_replication` can `REFRESH PUBLICATION` without a superuser. This `ALTER SUBSCRIPTION ... OWNER TO` runs on the superuser connection that bootstrap already opened.
+
+**Files:**
+- Modify: `commcare_connect/multidb/management/commands/setup_logical_replication.py`
+- Create: `commcare_connect/multidb/tests/test_bootstrap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `commcare_connect/multidb/tests/test_bootstrap.py`:
+
+```python
+from commcare_connect.multidb.management.commands import setup_logical_replication
+from commcare_connect.multidb.tests.test_gating import FakeCursor
+
+
+def test_transfer_subscription_ownership_issues_alter_owner():
+    cursor = FakeCursor()
+    setup_logical_replication.transfer_subscription_ownership(cursor, "app_secondary_role")
+    sql = " ".join(s for s, _ in cursor.executed)
+    assert "ALTER SUBSCRIPTION" in sql
+    assert "OWNER TO" in sql
+    assert '"app_secondary_role"' in sql
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest commcare_connect/multidb/tests/test_bootstrap.py -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'transfer_subscription_ownership'`.
+
+- [ ] **Step 3: Add the ownership-transfer helper**
+
+In `commcare_connect/multidb/management/commands/setup_logical_replication.py`, add a module-level function (near the top, after the imports and name constants):
+
+```python
+def transfer_subscription_ownership(cursor, secondary_role: str):
+    """Hand subscription ownership to the app's secondary role so the
+    recurring refresh can REFRESH PUBLICATION without a superuser (PG16+)."""
+    cursor.execute(
+        psycopg2.sql.SQL("ALTER SUBSCRIPTION {sub} OWNER TO {role}").format(
+            sub=psycopg2.sql.Identifier(SUBSCRIPTION_NAME),
+            role=psycopg2.sql.Identifier(secondary_role),
+        )
+    )
+```
+
+- [ ] **Step 4: Call it after the subscription is created/refreshed**
+
+In `setup_logical_replication.py`, the `with secondary_conn.cursor() as cursor:` block (currently lines ~97-133) creates or refreshes the subscription and then grants SELECT to the superset user. After the `_grant` / superset GRANT statement and before closing the connection, add the ownership transfer. Insert immediately after the superset GRANT `cursor.execute(...)` (around line 133):
+
+```python
+            self.stdout.write("Transferring subscription ownership to the app secondary role...")
+            secondary_role = secondary_db_settings["USER"]
+            transfer_subscription_ownership(cursor, secondary_role)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Subscription '{SUBSCRIPTION_NAME}' now owned by '{secondary_role}'."
+                )
+            )
+```
+
+(`secondary_db_settings` is already defined earlier in `handle()` at line ~80.)
+
+- [ ] **Step 5: Run the bootstrap test to verify it passes**
+
+Run: `pytest commcare_connect/multidb/tests/test_bootstrap.py -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 6: Sanity-check the command still imports/parses**
+
+Run: `python manage.py help setup_logical_replication`
+Expected: prints the command help with no import errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add commcare_connect/multidb/management/commands/setup_logical_replication.py \
+  commcare_connect/multidb/tests/test_bootstrap.py
+git commit -m "Transfer subscription ownership to app secondary role at bootstrap"
+```
+
+---
+
+## Task 6: Wire `refresh_replication` into the deploy pipeline (D2 trigger)
+
+`docker/start_migrate` runs `migrate_multi --noinput` then starts gunicorn. The only race-safe place to refresh replication is *after* `migrate_multi` returns (both DBs are at the new schema). Add the refresh between them. It is a no-op unless `REPLICATION_ENABLED=True`, so this is safe to merge before the PG16 upgrade.
+
+**Files:**
+- Modify: `docker/start_migrate`
+
+- [ ] **Step 1: Read the current script**
+
+Run: `cat docker/start_migrate`
+Expected current contents:
+
+```bash
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+echo "Django migrate"
+python manage.py migrate_multi --noinput
+echo "Run Gunicorn"
+gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 450 -w 10
+```
+
+- [ ] **Step 2: Insert the refresh step**
+
+Edit `docker/start_migrate` so the lines between `migrate_multi` and `Run Gunicorn` become:
+
+```bash
+echo "Django migrate"
+python manage.py migrate_multi --noinput
+echo "Refresh logical replication"
+python manage.py refresh_replication
+echo "Run Gunicorn"
+gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --timeout 450 -w 10
+```
+
+(The script uses `set -o errexit`; `refresh_replication` exits 0 on the no-op paths, so deploys are unaffected when replication is disabled.)
+
+- [ ] **Step 3: Verify the script is still valid bash**
+
+Run: `bash -n docker/start_migrate`
+Expected: no output (syntax OK).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker/start_migrate
+git commit -m "Run refresh_replication after migrate_multi on deploy"
+```
+
+---
+
+## Task 7: Update `logical_replication_status` to drop the superuser prompt
+
+Per the recommendation's "Out of scope → `logical_replication_status.py`" note: under D3.B its read-only status checks can run on the connections Django already has, so the secondary-superuser prompt is no longer needed. This task makes the status command consistent with the new model (its discovery import was already fixed in Task 1). This is a refactor of an interactive command; the meaningful unit is the table-count helper.
+
+**Files:**
+- Modify: `commcare_connect/multidb/management/commands/logical_replication_status.py`
+- Modify: `commcare_connect/multidb/tests/test_replication.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `commcare_connect/multidb/tests/test_replication.py`:
+
+```python
+def test_table_count_rows_uses_replicated_models(monkeypatch):
+    from commcare_connect.multidb.management.commands import logical_replication_status
+
+    class C:
+        def __init__(self, n):
+            self.n = n
+            self.executed = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, sql, params=None):
+            self.executed.append(sql)
+
+        def fetchone(self):
+            return (self.n,)
+
+    class Conn:
+        def __init__(self, n):
+            self.n = n
+
+        def cursor(self):
+            return C(self.n)
+
+    rows = logical_replication_status.table_count_rows(Conn(5), Conn(3))
+    tables = {r[0] for r in rows}
+    assert "opportunity_opportunity" in tables
+    assert all(r[1] == 5 and r[2] == 3 for r in rows)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest commcare_connect/multidb/tests/test_replication.py -k table_count -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'table_count_rows'`.
+
+- [ ] **Step 3: Extract the table-count helper and use Django's secondary connection**
+
+In `logical_replication_status.py`:
+
+(a) Add a module-level helper (after imports):
+
+```python
+def table_count_rows(primary_conn, secondary_conn):
+    """Return [(table_name, primary_count, secondary_count), ...] for all
+    replicated models."""
+    rows = []
+    for model in get_replicated_models():
+        table_name = model._meta.db_table
+        with primary_conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name};")
+            primary_count = cursor.fetchone()[0]
+        with secondary_conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name};")
+            secondary_count = cursor.fetchone()[0]
+        rows.append((table_name, primary_count, secondary_count))
+    return rows
+```
+
+(b) Replace the interactive superuser prompt + raw `psycopg2.connect(...)` for the secondary (lines ~33-50) with Django's existing secondary connection:
+
+```python
+        default_conn = connections[DEFAULT_DB_ALIAS]
+        secondary_conn = connections[secondary_db_alias]
+```
+
+Remove the now-unused `getpass` import, the `secondary_user`/`secondary_password` prompts, and the `secondary_conn.close()` at the end (Django manages its own connections).
+
+(c) Replace the inline table-count loop (lines ~126-136) with:
+
+```python
+        for table_name, primary_count, secondary_count in table_count_rows(default_conn, secondary_conn):
+            self.stdout.write(f"{table_name:<30}{primary_count:<20}{secondary_count}")
+```
+
+Note: subscription/replication-slot queries that previously ran on the raw superuser connection now run on `connections[secondary_db_alias]` (the app secondary role). Reading `pg_subscription` / `pg_stat_replication` is fine for the app role on PG16+; if a particular catalog read is restricted in an environment, it surfaces as a normal query error rather than requiring a superuser prompt.
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `pytest commcare_connect/multidb/tests/test_replication.py -k table_count -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Sanity-check the command parses**
+
+Run: `python manage.py help logical_replication_status`
+Expected: prints help with no import errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add commcare_connect/multidb/management/commands/logical_replication_status.py \
+  commcare_connect/multidb/tests/test_replication.py
+git commit -m "Run replication status checks on app connections, no superuser prompt"
+```
+
+---
+
+## Task 8: Full verification + documentation pointer
+
+**Files:**
+- Modify: `docs/replication-redesign-recommendation.md` (mark implementation status)
+
+- [ ] **Step 1: Run the whole multidb test suite**
+
+Run: `pytest commcare_connect/multidb/ -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 2: Run Django system checks**
+
+Run: `python manage.py check`
+Expected: `System check identified no issues`.
+
+- [ ] **Step 3: Confirm the old constant name is fully gone**
+
+Run: `grep -rn "REPLICATION_ALLOWED_MODELS" .`
+Expected: no output (ignore matches inside `.git/`).
+
+- [ ] **Step 4: Run linters**
+
+Run: `prek run -a`
+Expected: all hooks pass (black, isort, flake8 line-length 119, etc.). Fix any formatting the hooks rewrite, then re-run.
+
+- [ ] **Step 5: Add an implementation-status note to the recommendation doc**
+
+At the top of `docs/replication-redesign-recommendation.md`, under the title, add:
+
+```markdown
+> **Implementation status (2026-06):** Code landed — twin lists + system
+> check, `refresh_replication` command, bootstrap ownership transfer, and
+> deploy wiring. **Not yet rolled out to production:** gated behind
+> `REPLICATION_ENABLED=False` pending the secondary's Postgres 15 → 16
+> blue/green upgrade (see "Postgres version prerequisite").
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/replication-redesign-recommendation.md
+git commit -m "Note replication redesign implementation status"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- D1.B twin lists → Task 1; CI enforcement via system check → Task 2. ✓
+- D2 deploy-pipeline trigger after `migrate_multi` → Task 6; in-sync short-circuit → Tasks 3-4. ✓
+- D3.B bootstrap ownership transfer → Task 5; non-superuser recurring refresh → Task 4. ✓
+- `REPLICATION_ENABLED` gating → Task 3. ✓
+- Out-of-scope `logical_replication_status` rename + superuser removal → Tasks 1 & 7. ✓
+- PG16 prerequisite handled by keeping `REPLICATION_ENABLED=False` (Tasks 3, 6, 8) — code merges safely; rollout waits. ✓
+- Example "adding a new model" flow: system check fails locally/CI (Task 2) → deploy runs refresh after migrate (Tasks 4, 6). ✓
+
+**Type/name consistency:** `get_replicated_models`, `get_replicated_tables`, `replication_is_active`, `publication_exists`, `is_publication_in_sync`, `refresh_publication`, `refresh_subscription`, `transfer_subscription_ownership`, `table_count_rows` — each defined once and referenced with the same signature throughout. `FakeConnection`/`FakeCursor` defined in `test_gating.py` and reused. `REPLICATION_INCLUDED_MODELS`/`REPLICATION_EXCLUDED_MODELS`/`PUBLICATION_NAME`/`SUBSCRIPTION_NAME` consistent across constants, replication, and commands.
+
+**Known limitation (documented, intentional):** the in-sync short-circuit checks only the primary publication membership; if a prior deploy updated the publication but the subscriber `REFRESH` failed, the next deploy's short-circuit would skip the subscriber. Acceptable per YAGNI — a failed refresh fails the deploy step (`set -o errexit`), so the publication and subscriber move together in practice.


### PR DESCRIPTION
Ticket: https://dimagi.atlassian.net/browse/CCCT-2094
Supersedes the approach in https://github.com/dimagi/commcare-connect/pull/1179.

## Product Description

N/A — internal replication plumbing for the Superset secondary DB. No user-facing change.

## Technical Summary

Replaces the hand-maintained `REPLICATION_ALLOWED_MODELS` allowlist (a developer had to edit it and re-run an interactive command on every model change) with auto-discovery + a split lifecycle. Design and rationale: `docs/replication-redesign.md` and `docs/replication-redesign-recommendation.md` (full decision write-up, D1/D2/D3); implementation plan in `docs/superpowers/plans/2026-06-12-auto-discovered-logical-replication.md`.

Three pieces:
- **Twin lists** (`REPLICATION_INCLUDED_MODELS` / `REPLICATION_EXCLUDED_MODELS` in `multidb/constants.py`). Every local app model must be in exactly one — a pytest (`test_no_unclassified_local_models`) fails in CI otherwise, so adding a model forces a deliberate replicate/don't-replicate decision. pghistory event models and m2m through tables are auto-excluded; third-party tables are never replicated.
- **`refresh_replication`** management command (non-interactive), wired into `docker/start_migrate` after `migrate_multi` — the only race-safe trigger, since `migrate_multi` migrates both DBs in parallel and the publication SQL must run after both schemas exist. It reconciles the publication on the primary and `REFRESH`es the subscription on the secondary using only the connections Django already has — no superuser.
- **Bootstrap** (`setup_logical_replication`) now transfers subscription ownership to the app secondary role, which is what lets the recurring refresh run without a superuser. `logical_replication_status` likewise drops its superuser prompt and uses Django's connections.

## Safety Assurance

### Safety story

Gated behind `REPLICATION_ENABLED` (default **False**), so this is a no-op in every environment until the flag is flipped — merging changes nothing in production today. `refresh_replication` exits cleanly (0) when replication is inactive or when the publication doesn't yet exist, so it cannot break the deploy's `set -o errexit` in `start_migrate`.

**Out of scope / deploy ordering:** the no-superuser refresh path is only *legal* on **Postgres 16+** (non-superuser subscription ownership). The production secondary currently runs PG15, so `REPLICATION_ENABLED` must stay False until the secondary is upgraded via blue/green (see the "Postgres version prerequisite" section in the recommendation doc). `ALTER SUBSCRIPTION ... REFRESH PUBLICATION` must run outside a transaction — relies on management commands running in autocommit and the secondary alias having no `ATOMIC_REQUESTS`; noted in a code comment on `refresh_subscription`.

### Automated test coverage

19 tests in `commcare_connect/multidb/tests/`: the classification guard (proves the lists are complete and exempts events/m2m), gating (`replication_is_active`), bootstrap-state and in-sync detection, the publication/subscription refresh SQL, and the bootstrap ownership transfer.

### QA Plan

No QA needed for merge (feature disabled). Real validation happens against the PG16 secondary during the blue/green upgrade: bootstrap once, confirm `refresh_replication` reconciles the table set and Superset sees new/removed tables.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

---

Note: branch is well behind `main` (based on an older commit) — likely wants a rebase before merge.