### PR TITLE
Add name search to Opportunities list

### DIFF
--- a/commcare_connect/opportunity/filters.py
+++ b/commcare_connect/opportunity/filters.py
@@ -157,6 +157,7 @@ class OpportunityListFilterSet(django_filters.FilterSet):
             else:
                 del self.filters["program"]
 
+        self.form.helper.form_tag = False
         self.form.helper.layout = Layout(*modal_fields)
 
 

--- a/commcare_connect/opportunity/filters.py
+++ b/commcare_connect/opportunity/filters.py
@@ -127,6 +127,7 @@ class DeliverFilterSet(django_filters.FilterSet):
 
 
 class OpportunityListFilterSet(django_filters.FilterSet):
+    search = django_filters.CharFilter(label="Search", method="filter_noop")
     is_test = YesNoFilter(label="Is Test")
     status = django_filters.MultipleChoiceFilter(
         label="Status",
@@ -140,16 +141,23 @@ class OpportunityListFilterSet(django_filters.FilterSet):
     class Meta:
         form = CSRFExemptForm
 
+    def filter_noop(self, queryset, name, value):
+        return queryset
+
     def __init__(self, *args, **kwargs):
         request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
 
+        modal_fields = ["is_test", "status"]
         if request:
             user_programs = Program.objects.filter(organization=request.org)
             if user_programs.exists():
                 self.filters["program"].extra["choices"] = [(p.slug, p.name) for p in user_programs]
+                modal_fields.append("program")
             else:
                 del self.filters["program"]
+
+        self.form.helper.layout = Layout(*modal_fields)
 
 
 TASK_STATUS_CHOICES = [

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -446,6 +446,9 @@ class OpportunityData:
         base_filter = Q(organization=organization)
         if program_manager:
             base_filter |= Q(managedopportunity__program__organization=organization)
+        search = filters.get("search", "")
+        if search:
+            base_filter &= Q(name__icontains=search)
         is_test = filters.get("is_test", None)
         if is_test not in ["", None]:
             base_filter &= Q(is_test=is_test)

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -446,7 +446,7 @@ class OpportunityData:
         base_filter = Q(organization=organization)
         if program_manager:
             base_filter |= Q(managedopportunity__program__organization=organization)
-        search = filters.get("search", "")
+        search = filters.get("search", "").strip()
         if search:
             base_filter &= Q(name__icontains=search)
         is_test = filters.get("is_test", None)

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -528,6 +528,9 @@ def test_user_visit_review(
         ({"program": ["test-program-1"]}, 1),
         ({"program": ["test-program-2"]}, 1),
         ({"program": ["test-program-1", "test-program-2"]}, 2),
+        ({"search": "opportunity 2"}, 1),
+        ({"search": "test opportunity"}, 3),
+        ({"search": "nonexistent"}, 0),
     ],
 )
 def test_get_opportunity_list_data_all_annotations(organization, filters, expected_count):

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -529,6 +529,7 @@ def test_user_visit_review(
         ({"program": ["test-program-2"]}, 1),
         ({"program": ["test-program-1", "test-program-2"]}, 2),
         ({"search": "opportunity 2"}, 1),
+        ({"search": "OpPoRtUnItY 2"}, 1),
         ({"search": "test opportunity"}, 3),
         ({"search": "nonexistent"}, 0),
     ],

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -273,6 +273,8 @@ class OpportunityList(OrganizationUserMixin, FilterMixin, SingleTableView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context.update(self.get_filter_context())
+        filter_values = {k: v for k, v in self.get_filter_values().items() if k != "search"}
+        context["filters_applied_count"] = len([v for v in filter_values.values() if v not in (None, "", [])])
         return context
 
     def get_table_class(self):

--- a/commcare_connect/templates/opportunity/opportunities_list.html
+++ b/commcare_connect/templates/opportunity/opportunities_list.html
@@ -34,9 +34,11 @@
       <p class="text-sm text-brand-deep-purple">{% translate "Opportunities List" %}</p>
     <div class="flex gap-x-6 items-center" x-cloak x-data="{showFilterModal: false}">
       <div class="simple-input w-64">
+        <label for="id_search" class="sr-only">{% translate "Search by Opportunity name" %}</label>
         <i class="fa-solid fa-magnifying-glass text-slate-400"></i>
         <input
           type="text"
+          id="id_search"
           name="search"
           value="{{ filter_form.search.value|default:'' }}"
           placeholder="{% translate 'Search by Opportunity name' %}"

--- a/commcare_connect/templates/opportunity/opportunities_list.html
+++ b/commcare_connect/templates/opportunity/opportunities_list.html
@@ -29,9 +29,19 @@
 {% load i18n %}
 <div class="flex items-center justify-center">
   <div class="flex flex-col gap-2 w-full">
+  <form id="filterForm" method="get">
   <div class="flex relative mx-auto items-center justify-between w-full px-4 bg-slate-50 rounded-lg shadow-sm h-14">
       <p class="text-sm text-brand-deep-purple">{% translate "Opportunities List" %}</p>
     <div class="flex gap-x-6 items-center" x-cloak x-data="{showFilterModal: false}">
+      <div class="simple-input w-64">
+        <i class="fa-solid fa-magnifying-glass text-slate-400"></i>
+        <input
+          type="text"
+          name="search"
+          value="{{ filter_form.search.value|default:'' }}"
+          placeholder="{% translate 'Search by Opportunity name' %}"
+        >
+      </div>
       <button type="button" @click="showFilterModal = true" class="relative button-icon">
         <i class="fa-solid fa-sliders text-brand-deep-purple"></i>
         {% if filters_applied_count %}
@@ -51,29 +61,26 @@
         <div class="modal">
           <div class="header text-lg font-semibold text-brand-deep-purple">
             <h1>Filters</h1>
-            <button @click="showFilterModal = false">
+            <button type="button" @click="showFilterModal = false">
               <i class="fa-solid fa-xmark text-xl"></i>
             </button>
           </div>
-          <form
-            id="filterForm"
-            class="content"
-          >
+          <div class="content">
             <div class="modal-body">
               {% crispy filter_form %}
             </div>
             <div class="footer">
               <button type="button" @click="showFilterModal = false" class="button button-md outline-style">Close</button>
-              <button
-                form="filterForm" type="submit" @click="showFilterModal = false" class="button button-md primary-dark">
+              <button type="submit" @click="showFilterModal = false" class="button button-md primary-dark">
                 Apply
               </button>
             </div>
-          </form>
+          </div>
         </div>
       </div>
     </div>
     </div>
+  </form>
 
     <!-- Table Header -->
     <div class="flex flex-col w-full gap-2">


### PR DESCRIPTION
## Summary

- Adds an inline search bar to the Opportunities list page header
- Filters opportunities by name (case-insensitive `icontains`) on form submit
- Search input shares the same `<form>` as the filter modal so search and filters compose together
- Search is excluded from the filter badge count (the sliders icon)
<img width="1615" height="435" alt="Screenshot 2026-05-14 at 3 35 58 PM" src="https://github.com/user-attachments/assets/a67c7c31-0384-476b-b176-b3e94ff2d7df" />

Jira: [CCCT-2420](https://dimagi.atlassian.net/browse/CCCT-2420)

## Test plan

- [ ] Search for a partial opportunity name — matching rows appear, others disappear
- [ ] Applying a filter while a search is active preserves the search term
- [ ] Searching while filters are active preserves the filter values
- [ ] Clearing the search field and submitting restores the full list
- [ ] `filters_applied_count` badge does not increment when only search is set

[CCCT-2420]: https://dimagi.atlassian.net/browse/CCCT-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ