### PR TITLE
Fix usercase filter

### DIFF
--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -14,9 +14,13 @@ from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 HQ_CASE_BULK_CHUNK_SIZE = 100
 
 
-class GetCaseDataAPIFilters(TypedDict):
-    case_type: str
-    case_name: str
+GetCaseDataAPIFilters = TypedDict(
+    "GetCaseDataAPIFilters",
+    {
+        "case_type": str,
+        "properties.username": str,
+    },
+)
 
 
 @dataclasses.dataclass
@@ -214,7 +218,7 @@ def get_usercase(opportunity_access: OpportunityAccess) -> CommCareCase:
         domain,
         filters={
             "case_type": "commcare-user",
-            "case_name": user.username.lower(),
+            "properties.username": user.username.lower(),
         },
     )
     usercase = next(iter(case_data), None)


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
Just a bugfix for filter used to fetch usercase from HQ for a mobile worker.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/CCCT-2423

`case_name` stopped working after Connect push the user's username as the first name for the mobile worker when sending additional fields during user creation. `case_name` also seemed unreliable.
I found that HQ sets a case property called username on the usercase and keeps that in sync with the user's username, so that was more reliable to fetch the usercase.

https://github.com/dimagi/commcare-connect/pull/1187 now adds the user's HQ ID on the link, so that can also be used to fetch the commcare-user case assigned to the mobile worker but the change in this PR seems solid as well.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Testing on staging for integration but otherwise tests added.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
