### PR TITLE
Use Task Type Accessor for Task Table

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1908,7 +1908,7 @@ class WorkerCompletedTaskTable(tables.Table):
     use_view_url = True
 
     select = select_column(td_extra=_task_select_td_extra)
-    task_type = tables.Column(verbose_name=_("Task Type"), accessor="task", orderable=False)
+    task_type = tables.Column(verbose_name=_("Task Type"), accessor="task_type", orderable=False)
     assigned_by = tables.Column(
         verbose_name=_("Assigned By"),
         accessor="assigned_by__name",


### PR DESCRIPTION
## Product Description

The **Task Type** column in the worker tasks table was always blank. It now correctly displays the task type name and slug for each assigned task row.
<img width="807" height="265" alt="Screenshot_20260515_141435" src="https://github.com/user-attachments/assets/0750a178-3122-4812-b569-2625e8119fb9" />

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/QA-8508)

This is a release path 3 feature — Experiments & early stage iterations of product area

- **Bug fix** — `WorkerCompletedTaskTable.task_type` column had `accessor="task"`, which does not match any field on `AssignedTask`. Changed to `accessor="task_type"` to match the FK field name, allowing `render_task_type` to receive the `TaskType` instance and render `name (slug)` correctly.

## Safety Assurance

### Safety story

Single-character accessor rename with no data or logic changes. The queryset already `select_related("task_type")`, so no additional DB queries are introduced. No risk of data mutation.

### Automated test coverage

No new tests added — this is a pure display fix. The `render_task_type` method and queryset were already correct; only the column accessor was wrong.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Navigate to an opportunity's worker tasks tab for a worker with assigned tasks
- [ ] Confirm the **Task Type** column now shows `<name> (<slug>)` instead of being blank
- [ ] Confirm no other columns on the table are affected

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
