### PR TITLE
Fix Worker Tasks Filters

### DIFF
--- a/commcare_connect/opportunity/filters.py
+++ b/commcare_connect/opportunity/filters.py
@@ -209,7 +209,7 @@ class TasksFilterSet(django_filters.FilterSet):
         self.opportunity = kwargs.pop("opportunity", None)
         super().__init__(*args, **kwargs)
         if self.opportunity:
-            active_tasks = TaskType.objects.filter(opportunity=self.opportunity, is_active=True)
+            active_tasks = TaskType.objects.filter(app=self.opportunity.deliver_app, is_active=True)
             self.filters["task_type"].extra["choices"] = [(str(t.pk), t.name) for t in active_tasks]
 
             worker_queryset = (
@@ -270,7 +270,7 @@ class UserTasksFilterSet(django_filters.FilterSet):
         self.opportunity = kwargs.pop("opportunity", None)
         super().__init__(*args, **kwargs)
         if self.opportunity:
-            active_tasks = TaskType.objects.filter(opportunity=self.opportunity, is_active=True)
+            active_tasks = TaskType.objects.filter(app=self.opportunity.deliver_app, is_active=True)
             self.filters["task_type"].extra["choices"] = [(str(t.pk), t.name) for t in active_tasks]
         self.form.helper.layout = Layout(
             "task_status",

--- a/commcare_connect/opportunity/filters.py
+++ b/commcare_connect/opportunity/filters.py
@@ -373,6 +373,9 @@ class AssignedTaskFilterSet(django_filters.FilterSet):
     def __init__(self, *args, **kwargs):
         self.opportunity = kwargs.pop("opportunity", None)
         super().__init__(*args, **kwargs)
+        today = date.today().isoformat()
+        self.filters["date_assigned_after"].extra["widget"].attrs["max"] = today
+        self.filters["date_assigned_before"].extra["widget"].attrs["max"] = today
         if self.opportunity:
             self.filters["task_type"].extra["choices"] = self._get_task_type_choices()
             self.filters["worker_name"].extra["choices"] = self._get_worker_name_choices()

--- a/commcare_connect/opportunity/filters.py
+++ b/commcare_connect/opportunity/filters.py
@@ -214,7 +214,7 @@ class TasksFilterSet(django_filters.FilterSet):
         self.filters["date_assigned_from"].extra["widget"].attrs["max"] = today
         self.filters["date_assigned_to"].extra["widget"].attrs["max"] = today
         if self.opportunity:
-            active_tasks = TaskType.objects.filter(app=self.opportunity.deliver_app, is_active=True)
+            active_tasks = TaskType.objects.filter(opportunity=self.opportunity, is_active=True)
             self.filters["task_type"].extra["choices"] = [(str(t.pk), t.name) for t in active_tasks]
 
             worker_queryset = (
@@ -278,7 +278,7 @@ class UserTasksFilterSet(django_filters.FilterSet):
         self.filters["date_assigned_from"].extra["widget"].attrs["max"] = today
         self.filters["date_assigned_to"].extra["widget"].attrs["max"] = today
         if self.opportunity:
-            active_tasks = TaskType.objects.filter(app=self.opportunity.deliver_app, is_active=True)
+            active_tasks = TaskType.objects.filter(opportunity=self.opportunity, is_active=True)
             self.filters["task_type"].extra["choices"] = [(str(t.pk), t.name) for t in active_tasks]
         self.form.helper.layout = Layout(
             "task_status",

--- a/commcare_connect/opportunity/filters.py
+++ b/commcare_connect/opportunity/filters.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import django_filters
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Column, Div, Layout, Row
@@ -208,6 +210,9 @@ class TasksFilterSet(django_filters.FilterSet):
     def __init__(self, *args, **kwargs):
         self.opportunity = kwargs.pop("opportunity", None)
         super().__init__(*args, **kwargs)
+        today = date.today().isoformat()
+        self.filters["date_assigned_from"].extra["widget"].attrs["max"] = today
+        self.filters["date_assigned_to"].extra["widget"].attrs["max"] = today
         if self.opportunity:
             active_tasks = TaskType.objects.filter(app=self.opportunity.deliver_app, is_active=True)
             self.filters["task_type"].extra["choices"] = [(str(t.pk), t.name) for t in active_tasks]
@@ -269,6 +274,9 @@ class UserTasksFilterSet(django_filters.FilterSet):
     def __init__(self, *args, **kwargs):
         self.opportunity = kwargs.pop("opportunity", None)
         super().__init__(*args, **kwargs)
+        today = date.today().isoformat()
+        self.filters["date_assigned_from"].extra["widget"].attrs["max"] = today
+        self.filters["date_assigned_to"].extra["widget"].attrs["max"] = today
         if self.opportunity:
             active_tasks = TaskType.objects.filter(app=self.opportunity.deliver_app, is_active=True)
             self.filters["task_type"].extra["choices"] = [(str(t.pk), t.name) for t in active_tasks]

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1980,6 +1980,7 @@ class AddTaskTypeForm(forms.ModelForm):
     def save(self, commit=True):
         task_type = super().save(commit=False)
         task_type.app = self.opportunity.deliver_app
+        task_type.opportunity = self.opportunity
         task_type.slug = self.cleaned_data["task_unit_id"]
         unit_name = dict(self.fields["task_unit_id"].choices).get(task_type.slug, "")
         task_type.unit_name = unit_name[:255]

--- a/commcare_connect/opportunity/tests/test_filters.py
+++ b/commcare_connect/opportunity/tests/test_filters.py
@@ -56,8 +56,8 @@ def test_tasks_filterset_task_status_single():
 def test_tasks_filterset_task_type():
     opp = OpportunityFactory()
     access = OpportunityAccessFactory(opportunity=opp, accepted=True)
-    task_a = TaskTypeFactory(app=opp.deliver_app, is_active=True, name="Survey")
-    task_b = TaskTypeFactory(app=opp.deliver_app, is_active=True, name="Follow-up")
+    task_a = TaskTypeFactory(app=opp.deliver_app, opportunity=opp, is_active=True, name="Survey")
+    task_b = TaskTypeFactory(app=opp.deliver_app, opportunity=opp, is_active=True, name="Follow-up")
     AssignedTaskFactory(opportunity_access=access, task_type=task_a)
     AssignedTaskFactory(opportunity_access=access, task_type=task_b)
 
@@ -76,8 +76,8 @@ def test_tasks_filterset_task_type():
 @pytest.mark.django_db
 def test_tasks_filterset_task_type_excludes_inactive():
     opp = OpportunityFactory()
-    active_task = TaskTypeFactory(app=opp.deliver_app, is_active=True, name="Active")
-    inactive_task = TaskTypeFactory(app=opp.deliver_app, is_active=False, name="Inactive")
+    active_task = TaskTypeFactory(app=opp.deliver_app, opportunity=opp, is_active=True, name="Active")
+    inactive_task = TaskTypeFactory(app=opp.deliver_app, opportunity=opp, is_active=False, name="Inactive")
 
     qs = get_worker_tasks_base_queryset(opp)
     filterset = TasksFilterSet(data={}, queryset=qs, opportunity=opp)
@@ -93,7 +93,7 @@ class TestUserTasksFilterSet:
     def setup(self):
         self.opp = OpportunityFactory()
         self.access = OpportunityAccessFactory(opportunity=self.opp, accepted=True)
-        self.task_type = TaskTypeFactory(app=self.opp.deliver_app, is_active=True)
+        self.task_type = TaskTypeFactory(app=self.opp.deliver_app, opportunity=self.opp, is_active=True)
 
     def _filterset(self, data):
         qs = AssignedTask.objects.filter(opportunity_access__opportunity=self.opp)
@@ -115,9 +115,9 @@ class TestUserTasksFilterSet:
         assert result[0].status == AssignedTaskStatus.ASSIGNED
 
     def test_task_type(self):
-        task_a = TaskTypeFactory(app=self.opp.deliver_app, is_active=True, name="Survey")
-        task_b = TaskTypeFactory(app=self.opp.deliver_app, is_active=True, name="Follow-up")
-        inactive = TaskTypeFactory(app=self.opp.deliver_app, is_active=False, name="Old")
+        task_a = TaskTypeFactory(app=self.opp.deliver_app, opportunity=self.opp, is_active=True, name="Survey")
+        task_b = TaskTypeFactory(app=self.opp.deliver_app, opportunity=self.opp, is_active=True, name="Follow-up")
+        inactive = TaskTypeFactory(app=self.opp.deliver_app, opportunity=self.opp, is_active=False, name="Old")
         AssignedTaskFactory(opportunity_access=self.access, task_type=task_a)
         AssignedTaskFactory(opportunity_access=self.access, task_type=task_b)
 

--- a/commcare_connect/opportunity/tests/test_filters.py
+++ b/commcare_connect/opportunity/tests/test_filters.py
@@ -56,8 +56,8 @@ def test_tasks_filterset_task_status_single():
 def test_tasks_filterset_task_type():
     opp = OpportunityFactory()
     access = OpportunityAccessFactory(opportunity=opp, accepted=True)
-    task_a = TaskTypeFactory(opportunity=opp, app=opp.deliver_app, is_active=True, name="Survey")
-    task_b = TaskTypeFactory(opportunity=opp, app=opp.deliver_app, is_active=True, name="Follow-up")
+    task_a = TaskTypeFactory(app=opp.deliver_app, is_active=True, name="Survey")
+    task_b = TaskTypeFactory(app=opp.deliver_app, is_active=True, name="Follow-up")
     AssignedTaskFactory(opportunity_access=access, task_type=task_a)
     AssignedTaskFactory(opportunity_access=access, task_type=task_b)
 
@@ -76,8 +76,8 @@ def test_tasks_filterset_task_type():
 @pytest.mark.django_db
 def test_tasks_filterset_task_type_excludes_inactive():
     opp = OpportunityFactory()
-    active_task = TaskTypeFactory(opportunity=opp, app=opp.deliver_app, is_active=True, name="Active")
-    inactive_task = TaskTypeFactory(opportunity=opp, app=opp.deliver_app, is_active=False, name="Inactive")
+    active_task = TaskTypeFactory(app=opp.deliver_app, is_active=True, name="Active")
+    inactive_task = TaskTypeFactory(app=opp.deliver_app, is_active=False, name="Inactive")
 
     qs = get_worker_tasks_base_queryset(opp)
     filterset = TasksFilterSet(data={}, queryset=qs, opportunity=opp)
@@ -93,7 +93,7 @@ class TestUserTasksFilterSet:
     def setup(self):
         self.opp = OpportunityFactory()
         self.access = OpportunityAccessFactory(opportunity=self.opp, accepted=True)
-        self.task_type = TaskTypeFactory(opportunity=self.opp, app=self.opp.deliver_app, is_active=True)
+        self.task_type = TaskTypeFactory(app=self.opp.deliver_app, is_active=True)
 
     def _filterset(self, data):
         qs = AssignedTask.objects.filter(opportunity_access__opportunity=self.opp)
@@ -115,9 +115,9 @@ class TestUserTasksFilterSet:
         assert result[0].status == AssignedTaskStatus.ASSIGNED
 
     def test_task_type(self):
-        task_a = TaskTypeFactory(opportunity=self.opp, app=self.opp.deliver_app, is_active=True, name="Survey")
-        task_b = TaskTypeFactory(opportunity=self.opp, app=self.opp.deliver_app, is_active=True, name="Follow-up")
-        inactive = TaskTypeFactory(opportunity=self.opp, app=self.opp.deliver_app, is_active=False, name="Old")
+        task_a = TaskTypeFactory(app=self.opp.deliver_app, is_active=True, name="Survey")
+        task_b = TaskTypeFactory(app=self.opp.deliver_app, is_active=True, name="Follow-up")
+        inactive = TaskTypeFactory(app=self.opp.deliver_app, is_active=False, name="Old")
         AssignedTaskFactory(opportunity_access=self.access, task_type=task_a)
         AssignedTaskFactory(opportunity_access=self.access, task_type=task_b)
 

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -929,6 +929,7 @@ class TestAddTaskTypeForm:
         task_type = form.save()
         assert task_type.slug == "task_1"
         assert task_type.app == opportunity.deliver_app
+        assert task_type.opportunity == opportunity
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_helpers.py
+++ b/commcare_connect/opportunity/tests/test_helpers.py
@@ -634,8 +634,8 @@ def test_filter_worker_tasks_by_task_status(opportunity):
 def test_filter_worker_tasks_by_task_type(opportunity):
     access = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
     UserInviteFactory(opportunity=opportunity, opportunity_access=access, status="accepted")
-    task_a = TaskTypeFactory(app=opportunity.deliver_app, is_active=True)
-    task_b = TaskTypeFactory(app=opportunity.deliver_app, is_active=True)
+    task_a = TaskTypeFactory(app=opportunity.deliver_app, opportunity=opportunity, is_active=True)
+    task_b = TaskTypeFactory(app=opportunity.deliver_app, opportunity=opportunity, is_active=True)
     AssignedTaskFactory(opportunity_access=access, task_type=task_a)
     AssignedTaskFactory(opportunity_access=access, task_type=task_b)
 

--- a/commcare_connect/opportunity/tests/test_helpers.py
+++ b/commcare_connect/opportunity/tests/test_helpers.py
@@ -634,8 +634,8 @@ def test_filter_worker_tasks_by_task_status(opportunity):
 def test_filter_worker_tasks_by_task_type(opportunity):
     access = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
     UserInviteFactory(opportunity=opportunity, opportunity_access=access, status="accepted")
-    task_a = TaskTypeFactory(opportunity=opportunity, app=opportunity.deliver_app, is_active=True)
-    task_b = TaskTypeFactory(opportunity=opportunity, app=opportunity.deliver_app, is_active=True)
+    task_a = TaskTypeFactory(app=opportunity.deliver_app, is_active=True)
+    task_b = TaskTypeFactory(app=opportunity.deliver_app, is_active=True)
     AssignedTaskFactory(opportunity_access=access, task_type=task_a)
     AssignedTaskFactory(opportunity_access=access, task_type=task_b)
 
@@ -648,7 +648,7 @@ def test_filter_worker_tasks_by_task_type(opportunity):
 def test_filter_worker_tasks_by_date_assigned_range(opportunity):
     access = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
     UserInviteFactory(opportunity=opportunity, opportunity_access=access, status="accepted")
-    task_type = TaskTypeFactory(opportunity=opportunity, app=opportunity.deliver_app, is_active=True)
+    task_type = TaskTypeFactory(app=opportunity.deliver_app, is_active=True)
     old_task = AssignedTaskFactory(opportunity_access=access, task_type=task_type)
     AssignedTask.objects.filter(pk=old_task.pk).update(date_created=date.today() - timedelta(days=30))
 

--- a/commcare_connect/static/js/alpine.js
+++ b/commcare_connect/static/js/alpine.js
@@ -1,6 +1,7 @@
 import Alpine from 'alpinejs';
 import Persist from '@alpinejs/persist';
 import Tooltip from '@ryangjchandler/alpine-tooltip';
+import './alpine_data';
 Alpine.plugin(Persist);
 Alpine.plugin(Tooltip);
 window.Alpine = Alpine;

--- a/commcare_connect/static/js/alpine_data.js
+++ b/commcare_connect/static/js/alpine_data.js
@@ -1,0 +1,22 @@
+// Provides state for a filter modal, including resetting form fields to current
+// URL params when the modal is closed without applying.
+function resetFilterModalState(formId) {
+  return {
+    showFilterModal: false,
+    closeFilter() {
+      const params = new URLSearchParams(window.location.search);
+      const form = document.getElementById(formId);
+      form.querySelectorAll('input[type=date]').forEach((el) => {
+        el.value = params.get(el.name) || '';
+      });
+      form.querySelectorAll('[data-tomselect]').forEach((el) => {
+        if (!el.tomselect) return;
+        const values = params.getAll(el.name);
+        el.tomselect.clear();
+        if (values.length) el.tomselect.setValue(values);
+      });
+      this.showFilterModal = false;
+    },
+  };
+}
+window.resetFilterModalState = resetFilterModalState;

--- a/commcare_connect/templates/components/filter_modal.html
+++ b/commcare_connect/templates/components/filter_modal.html
@@ -20,7 +20,7 @@
 {% endcomment %}
 
 {% load i18n crispy_forms_tags %}
-<div x-cloak x-data="{showFilterModal: false}" {% if container_class %}class="{{ container_class }}"{% endif %}>
+<div x-cloak x-data="resetFilterModalState('{{ form_id }}')" {% if container_class %}class="{{ container_class }}"{% endif %}>
     <button type="button" @click="showFilterModal = true" class="relative button-icon shadow-sm">
         <i class="fa-solid fa-sliders text-brand-deep-purple"></i>
         {% if filters_applied_count %}
@@ -33,7 +33,7 @@
         <div class="modal">
             <div class="header text-lg font-semibold text-brand-deep-purple">
                 <h1>{% trans "Filters" %}</h1>
-                <button @click="showFilterModal = false">
+                <button @click="closeFilter()">
                     <i class="fa-solid fa-xmark text-xl"></i>
                 </button>
             </div>
@@ -51,7 +51,7 @@
                     {% crispy filter_form %}
                 </div>
                 <div class="footer">
-                    <button type="button" @click="showFilterModal = false" class="button button-md outline-style">{% trans "Close" %}</button>
+                    <button type="button" @click="closeFilter()" class="button button-md outline-style">{% trans "Close" %}</button>
                     <button form="{{ form_id }}" type="submit" @click="showFilterModal = false" class="button button-md primary-dark">{% trans "Apply" %}</button>
                 </div>
             </form>

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -10,22 +10,8 @@
      x-data="{
        showCreateTaskModal: false,
        showEditTaskModal: false,
-       showFilterModal: false,
        editTaskError: false,
-       closeFilter() {
-         const params = new URLSearchParams(window.location.search);
-         const form = document.getElementById('userTaskFilterForm');
-         form.querySelectorAll('input[type=date]').forEach(el => {
-           el.value = params.get(el.name) || '';
-         });
-         form.querySelectorAll('[data-tomselect]').forEach(el => {
-           if (!el.tomselect) return;
-           const values = params.getAll(el.name);
-           el.tomselect.clear();
-           if (values.length) el.tomselect.setValue(values);
-         });
-         this.showFilterModal = false;
-       },
+       ...resetFilterModalState('userTaskFilterForm'),
        ...selectableTable()
      }"
   >

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -12,6 +12,20 @@
        showEditTaskModal: false,
        showFilterModal: false,
        editTaskError: false,
+       closeFilter() {
+         const params = new URLSearchParams(window.location.search);
+         const form = document.getElementById('userTaskFilterForm');
+         form.querySelectorAll('input[type=date]').forEach(el => {
+           el.value = params.get(el.name) || '';
+         });
+         form.querySelectorAll('[data-tomselect]').forEach(el => {
+           if (!el.tomselect) return;
+           const values = params.getAll(el.name);
+           el.tomselect.clear();
+           if (values.length) el.tomselect.setValue(values);
+         });
+         this.showFilterModal = false;
+       },
        ...selectableTable()
      }"
   >
@@ -44,7 +58,7 @@
     <div class="modal">
       <div class="header text-lg font-semibold text-brand-deep-purple">
         <h1>{% trans "Filters" %}</h1>
-        <button @click="showFilterModal = false">
+        <button @click="closeFilter()">
           <i class="fa-solid fa-xmark text-xl"></i>
         </button>
       </div>
@@ -54,7 +68,7 @@
           {% crispy filter_form %}
         </div>
         <div class="footer">
-          <button type="button" @click="showFilterModal = false" class="button button-md outline-style">{% trans "Close" %}</button>
+          <button type="button" @click="closeFilter()" class="button button-md outline-style">{% trans "Close" %}</button>
           <button form="userTaskFilterForm" type="submit" @click="showFilterModal = false" class="button button-md primary-dark">
             {% trans "Apply" %}
           </button>


### PR DESCRIPTION
## Product Description

Several bugs in the worker tasks tab have been fixed. The **Task Type** filter dropdown now correctly populates with the task types for the opportunity. The **Date Assigned** filter inputs no longer accept future dates, since assignment dates are always in the past. When closing the filter modal without applying, any in-progress filter changes are discarded and the filter fields revert to their last applied state — so unapplied edits never persist across modal opens.

<img width="501" height="530" alt="Screenshot_20260515_144907" src="https://github.com/user-attachments/assets/f5d2279d-ab8c-465f-a85c-73d2b314c739" />

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/QA-8509)

This is a release path 3 feature — Experiments & early stage iterations of product area

Three bugs in the tasks feature are fixed in this PR. The root cause of the task type filter being empty was that `TaskType.objects.filter(opportunity=...)` was used to build filter choices, but `TaskType.opportunity` is a nullable FK that is never set — task types are linked to an opportunity via `app = opportunity.deliver_app`. The filter queries are corrected to use `app`. `AddTaskTypeForm.save()` is also updated to populate the `opportunity` FK going forward so both paths are consistent. The modal close behaviour is handled client-side: on close, each filter field reads the current URL params and restores its applied value (or clears if absent), so Tom Select and date inputs stay in sync with what's actually active.

- **Filter choices fix** — `TasksFilterSet` and `UserTasksFilterSet` both queried `TaskType` via the nullable `opportunity` FK; corrected to `app=opportunity.deliver_app`, matching how every other view looks up task types for an opportunity.
- **`AddTaskTypeForm.save()`** — now sets `task_type.opportunity = self.opportunity` so newly created task types have the FK populated.
- **Date inputs capped at today** — both filter sets set `max = date.today().isoformat()` on `date_assigned_from` / `date_assigned_to` widgets in `__init__`, preventing future date selection in the browser picker. `date_assigned` is an annotation of `auto_now_add` so it can never be in the future.
- **Filter modal close** — replaces the previous "reset everything if nothing applied" logic with a per-field restore: on close, `URLSearchParams` is read and each date input / Tom Select is set to its applied value, discarding any unapplied edits while preserving active filters.

## Safety Assurance

### Safety story

All changes are read-path or form-save additions with no destructive data operations. The `opportunity` FK addition to `AddTaskTypeForm.save()` is additive and backward-compatible — existing task types with `opportunity=null` continue to work and are still found via the `app`-based filter. The date `max` constraint is browser-side only and does not add server-side validation (the filter accepts any valid date regardless). The modal close reset is entirely client-side with no server interaction.

Local testing was also performed on the changes in this PR.

### Automated test coverage

- **`test_tasks_filterset_task_type`** — verifies filter choices are populated and filtering works when task types are linked only via `app` (no `opportunity` FK set)
- **`test_tasks_filterset_task_type_excludes_inactive`** — verifies inactive task types are excluded from choices
- **`TestUserTasksFilterSet::test_task_type`** — same coverage for `UserTasksFilterSet`; factories updated to omit `opportunity=` to reflect real data
- **`test_filter_worker_tasks_by_task_type`** — helper-level test updated to use app-only task types
- **`TestAddTaskTypeForm::test_save_sets_slug_and_app`** — extended with `assert task_type.opportunity == opportunity`

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Navigate to an opportunity's worker tasks tab
- [ ] Open the filter modal — confirm the **Task Type** dropdown is populated with the opportunity's task types
- [ ] Select a task type and confirm the table filters correctly
- [ ] Open the filter modal — confirm the **Date Assigned From / To** pickers do not allow selecting a future date
- [ ] Enter a filter value without clicking Apply, then close the modal — confirm the field reverts to the previously applied value (or clears if nothing was applied)
- [ ] Apply a filter, reopen the modal, change a value, then close without applying — confirm the applied filter remains active and the changed value is discarded

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
