### PR TITLE
Only Show Active Task Types when Creating Task

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1895,7 +1895,7 @@ class CreateTaskForm(forms.Form):
     def __init__(self, *args, opportunity=None, access=None, **kwargs):
         super().__init__(*args, **kwargs)
         if opportunity is not None:
-            self.fields["task"].queryset = TaskType.objects.filter(app=opportunity.deliver_app)
+            self.fields["task"].queryset = TaskType.objects.filter(app=opportunity.deliver_app, is_active=True)
             self.fields["access"].queryset = OpportunityAccess.objects.filter(
                 opportunity=opportunity,
                 accepted=True,


### PR DESCRIPTION
## Product Description

When assigning a task to a worker, the **Task** dropdown in the Create Task form previously showed all task types including archived ones. It now only shows active task types, preventing invalid assignments.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/QA-8512)

This is a release path 3 feature — Experiments & early stage iterations of product area

- **Bug fix** — `CreateTaskForm.__init__` filtered `TaskType` by `app=opportunity.deliver_app` but omitted `is_active=True`, so archived task types appeared as selectable options. Added `is_active=True` to match the filter used everywhere else task type choices are built.

## Safety Assurance

### Safety story

Single-line queryset filter addition. No data mutations, no model changes. Existing assigned tasks referencing archived task types are unaffected — this only restricts what can be newly selected in the form.

### Automated test coverage

No new tests added — this is a one-line queryset guard on a form field. The `is_active` filtering behaviour is already covered by `test_tasks_filterset_task_type_excludes_inactive` and `TestUserTasksFilterSet::test_task_type` for the analogous filter sets.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Navigate to a worker's tasks tab on an opportunity that has at least one archived task type
- [ ] Open the Create Task form and confirm the **Task** dropdown does not include the archived task type
- [ ] Confirm active task types still appear correctly in the dropdown
- [ ] Create a task using an active task type and confirm it saves successfully

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change