### PR TITLE
Reset Create Task Type Form on Close

### DIFF
--- a/commcare_connect/templates/opportunity/new_task_type_modal.html
+++ b/commcare_connect/templates/opportunity/new_task_type_modal.html
@@ -12,7 +12,7 @@
             </button>
         </div>
 
-        <form method="post"
+        <form method="post" x-ref="createTaskForm"
             action="{% url 'opportunity:task_types_config' request.org.slug opportunity.opportunity_id %}">
             {% csrf_token %}
             <div class="modal-body">

--- a/commcare_connect/templates/opportunity/task_types_config.html
+++ b/commcare_connect/templates/opportunity/task_types_config.html
@@ -9,6 +9,7 @@
 {% include 'components/breadcrumbs.html' with path=path %}
 
 <div class="container md:max-w-screen-lg mx-auto flex flex-col gap-6"
+     x-init="$watch('showCreateTaskTypeModal', val => { if (!val) $refs.createTaskForm.reset() })"
      x-data="{
        showCreateTaskTypeModal: {% if form.errors %}true{% else %}false{% endif %},
        showEditTaskTypeModal: false,


### PR DESCRIPTION
## Product Description

When filling out the "Add New Task Type" modal and then closing it (via the X button, Cancel, Escape, or clicking outside), the form fields now reset to their empty defaults instead of retaining the previously entered values.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/QA-8507)
This is a release path 3 feature — Experiments & early stage iterations of product area

Two small template changes wire up an Alpine.js `$watch` to call the native `form.reset()` whenever the create-task-type modal closes. An `x-ref="createTaskForm"` attribute was added to the `<form>` element in the modal, and an `x-init` with a `$watch` on `showCreateTaskTypeModal` was added to the parent Alpine component. This approach handles all four close paths (X button, Cancel button, Escape key, click-outside) in a single place without needing to modify each individual close trigger.

- **Reset mechanism:** `$watch('showCreateTaskTypeModal', val => { if (!val) $refs.createTaskForm.reset() })` — uses the browser-native `HTMLFormElement.reset()` to clear all fields
- **Scope:** Only affects the "Add New Task Type" modal; the edit modal is unchanged

## Safety Assurance

### Safety story

This is a pure UI change with no backend impact. The reset only fires on close, not on submit. If the modal is opened after a validation error (where Django re-renders with `form.errors` and sets `showCreateTaskTypeModal: true`), the form will already contain the submitted values — the watch fires only when the modal transitions from open to closed, so it does not interfere with that error-display flow.

### Automated test coverage

No automated tests added — this is a frontend-only interaction with no business logic. The existing backend view tests cover the form submission path and are unaffected.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Navigate to the "Configure Task Types" page for an opportunity
- [ ] Click "Add New Task Type" to open the modal
- [ ] Fill in values for Task Unit, Name, Description, and Case Property
- [ ] Close the modal using the X button — verify all fields are empty when reopened
- [ ] Repeat the above, this time closing via the Cancel button
- [ ] Repeat closing via the Escape key
- [ ] Repeat closing by clicking outside the modal
- [ ] Confirm that submitting the form with a validation error still shows the entered values (modal stays open with errors)

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
