### PR TITLE
Hide Overflow Tab Arrows if Not Overflowing

### DIFF
--- a/tailwind/tailwind.css
+++ b/tailwind/tailwind.css
@@ -718,7 +718,7 @@
 
 .better-tabs {
   .tabs {
-    @apply flex h-full gap-x-8 overflow-x-scroll px-2;
+    @apply flex h-full gap-x-8 overflow-x-auto px-2;
   }
 
   .tab {


### PR DESCRIPTION
## Product Description

The tab navigation component (e.g. Visits / Tasks tabs on the worker page) previously showed scroll arrows at all times due to `overflow-x-scroll`, even when there were only two tabs and no overflow was needed. Changing to `overflow-x-auto` ensures the scrollbar and arrows only appear when the tab list actually overflows its container.

Old:
<img width="537" height="362" alt="Screenshot_20260518_165638" src="https://github.com/user-attachments/assets/f80d9853-fea0-4255-9eff-72237d7fe47b" />

New:
<img width="537" height="362" alt="Screenshot_20260518_165621" src="https://github.com/user-attachments/assets/65404b28-1f5b-4be8-9572-a1d588d762b7" />

## Technical Summary

[Link to ticket](https://dimagi.atlassian.net/browse/QA-8518)

This is a release path 3 feature — Experiments & early stage iterations of product area

- **CSS fix:** Changed `overflow-x-scroll` → `overflow-x-auto` in the `.better-tabs .tabs` rule in `tailwind/tailwind.css`. `overflow-x-scroll` forces scroll UI (including navigation arrows) to always render; `overflow-x-auto` shows it only when content overflows.

## Safety Assurance

### Safety story

Pure CSS change with no logic or data impact. Visually verified locally — arrows no longer appear with two tabs, and scrolling still works when tabs overflow the container width.

### Automated test coverage

No automated test coverage applicable — this is a visual/CSS-only change.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Navigate to a worker page that shows the Visits / Tasks tab bar
- [ ] Confirm no scroll arrows appear when only two tabs are visible
- [ ] Confirm the tab bar still scrolls horizontally if many tabs are present and the container is narrow

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
