### PR TITLE
Update URL Reference for Dashboard Tasks

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3158,7 +3158,7 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
         },
     ]
 
-    tasks_url = reverse("opportunity:worker_tasks", args=(org_slug, opp_id))
+    tasks_url = reverse("opportunity:assigned_task_list", args=(org_slug, opp_id))
     opp_stats = [
         {
             "title": _("Connect Workers"),


### PR DESCRIPTION
## Product Description

Updates the "Tasks" link on the opportunity delivery stats dashboard to point to the task list page instead of the worker tasks page. This ensures the dashboard directs users to the correct page when viewing tasks for an opportunity.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2412)
This is a release path 3 feature — Experiments & early stage iterations of product area

- **URL fix:** Changed the `tasks_url` in `opportunity_delivery_stats` from resolving `opportunity:worker_tasks` to `opportunity:assigned_task_list`, aligning the dashboard link with the correct task list view.

## Safety Assurance

### Safety story

This is a single-line URL reversal change — no data, logic, or model changes are involved. The `assigned_task_list` URL pattern already exists and is in active use. The change only affects where the "Tasks" link in the delivery stats dashboard navigates to.

### Automated test coverage

No new tests added — the change is a trivial URL reference correction with no logic to unit test.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Navigate to an opportunity's delivery stats dashboard
- [ ] Click the "Tasks" link/button
- [ ] Verify it navigates to the assigned task list page (not the worker tasks page)

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change