### PR TITLE
Refactor bulk HQ case update helpers for clarity and safety

### DIFF
--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -178,6 +178,9 @@ def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> N
 
     All entries in `updates` must belong to the same opportunity. The domain, API key, and
     HQ server are derived from the first entry and applied to the entire batch.
+
+    The value for each key is a case update payload. In practice callers only set
+    ``"properties"``, e.g. ``{"properties": {"some_property": "value"}}``.
     """
     if not updates:
         return

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -110,10 +110,10 @@ def bulk_create_or_update_cases_by_work_areas(
     for wa in work_areas:
         case_data = dict(WorkAreaCaseSerializer(wa).data)
         case_data["owner_id"] = owner_id_by_username[wa.opportunity_access.user.username.lower()]
-        case_data["create"] = None  # UPSERT: HQ decides create vs update via external_id
         cases_data.append(case_data)
 
-    cases = bulk_create_or_update_cases(api_key, domain, cases_data)
+    # create=None is the UPSERT mode: HQ decides create vs update via external_id
+    cases = bulk_create_or_update_cases(api_key, domain, cases_data, create=None)
 
     wa_by_id = {str(wa.pk): wa for wa in work_areas if wa.case_id is None}
     newly_created = []
@@ -132,13 +132,14 @@ def bulk_create_or_update_cases(
     api_key: HQApiKey,
     domain: str,
     cases_data: list[dict[str, Any]],
+    create: bool | None,
 ) -> list[CommCareCase]:
     url = f"{api_key.hq_server.url}/a/{domain}/api/case/v2/"
     headers = {"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"}
     cases = []
     with httpx.Client(headers=headers) as client:
         for i in range(0, len(cases_data), HQ_CASE_BULK_CHUNK_SIZE):
-            chunk = cases_data[i : i + HQ_CASE_BULK_CHUNK_SIZE]  # noqa: E203
+            chunk = [{**case, "create": create} for case in cases_data[i : i + HQ_CASE_BULK_CHUNK_SIZE]]  # noqa: E203
             try:
                 response = client.post(url, json=chunk)
                 response.raise_for_status()
@@ -208,9 +209,9 @@ def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> N
             link.save()
         else:
             hq_case_id = link.hq_case_id
-        cases_data.append({"case_id": hq_case_id, "create": False, **data})
+        cases_data.append({"case_id": hq_case_id, **data})
 
-    bulk_create_or_update_cases(api_key, domain, cases_data)
+    bulk_create_or_update_cases(api_key, domain, cases_data, create=False)
 
 
 def get_usercase(opportunity_access: OpportunityAccess) -> CommCareCase:

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -45,6 +45,7 @@ def get_case_list(api_key: HQApiKey, domain: str, filters: GetCaseDataAPIFilters
     with httpx.Client(
         base_url=api_key.hq_server.url,
         headers={"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"},
+        timeout=300,
     ) as client:
         while url is not None:
             try:
@@ -137,7 +138,7 @@ def bulk_create_or_update_cases(
     url = f"{api_key.hq_server.url}/a/{domain}/api/case/v2/"
     headers = {"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"}
     cases = []
-    with httpx.Client(headers=headers) as client:
+    with httpx.Client(headers=headers, timeout=300) as client:
         for i in range(0, len(cases_data), HQ_CASE_BULK_CHUNK_SIZE):
             chunk = [{**case, "create": create} for case in cases_data[i : i + HQ_CASE_BULK_CHUNK_SIZE]]  # noqa: E203
             try:
@@ -159,7 +160,7 @@ def create_or_update_case(
     headers = {"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"}
 
     try:
-        with httpx.Client(base_url=base_url, headers=headers) as client:
+        with httpx.Client(base_url=base_url, headers=headers, timeout=300) as client:
             if case_id:
                 error_msg = f"Failed to update case data for {domain} with {case_id}."
                 response = client.put(f"{case_id}/", json=case_data)

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -183,8 +183,11 @@ def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> N
         return
 
     first_access = next(iter(updates))
-    domain = first_access.opportunity.deliver_app.cc_domain
-    api_key = first_access.opportunity.api_key
+    opportunity = first_access.opportunity
+    if any(access.opportunity_id != opportunity.id for access in updates.keys()):
+        raise ValueError("All entries in `updates` must belong to the same opportunity.")
+    domain = opportunity.deliver_app.cc_domain
+    api_key = opportunity.api_key
     hq_server = api_key.hq_server
 
     users = [access.user for access in updates]

--- a/commcare_connect/commcarehq/tests/test_api.py
+++ b/commcare_connect/commcarehq/tests/test_api.py
@@ -135,4 +135,18 @@ class TestBulkUpdateUsercases:
         mock_get_usercase.assert_called_once_with(access)
         mock_bulk.assert_called_once()
         cases_data = mock_bulk.call_args[0][2]
-        assert cases_data == [{"case_id": hq_case_id, "create": False, "properties": {"prop": "value"}}]
+        assert cases_data == [{"case_id": hq_case_id, "properties": {"prop": "value"}}]
+        assert mock_bulk.call_args[1]["create"] is False
+
+    def test_raises_when_updates_span_multiple_opportunities(self):
+        api_key = HQApiKeyFactory(hq_server=HQServerFactory())
+        access_a = OpportunityAccessFactory(opportunity__api_key=api_key)
+        access_b = OpportunityAccessFactory(opportunity__api_key=api_key)
+
+        with pytest.raises(ValueError, match="same opportunity"):
+            bulk_update_usercases(
+                {
+                    access_a: {"properties": {"prop": "1"}},
+                    access_b: {"properties": {"prop": "1"}},
+                }
+            )

--- a/commcare_connect/microplanning/helpers.py
+++ b/commcare_connect/microplanning/helpers.py
@@ -44,11 +44,11 @@ def exclude_work_areas_for_opportunity(opportunity, work_area_ids, user, exclusi
     for i in range(0, len(needs_hq), HQ_BULK_CHUNK_SIZE):
         chunk = needs_hq[i : i + HQ_BULK_CHUNK_SIZE]  # noqa: E203
         # HQ's "unassigned" convention is "-"; empty string falls back to the submitting user.
-        updates = [{"case_id": str(wa.case_id), "owner_id": "-", "create": False} for wa in chunk]
+        updates = [{"case_id": str(wa.case_id), "owner_id": "-"} for wa in chunk]
         try:
             with transaction.atomic(), pghistory.context(**pghistory_ctx):
                 _bulk_exclude(chunk, user, exclusion_reason)
-                bulk_create_or_update_cases(api_key, domain, updates)
+                bulk_create_or_update_cases(api_key, domain, updates, create=False)
         except CommCareHQAPIException as e:
             logger.warning("Failed to unassign HQ case chunk (size=%d): %s", len(chunk), e)
             failed += len(chunk)

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -478,7 +478,7 @@ class AssignedTask(XFormBaseModel):
 
     @classmethod
     def bulk_delete(cls, task_ids: list[int], opportunity: Opportunity) -> int:
-        from commcare_connect.commcarehq.api import HQ_CASE_BULK_CHUNK_SIZE, bulk_update_usercases
+        from commcare_connect.commcarehq.api import bulk_update_usercases
 
         tasks = list(
             cls.objects.filter(
@@ -491,36 +491,54 @@ class AssignedTask(XFormBaseModel):
         if not tasks:
             return 0
 
-        hq_updates: dict[tuple[int, str], OpportunityAccess] = {}
-        for task in tasks:
-            if prop := task.task_type.case_property:
-                hq_updates.setdefault((task.opportunity_access_id, prop), task.opportunity_access)
+        hq_updates = cls._collect_hq_updates(tasks)
 
         with transaction.atomic():
             deleted_count, _ = (
                 cls.objects.filter(pk__in=[t.pk for t in tasks]).exclude(status=AssignedTaskStatus.COMPLETED).delete()
             )
-            if hq_updates:
-                still_assigned = set(
-                    cls.objects.filter(
-                        opportunity_access_id__in={access_id for access_id, _ in hq_updates},
-                        status=AssignedTaskStatus.ASSIGNED,
-                        task_type__case_property__in={p for _, p in hq_updates},
-                    ).values_list("opportunity_access_id", "task_type__case_property")
-                )
-                to_reset: dict[OpportunityAccess, dict] = {}
-                for access_id, prop in hq_updates.keys() - still_assigned:
-                    access = hq_updates[access_id, prop]
-                    to_reset.setdefault(access, {"properties": {}})["properties"][prop] = ""
-                if len(to_reset) > HQ_CASE_BULK_CHUNK_SIZE:
-                    raise ListTooLongError(
-                        f"Too many HQ case property resets ({len(to_reset)}); "
-                        "split the delete into smaller batches."
-                    )
-                if to_reset:
-                    bulk_update_usercases(to_reset)
+            to_reset = cls._compute_hq_resets(hq_updates)
+            if to_reset:
+                bulk_update_usercases(to_reset)
 
         return deleted_count
+
+    @classmethod
+    def _collect_hq_updates(cls, tasks: list[AssignedTask]) -> dict[tuple[int, str], OpportunityAccess]:
+        """Map (opportunity_access_id, case_property) -> OpportunityAccess for tasks with an HQ case property."""
+        hq_updates: dict[tuple[int, str], OpportunityAccess] = {}
+        for task in tasks:
+            if prop := task.task_type.case_property:
+                hq_updates.setdefault((task.opportunity_access_id, prop), task.opportunity_access)
+        return hq_updates
+
+    @classmethod
+    def _compute_hq_resets(cls, hq_updates: dict[tuple[int, str], OpportunityAccess]) -> dict[OpportunityAccess, dict]:
+        """Return case property resets for any (access, property) pairs no longer covered by an assigned task."""
+        from commcare_connect.commcarehq.api import HQ_CASE_BULK_CHUNK_SIZE
+
+        if not hq_updates:
+            return {}
+
+        still_assigned = set(
+            cls.objects.filter(
+                opportunity_access_id__in={access_id for access_id, _ in hq_updates},
+                status=AssignedTaskStatus.ASSIGNED,
+                task_type__case_property__in={p for _, p in hq_updates},
+            ).values_list("opportunity_access_id", "task_type__case_property")
+        )
+
+        to_reset: dict[OpportunityAccess, dict] = {}
+        for access_id, prop in hq_updates.keys() - still_assigned:
+            access = hq_updates[access_id, prop]
+            to_reset.setdefault(access, {"properties": {}})["properties"][prop] = ""
+
+        if len(to_reset) > HQ_CASE_BULK_CHUNK_SIZE:
+            raise ListTooLongError(
+                f"Too many HQ case property resets ({len(to_reset)}); " "split the delete into smaller batches."
+            )
+
+        return to_reset
 
 
 class Assessment(XFormBaseModel):


### PR DESCRIPTION
## Product Description

Internal refactor of the CommCare HQ bulk case update API layer — no user-facing changes.

## Technical Summary

[CCCT-2511](https://dimagi.atlassian.net/browse/CCCT-2511)

This is a release path 3 feature — Experiments & early stage iterations of product area

These changes were inspired from the feedback received in [this](https://github.com/dimagi/commcare-connect/pull/1174) related PR.

Small clean-up pass on the `bulk_create_or_update_cases` / `bulk_update_usercases` API helpers to improve correctness and readability. The main changes are: moving the `"create"` field injection into the function that makes the HQ call (rather than each call site building it manually), adding a guard to `bulk_update_usercases` to catch misuse with mixed-opportunity inputs, and splitting the dense `AssignedTask.bulk_delete` method into focused private helpers.

- **`bulk_create_or_update_cases` — `create` param:** The `"create"` field (which controls HQ's create/update/UPSERT behaviour) was previously assembled by each caller into its case dicts. It is now a typed parameter (`bool | None`) on `bulk_create_or_update_cases` itself and injected centrally, so callers no longer need to know about the HQ API detail.
- **`bulk_update_usercases` — same-opportunity guard:** Added a `ValueError` if the `updates` dict contains `OpportunityAccess` entries from more than one opportunity. Previously the function silently derived domain/API key from the first entry and applied it to all, which would produce incorrect HQ calls if callers passed mixed data.
- **`AssignedTask.bulk_delete` — decomposition:** Extracted `_collect_hq_updates` (builds the `(access_id, property) → OpportunityAccess` index) and `_compute_hq_resets` (post-delete query to determine which properties need clearing) from the single `bulk_delete` method, making each step independently readable and testable.
- **Docstring improvements:** `bulk_update_usercases` now documents the expected shape of the `updates` values and the same-opportunity constraint.

## Safety Assurance

### Safety story

Pure internal refactor — no changes to data models, migrations, or user-facing behaviour. The `"create"` field previously set manually by callers is now set by the same values in the same places, just centrally. The new `ValueError` in `bulk_update_usercases` turns a previously silent bug (wrong domain/key applied to a mixed batch) into a loud failure. `AssignedTask.bulk_delete` logic is unchanged; only its structure differs.

### Automated test coverage

- **`TestBulkUpdateUsercases.test_falls_back_to_get_usercase_when_link_missing`** — updated to assert `create=False` is passed as a kwarg to `bulk_create_or_update_cases` rather than embedded in `cases_data`.
- **`TestBulkUpdateUsercases.test_raises_when_updates_span_multiple_opportunities`** — new test covering the same-opportunity `ValueError` guard.
- **`TestAssignedTaskDeleteAndResetHQ`** — existing suite (8 tests) continues to cover `bulk_delete` end-to-end through the refactored helpers with no changes needed.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Assign a task to a user with a `case_property` set — confirm the HQ usercase property is set to `"1"`.
- [ ] Delete that assigned task — confirm the HQ usercase property is reset to `""`.
- [ ] Delete a task where another assigned task for the same property still exists — confirm no HQ reset call is made.
- [ ] Exclude a work area with an HQ case — confirm the `owner_id` is set to `"-"` in HQ.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2401]: https://dimagi.atlassian.net/browse/CCCT-2401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCCT-2511]: https://dimagi.atlassian.net/browse/CCCT-2511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ