### PR TITLE
Group task

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -37,6 +37,7 @@ from commcare_connect.utils.tables import (
     TEXT_CENTER_ATTR,
     DMYTColumn,
     DurationColumn,
+    GroupedTable,
     IndexColumn,
     OrgContextTable,
     merge_attrs,
@@ -1369,14 +1370,18 @@ class GroupedByWorkerMixin:
         return next(self._row_counter)
 
 
-class WorkerTasksTable(GroupedByWorkerMixin, OrgContextTable):
+class WorkerTasksTable(GroupedTable, OrgContextTable):
     index = IndexColumn()
     worker_status = StatusIndicatorColumn(verbose_name=_("Status"), empty_values=())
-    user = tables.Column(verbose_name=_("Name"), orderable=True, order_by="user__name")
+    user = UserInfoColumn(verbose_name=_("Name"), orderable=True, order_by="user__name")
     task_name = tables.Column(verbose_name=_("Task Name"), empty_values=())
     date_assigned = DMYTColumn(verbose_name=_("Date Assigned"))
     due_date = DMYTColumn(verbose_name=_("Due Date"), accessor="task_due_date")
     task_status = TaskStatusColumn(verbose_name=_("Task Status"), empty_values=())
+
+    group_item_order_by = ("user__name", "assignedtask__date_created")
+    header_columns = ("index", "worker_status", "user")
+    group_item_label = (gettext_lazy("task"), gettext_lazy("tasks"))
 
     class Meta:
         fields = ()
@@ -1390,24 +1395,12 @@ class WorkerTasksTable(GroupedByWorkerMixin, OrgContextTable):
             "due_date",
             "task_status",
         )
-        row_attrs = {"class": "group"}
         empty_text = gettext_lazy("No tasks assigned for this opportunity.")
+        template_name = "grouped_table.html"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, data, *args, **kwargs):
         self.opp_id = kwargs.pop("opp_id")
-        super().__init__(*args, **kwargs)
-
-    def render_worker_status(self, record, value):
-        if self._is_seen(record):
-            return ""
-        return StatusIndicatorColumn.render(self.columns["worker_status"].column, record)
-
-    def render_task_name(self, value):
-        return value
-
-    def render_task_status(self, value, record):
-        self.run_after_every_row(record)
-        return TaskStatusColumn.render(self.columns["task_status"].column, value)
+        super().__init__(data, *args, **kwargs)
 
 
 class WorkerLearnTable(OrgContextTable):

--- a/commcare_connect/opportunity/tests/test_tables.py
+++ b/commcare_connect/opportunity/tests/test_tables.py
@@ -1,12 +1,10 @@
-import inspect
-
 import pytest
 from django.test import RequestFactory
 from django_tables2 import RequestConfig
 
 from commcare_connect.opportunity.helpers import get_worker_tasks_base_queryset
 from commcare_connect.opportunity.models import AssignedTaskStatus
-from commcare_connect.opportunity.tables import GroupedByWorkerMixin, WorkerDeliveryTable, WorkerTasksTable
+from commcare_connect.opportunity.tables import WorkerTasksTable
 from commcare_connect.opportunity.tests.factories import (
     AssignedTaskFactory,
     OpportunityAccessFactory,
@@ -50,18 +48,3 @@ def test_worker_tasks_table_empty(opportunity):
     table = _make_table(opportunity)
     rows = list(table.rows)
     assert len(rows) == 0
-
-
-@pytest.mark.parametrize(
-    "table_cls",
-    [WorkerTasksTable, WorkerDeliveryTable],
-)
-def test_last_column_calls_run_after_every_row(table_cls):
-    """The last column in Meta.sequence must call run_after_every_row to
-    ensure GroupedByWorkerMixin tracks seen workers correctly."""
-    assert issubclass(table_cls, GroupedByWorkerMixin)
-    last_col = table_cls.Meta.sequence[-1]
-    render_method = getattr(table_cls, f"render_{last_col}", None)
-    assert render_method is not None, f"{table_cls.__name__} has no render_{last_col}"
-    source = inspect.getsource(render_method)
-    assert "run_after_every_row" in source, f"{table_cls.__name__}.render_{last_col} must call run_after_every_row"

--- a/commcare_connect/templates/grouped_table.html
+++ b/commcare_connect/templates/grouped_table.html
@@ -1,0 +1,56 @@
+{% extends "base_table.html" %}
+{% load l10n %}
+
+{% block table.tbody %}
+  {% for row in table.paginated_rows %}
+  <tbody x-data="{open: false}">
+
+    <tr @click="open = !open" class="cursor-pointer select-none">
+      {% block group_header_row %}
+        {% for column, cell in row.items %}
+          {% if column.name in table.header_columns %}
+            <td {{ column.attrs.td.as_html }}>
+              {% if column.localize == None %}{{ cell }}
+              {% elif column.localize %}{{ cell|localize }}
+              {% else %}{{ cell|unlocalize }}{% endif %}
+            </td>
+          {% endif %}
+        {% endfor %}
+      {% endblock group_header_row %}
+      {% block group_header_extra %}
+        <td colspan="{{ table.non_header_column_count }}" class="pr-4">
+          <div class="flex items-center justify-end gap-2">
+            {% if table.group_item_label %}
+              {% with count=row.record.sub_rows|length %}
+                <span class="text-xs text-slate-400">{{ count }} {% if count == 1 %}{{ table.group_item_label.0 }}{% else %}{{ table.group_item_label.1 }}{% endif %}</span>
+              {% endwith %}
+            {% endif %}
+            <i class="fa-solid fa-chevron-down text-slate-400 transition-transform duration-200" :class="{'rotate-180': open}"></i>
+          </div>
+        </td>
+      {% endblock group_header_extra %}
+    </tr>
+
+    {% for sub_row in row.record.sub_rows %}
+    <tr x-show="open" x-cloak>
+      {% block group_item_row %}
+        {% for column, cell in sub_row.items %}
+          <td {{ column.attrs.td.as_html }}>
+            {% if column.localize == None %}{{ cell }}
+            {% elif column.localize %}{{ cell|localize }}
+            {% else %}{{ cell|unlocalize }}{% endif %}
+          </td>
+        {% endfor %}
+      {% endblock group_item_row %}
+    </tr>
+    {% endfor %}
+
+  </tbody>
+  {% empty %}
+  <tbody>
+    <tr>
+      <td colspan="{{ table.columns|length }}" class="text-center py-4">{{ table.empty_text }}</td>
+    </tr>
+  </tbody>
+  {% endfor %}
+{% endblock table.tbody %}

--- a/commcare_connect/utils/tables.py
+++ b/commcare_connect/utils/tables.py
@@ -1,9 +1,12 @@
 import datetime
 import itertools
 from datetime import timedelta
+from functools import cached_property
 
 import django_tables2 as tables
 from django.utils.timezone import is_aware, localtime  # For timezone handling
+from django_tables2.data import TableQuerysetData
+from django_tables2.rows import BoundRow
 
 STOP_CLICK_PROPAGATION_ATTR = {"td": {"@click.stop": ""}}
 TEXT_CENTER_ATTR = {"td": {"class": "text-center"}}
@@ -111,6 +114,80 @@ def get_validated_page_size(request):
         return page_size if page_size in PAGE_SIZE_OPTIONS else DEFAULT_PAGE_SIZE
     except (ValueError, TypeError):
         return DEFAULT_PAGE_SIZE
+
+
+class GroupedTableData(TableQuerysetData):
+    """Data source for `GroupedTable`. Paginates by distinct `pk` count, then
+    groups rows for each page into one head row per pk with a `sub_rows` list.
+    """
+
+    @cached_property
+    def _pks(self):
+        return list(dict.fromkeys(self.data.values_list("pk", flat=True)))
+
+    def order_by(self, aliases):
+        self.__dict__.pop("_pks", None)
+        super().order_by(aliases)
+
+    def __len__(self):
+        return len(self._pks)
+
+    def __iter__(self):
+        return iter(self._build_page(self._pks))
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            key = slice(key, key + 1)
+        return self._build_page(self._pks[key])
+
+    def _build_page(self, pks):
+        table = self.table
+        qs = self.data.filter(pk__in=pks)
+        if table.group_item_order_by:
+            qs = qs.order_by(*table.group_item_order_by)
+        groups: dict = {}
+        for row in qs:
+            if row.pk not in groups:
+                row.sub_rows = []
+                groups[row.pk] = row
+            groups[row.pk].sub_rows.append(table.SubBoundRow(record=row, table=table))
+        return [groups[pk] for pk in pks if pk in groups]
+
+
+class GroupedTable(tables.Table):
+    """A table where rows are grouped by `pk` into collapsible sections.
+    Each group renders as one clickable header row with sub-rows hidden beneath
+    it. Pagination counts groups, not individual rows — so a page size of 20
+    shows 20 headers, regardless of how many sub-rows they expand to.
+
+    Subclasses define:
+      - columns: as usual for django-tables2.
+      - `header_columns`: names of columns shown once in the group header row;
+        sub-rows leave these blank.
+      - `group_item_order_by`: ordering applied to rows within each group.
+      - `Meta`: standard django-tables2 Meta (template_name, etc.).
+
+    Pass a raw queryset — it is auto-wrapped into `GroupedTableData`.
+    """
+
+    group_item_order_by = ()
+    header_columns = ()
+    group_item_label = ()  # (singular, plural) — already translated; shown next to the count
+
+    class SubBoundRow(BoundRow):
+        def get_cell(self, name):
+            if name in self.table.header_columns:
+                return ""
+            return super().get_cell(name)
+
+    @property
+    def non_header_column_count(self):
+        return sum(1 for c in self.columns if c.name not in self.header_columns)
+
+    def __init__(self, data, *args, **kwargs):
+        if not isinstance(data, GroupedTableData):
+            data = GroupedTableData(data)
+        super().__init__(data, *args, **kwargs)
 
 
 def select_column(th_extra=None, td_extra=None):


### PR DESCRIPTION
## Product Description

<video src="https://github.com/user-attachments/assets/5732378b-35d8-4a6c-8c06-21332c358bab"></video>


## Technical Summary

**https://dimagi.atlassian.net/browse/CCCT-2406 - **RP-3****
[Connect-tech-demo link](https://dimagi.slack.com/archives/C09H7D1V1NK/p1779202353685859)

A new reusable `GroupedTable` base class and companion `GroupedTableData` were added to `commcare_connect/utils/tables.py`. The new implementation groups queryset rows by `pk`, paginates based on distinct group headers instead of individual rows, and builds each page into grouped head rows with their corresponding sub-rows. A new `grouped_table.html` template renders these groups as Alpine.js-powered accordion rows.

`WorkerTasksTable` was migrated from the old `GroupedByWorkerMixin` to the new stateless `GroupedTable`. This removes the previous fragile ordering dependency, where tables had to manually call `run_after_every_row` in the final render method and rely on stateful tracking of seen workers.


## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
 All existing tests continue to pass. One test was removed because it validated behaviour specific to the old implementation (`run_after_every_row`), which no longer exists in the new stateless `GroupedTable` implementation.


### QA Plan
Not needed

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
