### PR TITLE
CI-670: Fix feature flag leaking across orgs

### DIFF
--- a/commcare_connect/flags/models.py
+++ b/commcare_connect/flags/models.py
@@ -66,8 +66,28 @@ class Flag(AbstractUserFlag):
         user = getattr(request, "user", None)
         if not (user and user.is_authenticated):
             return False
-        active_flags_query = cls.active_flags_for_user(user, include_role_flags=True).filter(name=flag_name)
-        return active_flags_query.exists()
+        try:
+            flag = cls.objects.get(name=flag_name)
+        except cls.DoesNotExist:
+            return False
+
+        if flag.everyone:
+            return True
+        if flag.staff and user.is_staff:
+            return True
+        if flag.superusers and user.is_superuser:
+            return True
+        if flag.users.filter(pk=user.pk).exists():
+            return True
+
+        opportunity = getattr(request, "opportunity", None)
+        if opportunity and flag.is_active_for(opportunity):
+            return True
+        org = getattr(request, "org", None)
+        if org and flag.is_active_for(org):
+            return True
+
+        return False
 
     def is_active_for(self, obj: Organization | Opportunity | Program):
         if isinstance(obj, Organization):

--- a/commcare_connect/flags/models.py
+++ b/commcare_connect/flags/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models.signals import m2m_changed
 from django.utils.translation import gettext_lazy
 from waffle.models import CACHE_EMPTY, AbstractUserFlag
 from waffle.utils import get_cache, get_setting, keyfmt
@@ -126,3 +127,19 @@ class Flag(AbstractUserFlag):
 
         cache.add(cache_key, ids)
         return ids
+
+
+def _flush_flag_relation_cache(sender, instance, action, **kwargs):
+    from waffle.signals import flag_membership_changed
+
+    flag_membership_changed(sender, instance, action, **kwargs)
+
+
+# Ties the custom flag relationships to the m2m_changed signal
+# to ensure flag's cache is cleared after editing
+for _relation in ("organizations", "opportunities", "programs"):
+    m2m_changed.connect(
+        _flush_flag_relation_cache,
+        sender=getattr(Flag, _relation).through,
+        dispatch_uid=f"commcare_connect.flag.{_relation}.through",
+    )

--- a/commcare_connect/flags/models.py
+++ b/commcare_connect/flags/models.py
@@ -84,6 +84,9 @@ class Flag(AbstractUserFlag):
         opportunity = getattr(request, "opportunity", None)
         if opportunity and flag.is_active_for(opportunity):
             return True
+        program = _get_program_for_opportunity(opportunity)
+        if program and flag.is_active_for(program):
+            return True
         org = getattr(request, "org", None)
         if org and flag.is_active_for(org):
             return True
@@ -127,6 +130,13 @@ class Flag(AbstractUserFlag):
 
         cache.add(cache_key, ids)
         return ids
+
+
+def _get_program_for_opportunity(opportunity):
+    if not (opportunity and opportunity.managed):
+        return None
+    managed_opp = getattr(opportunity, "managedopportunity", None)
+    return managed_opp.program if managed_opp else None
 
 
 def _flush_flag_relation_cache(sender, instance, action, **kwargs):

--- a/commcare_connect/flags/models.py
+++ b/commcare_connect/flags/models.py
@@ -67,9 +67,8 @@ class Flag(AbstractUserFlag):
         user = getattr(request, "user", None)
         if not (user and user.is_authenticated):
             return False
-        try:
-            flag = cls.objects.get(name=flag_name)
-        except cls.DoesNotExist:
+        flag = cls.get(flag_name)
+        if flag.pk is None:
             return False
 
         if flag.everyone:
@@ -78,7 +77,7 @@ class Flag(AbstractUserFlag):
             return True
         if flag.superusers and user.is_superuser:
             return True
-        if flag.users.filter(pk=user.pk).exists():
+        if user.pk in flag._get_user_ids():
             return True
 
         opportunity = getattr(request, "opportunity", None)

--- a/commcare_connect/flags/tests/test_context_processors.py
+++ b/commcare_connect/flags/tests/test_context_processors.py
@@ -76,3 +76,23 @@ class TestChatWidgetContext:
         assert context["chat_widget_enabled"] is True
         assert context["chatbot_id"] == "test-chatbot-id"
         assert context["chatbot_embed_key"] == "test-embed-key"
+
+    def test_flag_does_not_leak_across_orgs_for_multi_org_user(self, settings):
+        settings.CHATBOT_ID = "test-chatbot-id"
+        settings.CHATBOT_EMBED_KEY = "test-embed-key"
+
+        org_with_flag = OrganizationFactory()
+        org_without_flag = OrganizationFactory()
+
+        user = UserFactory()
+        MembershipFactory(user=user, organization=org_with_flag)
+        MembershipFactory(user=user, organization=org_without_flag)
+
+        flag = Flag.objects.create(name="open_chat_studio_widget")
+        flag.organizations.add(org_with_flag)
+
+        request = RequestFactory().get("/")
+        request.user = user
+        request.org = org_without_flag
+
+        assert chat_widget_context(request)["chat_widget_enabled"] is False

--- a/commcare_connect/flags/tests/test_context_processors.py
+++ b/commcare_connect/flags/tests/test_context_processors.py
@@ -4,6 +4,7 @@ import pytest
 from django.test import RequestFactory
 
 from commcare_connect.flags.models import Flag
+from commcare_connect.program.tests.factories import ManagedOpportunityFactory, ProgramFactory
 from commcare_connect.users.tests.factories import MembershipFactory, OrganizationFactory, UserFactory
 from commcare_connect.web.context_processors import chat_widget_context
 
@@ -76,6 +77,44 @@ class TestChatWidgetContext:
         assert context["chat_widget_enabled"] is True
         assert context["chatbot_id"] == "test-chatbot-id"
         assert context["chatbot_embed_key"] == "test-embed-key"
+
+    def test_flag_enabled_for_program_of_managed_opportunity(self, settings, managed_opportunity):
+        settings.CHATBOT_ID = "test-chatbot-id"
+        settings.CHATBOT_EMBED_KEY = "test-embed-key"
+
+        user = UserFactory()
+        MembershipFactory(user=user, organization=managed_opportunity.organization)
+        flag = Flag.objects.create(name="open_chat_studio_widget")
+        flag.programs.add(managed_opportunity.program)
+
+        request = RequestFactory().get("/")
+        request.user = user
+        request.org = managed_opportunity.organization
+        request.opportunity = managed_opportunity
+
+        assert chat_widget_context(request)["chat_widget_enabled"] is True
+
+    def test_flag_does_not_leak_across_programs(self, settings, organization):
+        settings.CHATBOT_ID = "test-chatbot-id"
+        settings.CHATBOT_EMBED_KEY = "test-embed-key"
+
+        program_with_flag = ProgramFactory()
+        program_without_flag = ProgramFactory()
+        ManagedOpportunityFactory(program=program_with_flag, organization=organization)
+        opp_without_flag = ManagedOpportunityFactory(program=program_without_flag, organization=organization)
+
+        user = UserFactory()
+        MembershipFactory(user=user, organization=organization)
+
+        flag = Flag.objects.create(name="open_chat_studio_widget")
+        flag.programs.add(program_with_flag)
+
+        request = RequestFactory().get("/")
+        request.user = user
+        request.org = organization
+        request.opportunity = opp_without_flag
+
+        assert chat_widget_context(request)["chat_widget_enabled"] is False
 
     def test_flag_does_not_leak_across_orgs_for_multi_org_user(self, settings):
         settings.CHATBOT_ID = "test-chatbot-id"

--- a/commcare_connect/flags/tests/test_flag_models.py
+++ b/commcare_connect/flags/tests/test_flag_models.py
@@ -78,6 +78,15 @@ class TestFlagModel:
         assert active_flags.count() == 3
         assert set(active_flags) == {org_flag, opportunity_flag, program_flag}
 
+    def test_cache_is_invalidated_when_relation_membership_changes(self, flag, organization):
+        assert flag.is_active_for(organization) is False  # populates cache with CACHE_EMPTY
+
+        flag.organizations.add(organization)
+        assert flag.is_active_for(organization) is True
+
+        flag.organizations.remove(organization)
+        assert flag.is_active_for(organization) is False
+
     def test_active_flags_for_user_role_flags(self):
         user = UserFactory(is_staff=True)
         staff_flag = FlagFactory(staff=True)


### PR DESCRIPTION
## Product Description

For users who belong to multiple workspaces, feature flags enabled on one workspace were leaking into other workspaces the user belongs to. The two user-visible symptoms today are the chat widget (`open_chat_studio_widget`) and session tracking (`session_tracking`) — both rendered on workspaces that hadn't opted into the flag. Other request-scoped uses of `Flag.is_flag_active_for_request` would have had the same problem.

### Important note
Given the nature of the issue I think we need to deploy this to production as soon as it's merged.

## Technical Summary

[CI-670](https://dimagi.atlassian.net/browse/CI-670). Two related bugs in `commcare_connect/flags/`:

1. **`is_flag_active_for_request` ignored the request's workspace scope.** It delegated to `active_flags_for_user`, which returns flags active via *any* of the user's org/opportunity/program memberships — `request.org` was never consulted. Reworked it to short-circuit on request-independent activations (`everyone`, `staff`, `superusers`, direct `users`), then check `request.opportunity` → `request.org` via the already-existing scope-correct `flag.is_active_for()`.

2. **Custom m2m relations didn't invalidate the per-flag relation cache.** waffle registers `m2m_changed` handlers for its built-in `users` / `groups` m2m, but our custom `organizations` / `opportunities` / `programs` relations had no equivalent. Any `.add()` / `.remove()` / `.set()` / `.clear()` left `_get_relation_ids` returning stale (or `CACHE_EMPTY`) sets until the Flag itself was saved. Added `m2m_changed` handlers wired to waffle's `flag_membership_changed`.

## Safety Assurance

### Safety story

Scoped change to the toggle plumbing. The new request-scope check is additive after the existing user/role checks, so flags previously activated for a user directly (via `flag.users`) or via role (`everyone` / `staff` / `superusers`) continue to activate exactly as before. The m2m signal handlers only fire on relation changes and delegate to waffle's own flush logic.

### Automated test coverage

- `test_flag_does_not_leak_across_orgs_for_multi_org_user` — user is a member of two workspaces, flag enabled on workspace A only, request scoped to workspace B → expects `chat_widget_enabled` is False. Fails on `main`, passes with the fix.
- `test_cache_is_invalidated_when_relation_membership_changes` — verifies `flag.is_active_for(org)` reflects subsequent `.add()` / `.remove()` calls within the same process (i.e. the relation cache is flushed). Fails if the `m2m_changed` handler is disconnected.

### QA Plan
- As a user who is admin of two workspaces, enable `open_chat_studio_widget` on workspace A only. Confirm the chat widget appears on workspace A's pages and does **not** appear on workspace B's pages.
- In the internal Toggles UI, add a workspace to a flag's `organizations`, then immediately reload a page that gates on that flag — the new state should be reflected without a server restart.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CI-670]: https://dimagi.atlassian.net/browse/CI-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ