### PR TITLE
Work Area Case Property Fixes

### DIFF
--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -21,11 +21,19 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
             "properties",
         ]
 
-    def get_properties(self, obj) -> dict:
+    def get_properties(self, obj: WorkArea) -> dict:
+        centroid = f"{obj.centroid.y:.2f} {obj.centroid.x:.2f}" if obj.centroid else ""
+        bounding_box = ""
+        if obj.boundary:
+            for lat, lon in list(obj.boundary.shell.coords):
+                bounding_box += f"{lat:.2f} {lon:.2f}"
+
+        print(f"{centroid=}")
+        print(f"{bounding_box=}")
         return {
-            "bounding_box": str(obj.boundary) if obj.boundary else "",
+            "bounding_box": bounding_box,
             "building_count": str(obj.building_count),
-            "centroid": str(obj.centroid) if obj.centroid else "",
+            "centroid": centroid,
             "expected_visit_count": str(obj.expected_visit_count),
             "wa_status": obj.status,
             "ward": obj.ward,

--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -31,8 +31,10 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
             bounding_box = " ".join(lat_lon_strings)
         return {
             "bounding_box": bounding_box,
+            "bounding_box_wkt": str(obj.boundary) if obj.boundary else "",
             "building_count": str(obj.building_count),
             "centroid": centroid,
+            "centroid_wkt": str(obj.centroid) if obj.centroid else "",
             "expected_visit_count": str(obj.expected_visit_count),
             "wa_status": obj.status,
             "ward": obj.ward,

--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -22,11 +22,13 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
         ]
 
     def get_properties(self, obj: WorkArea) -> dict:
-        centroid = f"{obj.centroid.x:.2f} {obj.centroid.y:.2f}" if obj.centroid else ""
+        centroid = ""
+        if obj.centroid:
+            centroid = _coords_to_lat_lon_string(obj.centroid.coords)
         bounding_box = ""
         if obj.boundary:
-            for lat, lon in list(obj.boundary.shell.coords):
-                bounding_box += f"{lat:.2f} {lon:.2f} "
+            lat_lon_strings = [_coords_to_lat_lon_string(coords) for coords in list(obj.boundary.shell.coords)]
+            bounding_box = " ".join(lat_lon_strings)
         return {
             "bounding_box": bounding_box,
             "building_count": str(obj.building_count),
@@ -41,3 +43,8 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
             "lga": str(obj.case_properties.get("lga", "")),
             "state": str(obj.case_properties.get("state", "")),
         }
+
+
+def _coords_to_lat_lon_string(coords: tuple[float, float]) -> str:
+    lon, lat = coords
+    return f"{lat:.5f} {lon:.5f}"

--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -27,9 +27,6 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
         if obj.boundary:
             for lat, lon in list(obj.boundary.shell.coords):
                 bounding_box += f"{lat:.2f} {lon:.2f}"
-
-        print(f"{centroid=}")
-        print(f"{bounding_box=}")
         return {
             "bounding_box": bounding_box,
             "building_count": str(obj.building_count),

--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -22,18 +22,18 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
         ]
 
     def get_properties(self, obj: WorkArea) -> dict:
-        centroid = ""
+        centroid_lat_lon = ""
         if obj.centroid:
-            centroid = _coords_to_lat_lon_string(obj.centroid.coords)
-        bounding_box = ""
+            centroid_lat_lon = _coords_to_lat_lon_string(obj.centroid.coords)
+        bounding_box_lat_lon = ""
         if obj.boundary:
             lat_lon_strings = [_coords_to_lat_lon_string(coords) for coords in list(obj.boundary.shell.coords)]
-            bounding_box = " ".join(lat_lon_strings)
+            bounding_box_lat_lon = " ".join(lat_lon_strings)
         return {
-            "bounding_box": bounding_box,
+            "bounding_box": bounding_box_lat_lon,
             "bounding_box_wkt": str(obj.boundary) if obj.boundary else "",
             "building_count": str(obj.building_count),
-            "centroid": centroid,
+            "centroid": centroid_lat_lon,
             "centroid_wkt": str(obj.centroid) if obj.centroid else "",
             "expected_visit_count": str(obj.expected_visit_count),
             "wa_status": obj.status,

--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -22,11 +22,11 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
         ]
 
     def get_properties(self, obj: WorkArea) -> dict:
-        centroid = f"{obj.centroid.y:.2f} {obj.centroid.x:.2f}" if obj.centroid else ""
+        centroid = f"{obj.centroid.x:.2f} {obj.centroid.y:.2f}" if obj.centroid else ""
         bounding_box = ""
         if obj.boundary:
             for lat, lon in list(obj.boundary.shell.coords):
-                bounding_box += f"{lat:.2f} {lon:.2f}"
+                bounding_box += f"{lat:.2f} {lon:.2f} "
         return {
             "bounding_box": bounding_box,
             "building_count": str(obj.building_count),

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -23,11 +23,11 @@ def test_work_area_case_serializer():
 
     data = WorkAreaCaseSerializer(work_area).data
 
-    centroid = f"{work_area.centroid.y:.2f} {work_area.centroid.x:.2f}" if work_area.centroid else ""
+    centroid = f"{work_area.centroid.x:.2f} {work_area.centroid.y:.2f}" if work_area.centroid else ""
     bounding_box = ""
     if work_area.boundary:
         for lat, lon in list(work_area.boundary.shell.coords):
-            bounding_box += f"{lat:.2f} {lon:.2f}"
+            bounding_box += f"{lat:.2f} {lon:.2f} "
 
     assert data == {
         "case_name": "my-area",

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -24,13 +24,18 @@ def test_work_area_case_serializer():
     data = WorkAreaCaseSerializer(work_area).data
 
     centroid = f"{work_area.centroid.y:.2f} {work_area.centroid.x:.2f}" if work_area.centroid else ""
+    bounding_box = ""
+    if work_area.boundary:
+        for lat, lon in list(work_area.boundary.shell.coords):
+            bounding_box += f"{lat:.2f} {lon:.2f}"
+
     assert data == {
         "case_name": "my-area",
         "case_type": WORK_AREA_CASE_TYPE,
         "external_id": str(work_area.id),
         "owner_id": None,
         "properties": {
-            "bounding_box": str(work_area.boundary),
+            "bounding_box": bounding_box,
             "building_count": "5",
             "centroid": centroid,
             "expected_visit_count": "10",

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -22,6 +22,8 @@ def test_work_area_case_serializer():
     )
 
     data = WorkAreaCaseSerializer(work_area).data
+
+    centroid = f"{work_area.centroid.y:.2f} {work_area.centroid.x:.2f}" if work_area.centroid else ""
     assert data == {
         "case_name": "my-area",
         "case_type": WORK_AREA_CASE_TYPE,
@@ -30,7 +32,7 @@ def test_work_area_case_serializer():
         "properties": {
             "bounding_box": str(work_area.boundary),
             "building_count": "5",
-            "centroid": str(work_area.centroid),
+            "centroid": centroid,
             "expected_visit_count": "10",
             "wa_status": work_area.status,
             "ward": "ward-x",

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -40,10 +40,10 @@ def test_work_area_case_serializer():
         "owner_id": None,
         "properties": {
             "bounding_box": bounding_box,
-            "bounding_box_wkt": str(work_area.boundary) if work_area.boundary else "",
+            "bounding_box_wkt": str(work_area.boundary),
             "building_count": "5",
             "centroid": centroid,
-            "centroid_wkt": str(work_area.centroid) if work_area.centroid else "",
+            "centroid_wkt": str(work_area.centroid),
             "expected_visit_count": "10",
             "wa_status": work_area.status,
             "ward": "ward-x",

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -1,6 +1,10 @@
 import pytest
 
-from commcare_connect.microplanning.serializers import WORK_AREA_CASE_TYPE, WorkAreaCaseSerializer
+from commcare_connect.microplanning.serializers import (
+    WORK_AREA_CASE_TYPE,
+    WorkAreaCaseSerializer,
+    _coords_to_lat_lon_string,
+)
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 
 
@@ -23,11 +27,11 @@ def test_work_area_case_serializer():
 
     data = WorkAreaCaseSerializer(work_area).data
 
-    centroid = f"{work_area.centroid.x:.2f} {work_area.centroid.y:.2f}" if work_area.centroid else ""
+    centroid = _coords_to_lat_lon_string(work_area.centroid.coords)
     bounding_box = ""
     if work_area.boundary:
-        for lat, lon in list(work_area.boundary.shell.coords):
-            bounding_box += f"{lat:.2f} {lon:.2f} "
+        lat_lon = [_coords_to_lat_lon_string(coords) for coords in list(work_area.boundary.shell.coords)]
+        bounding_box = " ".join(lat_lon)
 
     assert data == {
         "case_name": "my-area",

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -40,8 +40,10 @@ def test_work_area_case_serializer():
         "owner_id": None,
         "properties": {
             "bounding_box": bounding_box,
+            "bounding_box_wkt": str(work_area.boundary) if work_area.boundary else "",
             "building_count": "5",
             "centroid": centroid,
+            "centroid_wkt": str(work_area.centroid) if work_area.centroid else "",
             "expected_visit_count": "10",
             "wa_status": work_area.status,
             "ward": "ward-x",

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -1,10 +1,8 @@
 import pytest
+from django.contrib.gis.geos import Point
 
-from commcare_connect.microplanning.serializers import (
-    WORK_AREA_CASE_TYPE,
-    WorkAreaCaseSerializer,
-    _coords_to_lat_lon_string,
-)
+from commcare_connect.microplanning.models import SRID
+from commcare_connect.microplanning.serializers import WORK_AREA_CASE_TYPE, WorkAreaCaseSerializer
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 
 
@@ -23,15 +21,10 @@ def test_work_area_case_serializer():
             "lga": "LGA1",
             "state": "State1",
         },
+        centroid=Point(77, 29, srid=SRID),
     )
 
     data = WorkAreaCaseSerializer(work_area).data
-
-    centroid = _coords_to_lat_lon_string(work_area.centroid.coords)
-    bounding_box = ""
-    if work_area.boundary:
-        lat_lon = [_coords_to_lat_lon_string(coords) for coords in list(work_area.boundary.shell.coords)]
-        bounding_box = " ".join(lat_lon)
 
     assert data == {
         "case_name": "my-area",
@@ -39,10 +32,11 @@ def test_work_area_case_serializer():
         "external_id": str(work_area.id),
         "owner_id": None,
         "properties": {
-            "bounding_box": bounding_box,
+            "bounding_box": "28.00000 77.00000 28.00000 78.00000 29.00000"
+            " 78.00000 29.00000 77.00000 28.00000 77.00000",
             "bounding_box_wkt": str(work_area.boundary),
             "building_count": "5",
-            "centroid": centroid,
+            "centroid": "29.00000 77.00000",
             "centroid_wkt": str(work_area.centroid),
             "expected_visit_count": "10",
             "wa_status": work_area.status,


### PR DESCRIPTION
## Product Description
This PR adds coordinate formatting changes for `centroid` and `bounding_box` work area case data properties.
The new format is `lat lon` for both centroid and list of `lat lon` bounding_box properties.
The WKT format is also sent to HQ under the `centroid_wkt` and `bounding_box_wkt` properties.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2431)

## Safety Assurance
### Safety story
Ticket Link

### Automated test coverage
Added automated test coverage

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change