### PR TITLE
Clear Create Task Modal on Close

### DIFF
--- a/commcare_connect/static/js/alpine_data.js
+++ b/commcare_connect/static/js/alpine_data.js
@@ -20,14 +20,3 @@ function resetFilterModalState(formId) {
   };
 }
 window.resetFilterModalState = resetFilterModalState;
-
-// Clears all fields of a modal form (native inputs and tom-select widgets).
-function resetModalForm(formId) {
-  const form = document.getElementById(formId);
-  if (!form) return;
-  form.reset();
-  form.querySelectorAll('[data-tomselect]').forEach((el) => {
-    if (el.tomselect) el.tomselect.clear();
-  });
-}
-window.resetModalForm = resetModalForm;

--- a/commcare_connect/static/js/alpine_data.js
+++ b/commcare_connect/static/js/alpine_data.js
@@ -20,3 +20,14 @@ function resetFilterModalState(formId) {
   };
 }
 window.resetFilterModalState = resetFilterModalState;
+
+// Clears all fields of a modal form (native inputs and tom-select widgets).
+function resetModalForm(formId) {
+  const form = document.getElementById(formId);
+  if (!form) return;
+  form.reset();
+  form.querySelectorAll('[data-tomselect]').forEach((el) => {
+    if (el.tomselect) el.tomselect.clear();
+  });
+}
+window.resetModalForm = resetModalForm;

--- a/commcare_connect/templates/opportunity/assigned_task_list.html
+++ b/commcare_connect/templates/opportunity/assigned_task_list.html
@@ -61,7 +61,7 @@
         <div id="task-list-table" class="bg-white rounded-lg shadow-xs p-4">
             <div class="flex gap-x-4 items-center justify-end mb-4">
                 {% if can_manage_tasks %}
-                <button type="button" class="button-icon shadow-sm" @click="showCreateTaskModal = true"
+                <button type="button" class="button-icon shadow-sm" @click.stop="showCreateTaskModal = true"
                     x-tooltip.raw="{% trans 'Create Task' %}">
                     <i class="fa-solid fa-plus text-brand-deep-purple"></i>
                 </button>

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -108,7 +108,7 @@
             <input type="hidden" name="task_ids" :value="id">
           </template>
         </form>
-        <button type="button" class="button button-md primary-dark" @click="showCreateTaskModal = true">
+        <button type="button" class="button button-md primary-dark" @click.stop="showCreateTaskModal = true">
           <i class="fa-solid fa-plus mr-2"></i>
           {% trans "Create Task" %}
         </button>

--- a/commcare_connect/templates/tasks/new_task_modal.html
+++ b/commcare_connect/templates/tasks/new_task_modal.html
@@ -8,6 +8,7 @@
 
 <div x-show="{{ modal_name }}" x-cloak x-transition.opacity class="modal-backdrop" role="dialog" aria-modal="true"
     aria-labelledby="new-task-modal-title"
+    x-init="$watch('{{ modal_name }}', val => { if (!val) resetModalForm('create-task-form') })"
     @keydown.escape.window="{{ modal_name }} = false"
     @create-task-success.window="{{ modal_name }} = false">
     <div @click.outside="{{ modal_name }} = false" class="modal">

--- a/commcare_connect/templates/tasks/new_task_modal.html
+++ b/commcare_connect/templates/tasks/new_task_modal.html
@@ -6,9 +6,11 @@
 <script src="{% static 'bundles/js/tomselect-bundle.js' %}"></script>
 
 
-<div x-show="{{ modal_name }}" x-cloak x-transition.opacity class="modal-backdrop" role="dialog" aria-modal="true"
+<template x-if="{{ modal_name }}">
+{# The form lives inside an x-if <template>, which htmx's page-load scan ignores. Without htmx.process, hx-post is dead and the form falls back to a native POST. #}
+<div x-transition.opacity class="modal-backdrop" role="dialog" aria-modal="true"
     aria-labelledby="new-task-modal-title"
-    x-init="$watch('{{ modal_name }}', val => { if (!val) resetModalForm('create-task-form') })"
+    x-init="htmx.process($el)"
     @keydown.escape.window="{{ modal_name }} = false"
     @create-task-success.window="{{ modal_name }} = false">
     <div @click.outside="{{ modal_name }} = false" class="modal">
@@ -50,3 +52,4 @@
         </div>
     </div>
 </div>
+</template>


### PR DESCRIPTION
## Product Description

The "Create Task" modal now clears its form state when closed and reopened. Previously, closing and reopening the modal would show stale data from the previous interaction. After this change, the modal is fully reset each time it's opened.

<img width="1669" height="587" alt="modal-clear-on-close" src="https://github.com/user-attachments/assets/6a635ea0-fd75-482b-9525-ca8cec3b940e" />

## Technical Summary

[QA-8507](https://dimagi.atlassian.net/browse/QA-8507)

This is a release path 3 feature — Experiments & early stage iterations of product area

The modal was previously rendered with `x-show`, which keeps the DOM node alive (and the form populated) even when hidden. Switching to `x-if` destroys and recreates the element on each open/close cycle, which naturally resets form state. The trade-off is that htmx's page-load scan never sees elements inside an `x-if` `<template>`, so `htmx.process($el)` is called via `x-init` to manually initialise htmx bindings after the element is inserted. The `@click` handlers on the trigger buttons are also updated to `.stop` to prevent event bubbling from interfering with the `@click.outside` close handler.

- **Modal lifecycle:** `x-show` → `x-if` on `new_task_modal.html` so the form DOM is destroyed on close and recreated fresh on open
- **htmx re-initialisation:** `x-init="htmx.process($el)"` ensures `hx-post` bindings are active after Alpine inserts the element
- **Event bubbling fix:** `@click` → `@click.stop` on both trigger buttons (`assigned_task_list.html`, `user_tasks.html`) to prevent the open-click from immediately triggering the `@click.outside` close handler

## Safety Assurance

### Safety story

This is a pure frontend change with no backend, model, or data impact. The modal behaviour is fully controlled by Alpine.js and htmx on the client side. Tested locally by opening, partially filling, closing, and reopening the modal to confirm the form resets correctly, and by submitting a task to confirm the `hx-post` still fires.

### Automated test coverage

No automated test coverage — this is a client-side UI behaviour change not covered by the existing pytest suite.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Open the Create Task modal, fill in some fields, then close it via the × button
- [ ] Reopen the modal and confirm all fields are empty/reset
- [ ] Close the modal by clicking outside it and confirm the same reset behaviour
- [ ] Close via the Escape key and confirm reset
- [ ] Submit a valid task and confirm the form submits correctly (hx-post fires, not a native POST)
- [ ] Confirm no console errors on open/close/submit

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

[QA-8507]: https://dimagi.atlassian.net/browse/QA-8507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ