### PR TITLE
Make Opportunity Credentials opt-out vs opt-in

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -225,20 +225,27 @@ class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
         ]
 
         if switch_is_active(OPPORTUNITY_CREDENTIALS):
+            _cred_config = (
+                CredentialConfiguration.objects.filter(opportunity=self.instance).first() if self.instance else None
+            )
             layout_fields.append(
                 Row(
                     HTML(
                         format_html(
                             """
                             <div class='col-span-2'>
-                                <h6 class='title-sm'>{}</h6>
+                                <div class='flex items-center gap-3 mb-1'>
+                                    <h6 class='title-sm'>{heading}</h6>
+                                    <input type='checkbox' name='enable_credentials'
+                                           class='simple-toggle' x-model='credentialsEnabled'>
+                                </div>
                                 <span class='hint'>
-                                    {}
+                                    {hint}
                                 </span>
                             </div>
                             """,
-                            _("Manage Credentials"),
-                            format_html(
+                            heading=_("Manage Credentials"),
+                            hint=format_html(
                                 _(
                                     "Configure credential requirements for learning and delivery. For more "
                                     "information, please refer to the {link_start}following documentation{link_end}."
@@ -254,14 +261,17 @@ class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
                     ),
                     Column(
                         Field("learn_level"),
+                        **{"x-show": "credentialsEnabled"},
                     ),
                     Column(
                         Field("delivery_level"),
+                        **{"x-show": "credentialsEnabled"},
                     ),
                     css_class="grid grid-cols-2 gap-4 p-6 card_bg",
+                    **{"x-data": f"{{ credentialsEnabled: {'true' if _cred_config else 'false'} }}"},
                 )
             )
-            self.add_credential_fields()
+            self.add_credential_fields(_cred_config)
 
         layout_fields.append(
             Row(Submit("submit", "Submit", css_class="button button-md primary-dark"), css_class="flex justify-end")
@@ -282,24 +292,27 @@ class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
                 self.initial["end_date"] = self.instance.end_date.isoformat()
             self.currently_active = self.instance.active
 
-    def add_credential_fields(self):
-        credential_issuer = None
-        if self.instance:
-            credential_issuer = CredentialConfiguration.objects.filter(opportunity=self.instance).first()
+    def add_credential_fields(self, credential_config=None):
+        if credential_config is None and self.instance:
+            credential_config = CredentialConfiguration.objects.filter(opportunity=self.instance).first()
 
+        self.fields["enable_credentials"] = forms.BooleanField(
+            required=False,
+            initial=credential_config is not None,
+        )
         self.fields["learn_level"] = forms.ChoiceField(
             choices=[("", _("None"))] + UserCredential.LearnLevel.choices,
             required=False,
             label=_("Learn Level"),
             help_text=_("Credential level required for completing the learning phase."),
-            initial=credential_issuer.learn_level if credential_issuer else "",
+            initial=credential_config.learn_level if credential_config else "",
         )
         self.fields["delivery_level"] = forms.ChoiceField(
             choices=[("", _("None"))] + UserCredential.DeliveryLevel.choices,
             required=False,
             label=_("Delivery Level"),
             help_text=_("Credential level required for completing deliveries."),
-            initial=credential_issuer.delivery_level if credential_issuer else "",
+            initial=credential_config.delivery_level if credential_config else "",
         )
 
     def clean_users(self):
@@ -327,19 +340,19 @@ class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
         if not switch_is_active(OPPORTUNITY_CREDENTIALS):
             return instance
 
+        if not self.cleaned_data.get("enable_credentials"):
+            CredentialConfiguration.objects.filter(opportunity=instance).delete()
+            return instance
+
         learn_level = self.cleaned_data.get("learn_level") or None
         delivery_level = self.cleaned_data.get("delivery_level") or None
-        if learn_level or delivery_level:
-            CredentialConfiguration.objects.update_or_create(
-                opportunity=instance,
-                defaults={
-                    "learn_level": learn_level,
-                    "delivery_level": delivery_level,
-                },
-            )
-        else:
-            CredentialConfiguration.objects.filter(opportunity=instance).delete()
-
+        CredentialConfiguration.objects.update_or_create(
+            opportunity=instance,
+            defaults={
+                "learn_level": learn_level,
+                "delivery_level": delivery_level,
+            },
+        )
         return instance
 
 
@@ -596,6 +609,14 @@ class OpportunityInitForm(forms.ModelForm):
 
         if commit:
             opportunity.save()
+            if switch_is_active(OPPORTUNITY_CREDENTIALS):
+                CredentialConfiguration.objects.get_or_create(
+                    opportunity=opportunity,
+                    defaults={
+                        "learn_level": UserCredential.LearnLevel.LEARN_PASSED,
+                        "delivery_level": UserCredential.DeliveryLevel.TWENTY_FIVE,
+                    },
+                )
         return opportunity
 
 

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -293,9 +293,6 @@ class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
             self.currently_active = self.instance.active
 
     def add_credential_fields(self, credential_config=None):
-        if credential_config is None and self.instance:
-            credential_config = CredentialConfiguration.objects.filter(opportunity=self.instance).first()
-
         self.fields["enable_credentials"] = forms.BooleanField(
             required=False,
             initial=credential_config is not None,

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -38,6 +38,7 @@ from commcare_connect.opportunity.tests.factories import (
     TaskTypeFactory,
 )
 from commcare_connect.program.tests.factories import ManagedOpportunityFactory, ProgramFactory
+from commcare_connect.users.models import UserCredential
 
 
 @pytest.fixture
@@ -72,6 +73,7 @@ class TestOpportunityChangeForm:
             "delivery_type": valid_opportunity.delivery_type.id,
             "end_date": (datetime.date.today() + datetime.timedelta(days=60)).isoformat(),
             "users": "+1234567890\n+9876543210",
+            "enable_credentials": True,
             "learn_level": None,
             "deliver_level": None,
         }
@@ -227,17 +229,20 @@ class TestOpportunityChangeForm:
 
     @override_switch(OPPORTUNITY_CREDENTIALS, active=True)
     @pytest.mark.parametrize(
-        "learn_level,delivery_level",
+        "enable_credentials,learn_level,delivery_level",
         [
-            ("LEARN_PASSED", "25_DELIVERIES"),
-            ("LEARN_PASSED", "1000_DELIVERIES"),
-            ("", "50_DELIVERIES"),
-            ("LEARN_PASSED", ""),
-            ("", ""),
+            (True, "LEARN_PASSED", "25_DELIVERIES"),
+            (True, "LEARN_PASSED", "1000_DELIVERIES"),
+            (True, "", "50_DELIVERIES"),
+            (True, "LEARN_PASSED", ""),
+            (False, "", ""),  # opt-out via toggle
         ],
     )
-    def test_save_credential_issuer(self, valid_opportunity, base_form_data, learn_level, delivery_level):
+    def test_save_credential_issuer(
+        self, valid_opportunity, base_form_data, enable_credentials, learn_level, delivery_level
+    ):
         data = base_form_data.copy()
+        data["enable_credentials"] = enable_credentials
         data["learn_level"] = learn_level
         data["delivery_level"] = delivery_level
 
@@ -245,7 +250,7 @@ class TestOpportunityChangeForm:
         assert form.is_valid(), form.errors
         form.save()
 
-        if learn_level or delivery_level:
+        if enable_credentials:
             credential_issuer = CredentialConfiguration.objects.get(opportunity=valid_opportunity)
             assert credential_issuer.learn_level == (learn_level or None)
             assert credential_issuer.delivery_level == (delivery_level or None)
@@ -263,14 +268,21 @@ class TestOpportunityChangeForm:
         assert "learn_level" in form.errors or "delivery_level" in form.errors
 
     def test_credential_switch(self, valid_opportunity):
+        cache.clear()
         form = OpportunityChangeForm(instance=valid_opportunity)
         assert "learn_level" not in form.fields
         assert "delivery_level" not in form.fields
+        assert "enable_credentials" not in form.fields
 
         with override_switch(OPPORTUNITY_CREDENTIALS, active=True):
             form = OpportunityChangeForm(instance=valid_opportunity)
             assert "learn_level" in form.fields
             assert "delivery_level" in form.fields
+            assert "enable_credentials" in form.fields
+            # No credential config exists for valid_opportunity → toggle defaults to False (opted out)
+            assert form.fields["enable_credentials"].initial is False
+            assert form.fields["learn_level"].initial == ""
+            assert form.fields["delivery_level"].initial == ""
 
 
 @pytest.mark.django_db
@@ -510,6 +522,44 @@ class TestOpportunityInitForm:
         new_opportunity.refresh_from_db()
         assert new_opportunity.pk != opportunity.pk
         assert new_opportunity.automatic_visit_verification is switch_active
+
+    @pytest.mark.parametrize("switch_active", [True, False])
+    def test_default_credential_config_on_new_opportunity(self, opportunity, switch_active):
+        cache.clear()
+        learn_app = opportunity.learn_app
+        deliver_app = opportunity.deliver_app
+        data = {
+            "name": "New opportunity with credentials",
+            "description": "Description",
+            "short_description": "Short",
+            "currency": opportunity.currency.code,
+            "country": opportunity.country.code,
+            "hq_server": opportunity.hq_server.id,
+            "api_key": str(opportunity.api_key.id),
+            "learn_app_domain": learn_app.cc_domain,
+            "learn_app": json.dumps({"id": learn_app.cc_app_id, "name": learn_app.name}),
+            "learn_app_description": "Learn description",
+            "learn_app_passing_score": 70,
+            "deliver_app_domain": deliver_app.cc_domain,
+            "deliver_app": json.dumps({"id": deliver_app.cc_app_id, "name": deliver_app.name}),
+        }
+        form = OpportunityInitForm(
+            data=data,
+            user=opportunity.api_key.user,
+            org_slug=opportunity.organization.slug,
+        )
+        assert form.is_valid(), form.errors
+
+        with override_switch(OPPORTUNITY_CREDENTIALS, active=switch_active):
+            new_opportunity = form.save()
+
+        credential_config = CredentialConfiguration.objects.filter(opportunity=new_opportunity).first()
+        if switch_active:
+            assert credential_config is not None
+            assert credential_config.learn_level == UserCredential.LearnLevel.LEARN_PASSED
+            assert credential_config.delivery_level == UserCredential.DeliveryLevel.TWENTY_FIVE
+        else:
+            assert credential_config is None
 
 
 class TestAddBudgetNewUsersForm:


### PR DESCRIPTION
## Product Description
The Opportunity edit form now includes a toggle in the “Manage Credentials” section. Disabling the toggle removes all credential requirements for the opportunity, while enabling it reveals the learn-level and delivery-level dropdowns and saves the selected configuration.

When creating a new opportunity with the credentials feature enabled, default credential requirements are automatically initialized as:
- Learn Level: Passed
- Delivery Requirement: 25 deliveries

<img width="2166" height="602" alt="image" src="https://github.com/user-attachments/assets/56c34b7e-de6d-4d2b-b3e2-e0ed15b4ccda" />
<img width="2184" height="344" alt="image" src="https://github.com/user-attachments/assets/fc95beeb-7563-40a8-8f90-3a8c4b6d53c8" />

## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-2414
- Added an `enable_credentials` toggle to `OpportunityChangeForm`
- Added Alpine.js logic to conditionally show credential configuration fields
- Refactored form save logic so the toggle acts as the source of truth:
  - disabling removes any existing `CredentialConfiguration`
  - enabling creates or updates the configuration
- Added automatic default `CredentialConfiguration` creation in `OpportunityInitForm.save()` when the `OPPORTUNITY_CREDENTIALS` waffle switch is enabled
- Removed a redundant database query by reusing the fetched `CredentialConfiguration` in `add_credential_fields`

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
Added tests

### QA Plan
Not needed

## Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change