### PR TITLE
Fix spelling mistake

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -924,7 +924,7 @@ class UserVisit(XFormBaseModel):
     def duration(self):
         duration = None
         start = self.form_json["metadata"].get("timeStart")
-        end = self.form_json["metatdata"].get("timeEnd")
+        end = self.form_json["metadata"].get("timeEnd")
         if start and end:
             try:
                 duration = parse_datetime(end) - parse_datetime(start)


### PR DESCRIPTION
## Technical Summary
I've notices a spelling mistake in the accessor key, which should probably be "metadata".

## Safety Assurance

### Safety story
Did not test this in particular, but I'm confident it's right.

### Automated test coverage
Not including a test

### QA Plan
N.A

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
