### PR TITLE
Add 'email' field to UserSerializer

### DIFF
--- a/commcare_connect/users/api/serializers.py
+++ b/commcare_connect/users/api/serializers.py
@@ -7,7 +7,7 @@ User = get_user_model()
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ["name", "url"]
+        fields = ["email", "name", "url"]
 
         extra_kwargs = {
             "url": {"view_name": "api:user-detail", "lookup_field": "pk"},

--- a/commcare_connect/users/api/serializers.py
+++ b/commcare_connect/users/api/serializers.py
@@ -8,6 +8,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ["email", "name", "url"]
+        read_only_fields = ["email"]
 
         extra_kwargs = {
             "url": {"view_name": "api:user-detail", "lookup_field": "pk"},

--- a/commcare_connect/users/tests/test_drf_views.py
+++ b/commcare_connect/users/tests/test_drf_views.py
@@ -1,6 +1,7 @@
 import pytest
 from rest_framework.test import APIRequestFactory
 
+from commcare_connect.users.api.serializers import UserSerializer
 from commcare_connect.users.api.views import UserViewSet
 from commcare_connect.users.models import User
 
@@ -31,4 +32,13 @@ class TestUserViewSet:
         assert response.data == {
             "url": f"http://testserver/api/users/{user.pk}/",
             "name": user.name,
+            "email": user.email,
         }
+
+    def test_email_is_read_only(self, user: User):
+        original_email = user.email
+        serializer = UserSerializer(user, data={"email": "new@example.com", "name": user.name}, partial=True)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+        user.refresh_from_db()
+        assert user.email == original_email


### PR DESCRIPTION
## Product Description
Expose the user email address via the `/api/users/me` endpoint. This is important information for other systems that need access to a user identity e.g. Scout.

## Technical Summary
Include user `email` in the `/api/users/me` endpoint payload. This field is marked as read only preventing it from being changed outside of the proper verification flow.

## Safety Assurance

### Safety story
Adds an existing field to the API. Tests updated and verified email field is read only.

### Automated test coverage

Updated

### QA Plan
None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
