### PR TITLE
Query on Assigned Tasks for Dashboard Metric

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -28,6 +28,8 @@ from django.utils.timezone import now
 
 from commcare_connect.opportunity.models import (
     Assessment,
+    AssignedTask,
+    AssignedTaskStatus,
     CompletedModule,
     CompletedWork,
     CompletedWorkStatus,
@@ -36,7 +38,6 @@ from commcare_connect.opportunity.models import (
     OpportunityClaim,
     OpportunityClaimLimit,
     Payment,
-    TaskType,
     UserInvite,
     UserInviteStatus,
     UserVisit,
@@ -698,8 +699,11 @@ def get_opportunity_delivery_progress(opp_id):
     )
     active_tasks_count = Coalesce(
         Subquery(
-            TaskType.objects.filter(opportunity_id=OuterRef("pk"), is_active=True)
-            .values("opportunity_id")
+            AssignedTask.objects.filter(
+                opportunity_access__opportunity_id=OuterRef("pk"),
+                status=AssignedTaskStatus.ASSIGNED,
+            )
+            .values("opportunity_access__opportunity_id")
             .annotate(total=Count("pk"))
             .values("total"),
             output_field=IntegerField(),

--- a/commcare_connect/opportunity/tests/test_helpers.py
+++ b/commcare_connect/opportunity/tests/test_helpers.py
@@ -397,6 +397,12 @@ def test_opportunity_delivery_stats(opportunity):
     PaymentFactory(opportunity_access=oa1, date_paid=yesterday, amount=100)
     PaymentFactory(opportunity_access=oa2, date_paid=today, amount=50)
 
+    # active_tasks_count counts AssignedTask rows with status ASSIGNED on this opportunity
+    task_type = TaskTypeFactory(opportunity=opportunity, app=opportunity.deliver_app, is_active=True)
+    AssignedTaskFactory(opportunity_access=oa1, task_type=task_type, status=AssignedTaskStatus.ASSIGNED)
+    AssignedTaskFactory(opportunity_access=oa2, task_type=task_type, status=AssignedTaskStatus.ASSIGNED)
+    AssignedTaskFactory(opportunity_access=oa2, task_type=task_type, status=AssignedTaskStatus.COMPLETED)
+
     result = get_opportunity_delivery_progress(opportunity.id)
 
     assert opportunity.id == result.id
@@ -411,6 +417,7 @@ def test_opportunity_delivery_stats(opportunity):
     assert result.recent_payment == today
     assert result.workers_invited == 3
     assert result.pending_invites == 1
+    assert result.active_tasks_count == 2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Product Description

The opportunity dashboard's "active tasks" metric now reflects the number of tasks currently assigned to workers (with status `ASSIGNED`) rather than the number of active task type definitions configured on the opportunity. This makes the metric represent real workload in progress rather than configuration.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/QA-8513)

This is a release path 3 feature — Experiments & early stage iterations of product area.

The `active_tasks_count` subquery in `get_opportunity_delivery_progress` previously counted rows in `TaskType` filtered by `is_active=True`, which represented configured task type definitions on the opportunity rather than work assigned to workers. The query has been swapped to count `AssignedTask` rows with `status=ASSIGNED`, traversing via `opportunity_access__opportunity_id` to scope to the opportunity. The shape of the subquery (group-by opportunity, return count) is preserved so the surrounding annotation behavior is unchanged.

- **Query change in `helpers.py`:** Replaced `TaskType.objects.filter(opportunity_id=..., is_active=True)` with `AssignedTask.objects.filter(opportunity_access__opportunity_id=..., status=AssignedTaskStatus.ASSIGNED)` inside the `active_tasks_count` subquery on `get_opportunity_delivery_progress`.
- **Imports:** Dropped the now-unused `TaskType` import; added `AssignedTask` and `AssignedTaskStatus`.

## Safety Assurance

### Safety story

The change is isolated to a single annotation subquery on a read-only dashboard helper. No migrations, no writes, no schema changes, and no changes to access control. The metric's semantics shift (configuration count → assigned-work count), but the surrounding view and consumers treat it as an integer count, so downstream behavior is unaffected. Easily revertible by restoring the prior subquery.

### Automated test coverage

- `commcare_connect/opportunity/tests/test_helpers.py::test_opportunity_delivery_stats` was extended to seed `AssignedTask` rows in `ASSIGNED` and `COMPLETED` states and assert `result.active_tasks_count == 2`, verifying both the count and that non-`ASSIGNED` statuses are excluded.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] On an opportunity with multiple `AssignedTask` rows in mixed statuses, load the opportunity delivery progress / dashboard view and confirm `active_tasks_count` reflects only `ASSIGNED` tasks.
- [ ] Confirm an opportunity with zero assigned tasks shows `active_tasks_count == 0` (rather than NULL/error).
- [ ] Confirm an opportunity with `TaskType` rows marked `is_active=True` but no `AssignedTask` rows reports `active_tasks_count == 0` (verifies the metric is no longer driven by task type config).

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
