### PR TITLE
Remove .claude from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -324,5 +324,4 @@ webpack-stats.json
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
 
-.claude
 .worktrees/


### PR DESCRIPTION
## Technical Summary
`.claude` was removed in [this PR](https://github.com/dimagi/commcare-connect/commit/3037a2115f4d45811195dbcc9b6e35b69baf2475#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947R327) (unintentionally). This PR is adding it back so we can add skills / plugins / agents to this repo if we need. 

## Safety Assurance

### Safety story
It's a safe change.

### Automated test coverage
n.a

### QA Plan
n.a

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
