### PR TITLE
Fix short_description max_length in ManagedOpportunityCreateSerializer

### DIFF
--- a/commcare_connect/program/api/serializers.py
+++ b/commcare_connect/program/api/serializers.py
@@ -130,7 +130,7 @@ class LearnAppInputSerializer(CommCareAppInputSerializer):
 class ManagedOpportunityCreateSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=255)
     description = serializers.CharField()
-    short_description = serializers.CharField(max_length=255)
+    short_description = serializers.CharField(max_length=50)
     organization = serializers.SlugRelatedField(slug_field="slug", queryset=Organization.objects.all())
     start_date = serializers.DateField()
     end_date = serializers.DateField()


### PR DESCRIPTION
## Product Description

Prevents users from submitting `short_description` values longer than 50 characters via the managed opportunity create API, which would have been accepted by the serializer but rejected by the database.

## Technical Summary

CI-659. The `short_description` field on `Opportunity` is defined as `max_length=50`, but `ManagedOpportunityCreateSerializer` declared the field with `max_length=255`, allowing oversized values past serializer validation only to fail at the model layer.

## Safety Assurance

### Safety story

One-line change tightening a serializer constraint to match the underlying model. Existing valid data (≤50 chars) is unaffected.

### Automated test coverage

No new tests — the constraint now matches the model and DB-level validation already cover the bound.

### QA Plan

- POST to the managed opportunity create endpoint with `short_description` > 50 chars and verify a 400 response.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change