### PR TITLE
Remove redundant work area upload fields

### DIFF
--- a/commcare_connect/microplanning/serializers.py
+++ b/commcare_connect/microplanning/serializers.py
@@ -31,8 +31,6 @@ class WorkAreaCaseSerializer(serializers.ModelSerializer):
             "ward": obj.ward,
             "work_area_group": getattr(obj.work_area_group, "name", ""),
             "work_area_group_id": str(obj.work_area_group_id) if obj.work_area_group_id else "",
-            "max_wag": str(obj.case_properties.get("max_wag", "")),
-            "wag_serial_number": str(obj.case_properties.get("wag_serial_number", "")),
             "lga": str(obj.case_properties.get("lga", "")),
             "state": str(obj.case_properties.get("state", "")),
         }

--- a/commcare_connect/microplanning/tasks.py
+++ b/commcare_connect/microplanning/tasks.py
@@ -37,8 +37,6 @@ class WorkAreaCSVImporter:
         "building_count": "Building Count",
         "visit_count": "Expected Visit Count",
         "target_population": "Target Population",
-        "max_wag": "Max WAG",
-        "wag_serial_number": "WAG Serial Number",
         "lga": "LGA",
         "state": "State",
     }
@@ -84,8 +82,6 @@ class WorkAreaCSVImporter:
                     expected_visit_count=visits,
                     target_population=self.get_target_population(row),
                     case_properties={
-                        "max_wag": extra_props.get("max_wag"),
-                        "wag_serial_number": extra_props.get("wag_serial_number"),
                         "lga": extra_props.get("lga"),
                         "state": extra_props.get("state"),
                     },
@@ -170,13 +166,9 @@ class WorkAreaCSVImporter:
         return self._get_int(row, "target_population")
 
     def get_extra_properties(self, row):
-        max_wag = row.get(self.HEADERS.get("max_wag"))
-        wag_serial_number = row.get(self.HEADERS.get("wag_serial_number"))
         lga = row.get(self.HEADERS.get("lga"))
         state = row.get(self.HEADERS.get("state"))
         return {
-            "max_wag": max_wag,
-            "wag_serial_number": wag_serial_number,
             "lga": lga,
             "state": state,
         }
@@ -287,8 +279,6 @@ class WorkAreaCSVExporter:
         "building_count": lambda wa: wa.building_count,
         "visit_count": lambda wa: wa.expected_visit_count,
         "target_population": lambda wa: wa.target_population,
-        "max_wag": lambda wa: (wa.case_properties or {}).get("max_wag", ""),
-        "wag_serial_number": lambda wa: (wa.case_properties or {}).get("wag_serial_number", ""),
         "lga": lambda wa: (wa.case_properties or {}).get("lga", ""),
         "state": lambda wa: (wa.case_properties or {}).get("state", ""),
         "group_name": lambda wa: wa.group_name or "",

--- a/commcare_connect/microplanning/tests/test_serializers.py
+++ b/commcare_connect/microplanning/tests/test_serializers.py
@@ -14,8 +14,6 @@ def test_work_area_case_serializer():
         building_count=5,
         expected_visit_count=10,
         case_properties={
-            "max_wag": "3",
-            "wag_serial_number": "WAG123",
             "lga": "LGA1",
             "state": "State1",
         },
@@ -36,8 +34,6 @@ def test_work_area_case_serializer():
             "ward": "ward-x",
             "work_area_group": "group-a",
             "work_area_group_id": str(group.id),
-            "max_wag": "3",
-            "wag_serial_number": "WAG123",
             "lga": "LGA1",
             "state": "State1",
         },

--- a/commcare_connect/microplanning/tests/test_tasks.py
+++ b/commcare_connect/microplanning/tests/test_tasks.py
@@ -27,8 +27,6 @@ class TestWorkAreaCSVImporter:
         "Building Count",
         "Expected Visit Count",
         "Target Population",
-        "Max WAG",
-        "WAG Serial Number",
         "LGA",
         "State",
     ]
@@ -54,8 +52,6 @@ class TestWorkAreaCSVImporter:
                     5,
                     "6",
                     "100",
-                    "3",
-                    "WAG123",
                     "LGA1",
                     "State1",
                 ]
@@ -145,8 +141,6 @@ class TestWorkAreaCSVImporter:
             "Ward",
             "Building Count",
             "Target Population",
-            "Max WAG",
-            "WAG Serial Number",
             "State",
             "LGA",
         ]
@@ -159,8 +153,6 @@ class TestWorkAreaCSVImporter:
             "ward-1",
             "5",
             "50",
-            "7",
-            "WAG456",
             "State2",
             "LGA2",
         ]
@@ -183,7 +175,7 @@ class TestWorkAreaCSVImporter:
         result = WorkAreaCSVImporter(opportunity.id, csv).run()
         assert "errors" in result
         error_keys = " ".join(result["errors"].keys()).lower()
-        expected_error = "Missing values for properties: max_wag, wag_serial_number, lga, state"
+        expected_error = "Missing values for properties: lga, state"
         assert expected_error.lower() in error_keys
 
 

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -647,7 +647,7 @@ class TestDownloadWorkAreas(BaseMicroplanningFlagTest):
             ward="ward-x",
             building_count=10,
             expected_visit_count=5,
-            case_properties={"max_wag": "3", "wag_serial_number": "42", "lga": "LGA1", "state": "State1"},
+            case_properties={"lga": "LGA1", "state": "State1"},
             work_area_group=WorkAreaGroupFactory(opportunity=opportunity, name="Group A"),
         )
         client.force_login(org_user_admin)
@@ -668,8 +668,6 @@ class TestDownloadWorkAreas(BaseMicroplanningFlagTest):
             "10",
             "5",
             "0",
-            "3",
-            "42",
             "LGA1",
             "State1",
             wa.work_area_group.name,
@@ -693,7 +691,7 @@ class TestDownloadWorkAreas(BaseMicroplanningFlagTest):
         WorkAreaFactory(opportunity=opportunity, case_properties=None, work_area_group=None)
         client.force_login(org_user_admin)
         row = self._parse_csv(client.get(self.url(opportunity)))[1]
-        assert row[6:] == ["0", "", "", "", "", ""]
+        assert row[6:] == ["0", "", "", ""]
 
     @pytest.mark.parametrize(
         "login_as, method, expected_status",
@@ -764,7 +762,7 @@ class TestDownloadWorkAreas(BaseMicroplanningFlagTest):
             building_count=4,
             expected_visit_count=2,
             work_area_group=WorkAreaGroupFactory(opportunity=opportunity, name="Rev Group"),
-            case_properties={"max_wag": "1", "wag_serial_number": "77", "lga": "RevLGA", "state": "RevState"},
+            case_properties={"lga": "RevLGA", "state": "RevState"},
         )
         client.force_login(org_user_admin)
 
@@ -781,8 +779,6 @@ class TestDownloadWorkAreas(BaseMicroplanningFlagTest):
         assert row_dict["Ward"] == "ward-rev"
         assert row_dict["Building Count"] == "4"
         assert row_dict["Expected Visit Count"] == "2"
-        assert row_dict["Max WAG"] == "1"
-        assert row_dict["WAG Serial Number"] == "77"
         assert row_dict["LGA"] == "RevLGA"
         assert row_dict["State"] == "RevState"
         assert row_dict["Work Area Group Name"] == "Rev Group"

--- a/commcare_connect/templates/microplanning/import_work_area_modal.html
+++ b/commcare_connect/templates/microplanning/import_work_area_modal.html
@@ -115,8 +115,6 @@
                                 <li>{% translate "Boundary – Polygon in WKT format" %}</li>
                                 <li>{% translate "Building Count – positive integer" %}</li>
                                 <li>{% translate "Expected Visit Count – positive integer" %}</li>
-                                <li>{% translate "Max WAG – positive integer" %}</li>
-                                <li>{% translate "WAG Serial Number – Determines which order Connect Worker should visit the work area groups" %}</li>
                                 <li>{% translate "LGA – name of the LGA the work area is in" %}</li>
                                 <li>{% translate "State – name of the state the work area is in" %}</li>
                             </ul>


### PR DESCRIPTION
## Product Description
This PR removes these two fields that are not needed anymore in work area upload.
- max_wag
- wag_serial_number

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2446)

## Safety Assurance
### Safety story
- Tested Locally

### Automated test coverage
- Updated Automated Tests

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
