### PR TITLE
Fix invoice report download not working (CI-648)

### DIFF
--- a/commcare_connect/reports/tests/test_reports.py
+++ b/commcare_connect/reports/tests/test_reports.py
@@ -567,6 +567,12 @@ class TestInvoiceReportFilter:
         assert getattr(self, expected_in).id in ids
         assert getattr(self, expected_out).id not in ids
 
+    def test_instantiation_without_request(self):
+        qs = InvoiceReportView.get_invoice_queryset(user=self.user)
+        f = InvoiceReportFilter(data={}, queryset=qs)
+        assert f.is_valid()
+        assert set(f.qs.values_list("id", flat=True)) == {self.invoice1.id, self.invoice2.id}
+
     @pytest.mark.parametrize(
         "use_member_user, other_opp_visible",
         [

--- a/commcare_connect/reports/views.py
+++ b/commcare_connect/reports/views.py
@@ -221,7 +221,7 @@ class InvoiceReportFilter(django_filters.FilterSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not self.request.user.has_perm(ALL_ORG_ACCESS):
+        if self.request and not self.request.user.has_perm(ALL_ORG_ACCESS):
             self.filters["opportunity_name"].queryset = (
                 ManagedOpportunity.objects.filter(program__organization__memberships__user=self.request.user)
                 .distinct()
@@ -312,7 +312,7 @@ class InvoiceReportView(
 @login_required
 @permission_required(INVOICE_REPORT_ACCESS, raise_exception=True)
 def export_invoice_report(request):
-    filterset = InvoiceReportFilter(request.POST, queryset=PaymentInvoice.objects.none())
+    filterset = InvoiceReportFilter(request.POST, queryset=PaymentInvoice.objects.none(), request=request)
     if not filterset.is_valid():
         return HttpResponse("Invalid filters", status=400)
 


### PR DESCRIPTION
## Product Description

The download (↓) button on the **Invoice Report** page (`/admin_reports/invoice_report`) silently does nothing — no file is generated, no error is shown. Reproduces for any combination of filters. After this fix, clicking download starts the export, shows the progress spinner, and produces a CSV via the existing "Download Export" link.

| Before | After |
| --- | --- |
| Click → page unchanged, no error visible | Click → spinner → "Download Export" link → CSV |

## Technical Summary

Jira: [CI-648](https://dimagi.atlassian.net/browse/CI-648)

Root cause: `InvoiceReportFilter.__init__` accessed `self.request.user.has_perm(ALL_ORG_ACCESS)` unguarded. django-filter's `FilterSet` only populates `self.request` when constructed via a `FilterView` (the page-display path). The two manual instantiations — `export_invoice_report` (POST handler for the download button) and `export_invoice_report_task` (Celery task) — pass no `request`, so `self.request` was `None` and `__init__` raised `AttributeError: 'NoneType' object has no attribute 'user'`. The POST returned 500, no `HX-Redirect` header was issued, htmx made no follow-up navigation, and the user saw nothing happen.

The null guard was originally in place but was removed in `8544403e "removed null check"`, which is what broke the flow.

Fix (`commcare_connect/reports/views.py`):
- `InvoiceReportFilter.__init__`: guard the per-user dropdown scoping behind `if self.request and ...`, so the filter can be constructed outside a view.
- `export_invoice_report`: pass `request=request` to the filter so the scoping still applies when validating posted filter data.

## Safety Assurance

### Safety story

- Scope is narrow: three lines in one filter class. No model, migration, or URL changes.
- The guard only re-allows `self.request is None`; the existing behavior when `self.request` is set is unchanged. The branch it protects (`opportunity_name` queryset narrowing for non-`ALL_ORG_ACCESS` users) only affects what the form *validates*; the actual returned queryset is independently scoped in `InvoiceReportView.get_invoice_queryset(user=...)`, which is unchanged.
- The page-display path (`FilterView`) was never broken because django-filter passes `request` automatically there. This PR doesn't change that path.

### Automated test coverage

Added `TestInvoiceReportFilter.test_instantiation_without_request`: constructs the filter without a request, asserts it validates and returns the expected queryset. This is exactly the path that previously raised `AttributeError`; it fails without the fix and passes with it.

The pre-existing `test_export_invoice_report_task_creates_export_file` mocked out `InvoiceReportFilter` entirely, so it didn't catch this regression — the new test exercises the real class.

### QA Plan

Manually reproduced end-to-end with Playwright against a local dev server + Celery worker:
- Seeded an org, a user with `invoice_report_access` permission, and three `PaymentInvoice`s.
- Logged in, navigated to `/admin_reports/invoice_report`, clicked the download button.
- **Before fix:** `POST /admin_reports/export_invoice_report` → 500 (AttributeError), page unchanged, no spinner, no download. Matches the reported symptom.
- **After fix:** `POST` → 204 with `HX-Redirect: /admin_reports/invoice_report?task_id=…`, htmx redirected, spinner ran, "Download Export" link appeared, CSV contained the three seeded invoices.

QA on staging: log in as a user with Invoice Report access, open the Invoice Report, click the download icon with and without filters applied, confirm the spinner appears and the CSV downloads.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CI-648]: https://dimagi.atlassian.net/browse/CI-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ