### PR TITLE
Exclude test opportunities from auto-invoice generation

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -637,9 +637,9 @@ def generate_automated_service_delivery_invoice():
     opp_start_date = datetime.date(2026, 1, 1)
     created_invoices_ids = []
 
-    for opportunity in Opportunity.objects.filter(active=True, managed=True, start_date__gte=opp_start_date).iterator(
-        chunk_size=CHUNK_SIZE
-    ):
+    for opportunity in Opportunity.objects.filter(
+        active=True, managed=True, is_test=False, start_date__gte=opp_start_date
+    ).iterator(chunk_size=CHUNK_SIZE):
         start_date = get_start_date_for_invoice(opportunity)
         # Below indicates there are no uninvoiced completed works to invoice in previous month or earlier
         if start_date > end_date_prev_month:

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -290,8 +290,12 @@ class TestGenerateAutomatedServiceDeliveryInvoice:
             yield
 
     def test_generate_invoice_for_two_active_managed_opportunities(self):
-        opportunity1 = OpportunityFactory(active=True, managed=True, start_date=datetime.date(2026, 1, 1))
-        opportunity2 = OpportunityFactory(active=True, managed=True, start_date=datetime.date(2026, 12, 1))
+        opportunity1 = OpportunityFactory(
+            active=True, managed=True, is_test=False, start_date=datetime.date(2026, 1, 1)
+        )
+        opportunity2 = OpportunityFactory(
+            active=True, managed=True, is_test=False, start_date=datetime.date(2026, 12, 1)
+        )
 
         payment_unit1 = PaymentUnitFactory(opportunity=opportunity1, amount=Decimal("100.00"))
         payment_unit2 = PaymentUnitFactory(opportunity=opportunity2, amount=Decimal("50.00"))
@@ -341,7 +345,9 @@ class TestGenerateAutomatedServiceDeliveryInvoice:
         assert completed_work2.invoice == invoice2
 
     def test_no_invoice_for_inactive_opportunities(self):
-        inactive_opportunity = OpportunityFactory(active=False, managed=True, start_date=datetime.date(2026, 1, 1))
+        inactive_opportunity = OpportunityFactory(
+            active=False, managed=True, is_test=False, start_date=datetime.date(2026, 1, 1)
+        )
         payment_unit = PaymentUnitFactory(opportunity=inactive_opportunity)
         access = OpportunityAccessFactory(opportunity=inactive_opportunity)
         completed_work = CompletedWorkFactory(
@@ -361,7 +367,9 @@ class TestGenerateAutomatedServiceDeliveryInvoice:
         assert completed_work.invoice is None
 
     def test_no_invoice_for_active_unmanaged_opportunity(self):
-        unmanaged_opportunity = OpportunityFactory(active=True, managed=False, start_date=datetime.date(2026, 1, 1))
+        unmanaged_opportunity = OpportunityFactory(
+            active=True, managed=False, is_test=False, start_date=datetime.date(2026, 1, 1)
+        )
         payment_unit = PaymentUnitFactory(opportunity=unmanaged_opportunity, amount=Decimal("100.00"))
         access = OpportunityAccessFactory(opportunity=unmanaged_opportunity)
         completed_work = CompletedWorkFactory(
@@ -379,12 +387,36 @@ class TestGenerateAutomatedServiceDeliveryInvoice:
         assert completed_work.invoice is None
 
     def test_no_invoice_with_no_approved_work(self):
-        opportunity = OpportunityFactory(active=True, managed=True, start_date=datetime.date(2026, 1, 1))
+        opportunity = OpportunityFactory(
+            active=True, managed=True, is_test=False, start_date=datetime.date(2026, 1, 1)
+        )
 
         generate_automated_service_delivery_invoice()
 
         invoice = PaymentInvoice.objects.filter(opportunity=opportunity)
         assert len(invoice) == 0
+
+    def test_no_invoice_for_test_opportunity(self):
+        test_opportunity = OpportunityFactory(
+            active=True, managed=True, is_test=True, start_date=datetime.date(2026, 1, 1)
+        )
+        payment_unit = PaymentUnitFactory(opportunity=test_opportunity, amount=Decimal("100.00"))
+        access = OpportunityAccessFactory(opportunity=test_opportunity)
+        completed_work = CompletedWorkFactory(
+            opportunity_access=access,
+            payment_unit=payment_unit,
+            status=CompletedWorkStatus.approved,
+            status_modified_date=datetime.date(2024, 1, 5),
+        )
+        completed_work.saved_payment_accrued = Decimal("100.00")
+        completed_work.save()
+
+        generate_automated_service_delivery_invoice()
+
+        completed_work.refresh_from_db()
+
+        assert PaymentInvoice.objects.count() == 0
+        assert completed_work.invoice is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Product Description

Auto-generated service delivery invoices were being created for Opportunities marked as test. Test Opps should never be invoiced. This change ensures only non-test Opportunities are included in the auto-invoice generation process.

## Technical Summary
Ticket: [CI-666](https://dimagi.atlassian.net/browse/CI-666)

The `generate_automated_service_delivery_invoice()` Celery task queried `Opportunity.objects.filter(active=True, managed=True, start_date__gte=...)`, which did not exclude test opportunities. Added `is_test=False` to that filter.

**Gotcha worth noting:** `Opportunity.is_test` defaults to `True` at the model level, and `OpportunityFactory` does not override it. So before this change every opportunity in the existing invoice tests was technically a test opportunity — they only passed because the filter ignored `is_test`. The existing tests now set `is_test=False` explicitly so they continue to generate invoices, and the "no invoice" tests set it too so they isolate the condition under test rather than passing because of the new filter.

## Safety Assurance

### Safety story

Single, narrowly-scoped query filter addition. No data migration. Existing real opportunities created without explicitly setting `is_test=False` will now be excluded from auto-invoicing — this is the intended behavior per the acceptance criteria, but worth confirming production opportunities that should be invoiced have `is_test=False`.

### Automated test coverage

- Added `test_no_invoice_for_test_opportunity`: a test opp (`is_test=True`) with approved work produces no invoice and its completed work is not linked.
- Existing invoice tests updated to set `is_test=False`; they continue to assert correct invoice generation for non-test opps (no regression).

### QA Plan

- Confirm auto-invoice run produces invoices for non-test active/managed opps with approved work.
- Confirm test opps are skipped entirely.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CI-666]: https://dimagi.atlassian.net/browse/CI-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ