### PR TITLE
Fix use user uuid instead of id for View Visits view

### DIFF
--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -260,7 +260,7 @@ def _get_assignment_mode_context(request, opportunity):
         "assignees_json": list(
             OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True, suspended=False)
             .select_related("user")
-            .values("id", "user__name", "user_id")
+            .values("id", "user__name", "user__user_id")
         ),
         "group_work_areas_url": reverse(
             "microplanning:get_work_areas_for_assignment",

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -352,12 +352,12 @@
 
             getAssigneeUserId() {
                 const a = this.assignees.find(a => String(a.id) === String(this.selectedAssigneeId));
-                return a ? a.user_id : '';
+                return a ? a.user__user_id : '';
             },
 
             getFlwSummaryUserId() {
                 const a = this.assignees.find(a => String(a.id) === String(this.flwSummaryAssigneeId));
-                return a ? a.user_id : '';
+                return a ? a.user__user_id : '';
             },
 
             addToQueue() {


### PR DESCRIPTION
## Product Description
This PR changes the id that is passed to the User Visit Verification view URL. The view expects an UUID instead of the ID.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/QA-8526)

## Safety Assurance
### Safety story
- Tested Locally

### QA Plan
- QA request already exists.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
