### PR TITLE
Revert updates to the clustering algorithm and change max building count

### DIFF
--- a/commcare_connect/microplanning/clustering.py
+++ b/commcare_connect/microplanning/clustering.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass
 from django.db import transaction
 from pyproj import Transformer
 from shapely import get_dimensions, wkb
-from shapely.geometry import LineString
 from shapely.geometry.base import BaseGeometry
-from shapely.ops import nearest_points, transform
+from shapely.ops import transform
 from shapely.strtree import STRtree
 
 from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup, WorkAreaStatus
@@ -55,14 +54,9 @@ class WorkAreaGrouper:
         opportunity_id:  The ID of the opportunity whose work areas should be grouped
         max_buildings:   Maximum total building count allowed per work area group.
                          Default is 300.
-        max_work_areas:  Maximum number of work areas allowed per work area group.
-                         Default is 60. Either cap (max_buildings or max_work_areas)
-                         stops cluster growth — whichever trips first.
         buffer_distance: Distance in meters to consider work areas as adjacent even if
-                         they don't share a boundary. Default is 10 meters — large
-                         enough to tolerate minor topology slivers in input polygons,
-                         small enough to avoid bridging clusters across real gaps
-                         between distinct regions.
+                         they don't share a boundary. Default is 100 meters. This helps
+                         connect work areas that are close but separated by small gaps.
 
     Note:
         - Only work areas without an existing work_area_group are processed
@@ -75,12 +69,10 @@ class WorkAreaGrouper:
         self,
         opportunity_id: int,
         max_buildings: int = 300,
-        max_work_areas: int = 60,
-        buffer_distance: int = 10,
+        buffer_distance: int = 100,
     ):
         self.opportunity_id = opportunity_id
         self.max_buildings = max_buildings
-        self.max_work_areas = max_work_areas
         self.buffer_distance = buffer_distance
         self.transformer = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
 
@@ -98,13 +90,11 @@ class WorkAreaGrouper:
             wards[wa_data.ward].append(wa_id)
 
         logger.info(
-            "Opportunity %s: clustering %d work areas across %d wards "
-            "(max_buildings=%d, max_work_areas=%d, buffer_distance=%d)",
+            "Opportunity %s: clustering %d work areas across %d wards (max_buildings=%d, buffer_distance=%d)",
             self.opportunity_id,
             len(work_areas),
             len(wards),
             self.max_buildings,
-            self.max_work_areas,
             self.buffer_distance,
         )
 
@@ -201,39 +191,17 @@ class WorkAreaGrouper:
                 shared_edge = geom.intersection(candidate_geom)
                 dist = geom.distance(candidate_geom)
 
-                is_shared_edge = not shared_edge.is_empty and get_dimensions(shared_edge) >= 1
-                is_close_enough = 0 < dist <= self.buffer_distance
-                if not is_shared_edge and not is_close_enough:
-                    continue
-
-                if not is_shared_edge and self._has_blocker(
-                    geom, candidate_geom, spatial_index, wa_ids_list, work_area_id, neighbour_id
-                ):
-                    continue
-
-                adjacency[work_area_id].add(neighbour_id)
-                adjacency[neighbour_id].add(work_area_id)
-                pair = (min(work_area_id, neighbour_id), max(work_area_id, neighbour_id))
-                distances[pair] = dist
+                if get_dimensions(shared_edge) >= 1 or dist <= self.buffer_distance:
+                    adjacency[work_area_id].add(neighbour_id)
+                    adjacency[neighbour_id].add(work_area_id)
+                    pair = (min(work_area_id, neighbour_id), max(work_area_id, neighbour_id))
+                    distances[pair] = dist
 
         def _dist(wa_id, neighbour_id):
             pair = (min(wa_id, neighbour_id), max(wa_id, neighbour_id))
             return distances[pair]
 
         return {wa_id: sorted(neighbours, key=lambda n: _dist(wa_id, n)) for wa_id, neighbours in adjacency.items()}
-
-    @staticmethod
-    def _has_blocker(geom, candidate_geom, spatial_index, wa_ids_list, work_area_id, neighbour_id):
-        # Distance-based adjacency: skip if another work area's polygon sits on the line
-        # between the two nearest points. Prevents BFS from forming an over-the-top edge
-        # that bridges two regions separated by an intervening work area.
-        near_a, near_b = nearest_points(geom, candidate_geom)
-        connector = LineString([near_a, near_b])
-        for idx in spatial_index.query(connector, predicate="intersects"):
-            blocker_id = wa_ids_list[idx]
-            if blocker_id != work_area_id and blocker_id != neighbour_id:
-                return True
-        return False
 
     def _bfs_cluster(
         self,
@@ -255,7 +223,7 @@ class WorkAreaGrouper:
 
             building_count = work_areas[current].building_count
 
-            if total_buildings + building_count > self.max_buildings or len(cluster) >= self.max_work_areas:
+            if total_buildings + building_count > self.max_buildings:
                 seen.discard(current)
                 continue
 

--- a/commcare_connect/microplanning/clustering.py
+++ b/commcare_connect/microplanning/clustering.py
@@ -53,7 +53,7 @@ class WorkAreaGrouper:
     Args:
         opportunity_id:  The ID of the opportunity whose work areas should be grouped
         max_buildings:   Maximum total building count allowed per work area group.
-                         Default is 300.
+                         Default is 200.
         buffer_distance: Distance in meters to consider work areas as adjacent even if
                          they don't share a boundary. Default is 100 meters. This helps
                          connect work areas that are close but separated by small gaps.
@@ -68,7 +68,7 @@ class WorkAreaGrouper:
     def __init__(
         self,
         opportunity_id: int,
-        max_buildings: int = 300,
+        max_buildings: int = 200,
         buffer_distance: int = 100,
     ):
         self.opportunity_id = opportunity_id

--- a/commcare_connect/microplanning/tests/test_clustering.py
+++ b/commcare_connect/microplanning/tests/test_clustering.py
@@ -190,9 +190,8 @@ class TestWorkAreaGrouper:
         assert work_area.work_area_group is None
 
     def test_cluster_corner_sharing_work_areas(self, opportunity):
-        """Work areas sharing only a corner (point) must NOT be grouped together.
-        Diagonal-only neighbors aren't meaningfully contiguous — adjacency requires
-        a shared edge (dim >= 1) or strictly-positive distance within buffer_distance."""
+        """Work areas sharing only a corner (point) should be grouped together
+        because their distance is 0, which is within the default buffer_distance."""
         size = 0.01
         # Create two squares that touch only at a corner point
         wa1 = WorkAreaFactory(
@@ -228,11 +227,11 @@ class TestWorkAreaGrouper:
         grouper.cluster_work_areas()
 
         groups = WorkAreaGroup.objects.filter(opportunity=opportunity)
-        assert groups.count() == 2
+        assert groups.count() == 1
 
         wa1.refresh_from_db()
         wa2.refresh_from_db()
-        assert wa1.work_area_group != wa2.work_area_group
+        assert wa1.work_area_group == wa2.work_area_group
 
     def test_cluster_single_work_area_exceeding_max_buildings(self, opportunity):
         work_area = WorkAreaFactory(
@@ -255,124 +254,3 @@ class TestWorkAreaGrouper:
         assert group.building_count == 500
         work_area.refresh_from_db()
         assert work_area.work_area_group == group
-
-    def test_cluster_respects_max_work_areas(self, opportunity):
-        """4 adjacent WAs (200 buildings total) with max_work_areas=2 should split into 2 groups
-        of 2 WAs each. The building cap (default 300) does not trip — only the count cap does."""
-        work_areas = self.create_adjacent_work_areas(opportunity, ward="ward-1")
-        # create_adjacent_work_areas sets building_count=50 per WA; total = 200, well under 300.
-
-        grouper = WorkAreaGrouper(
-            opportunity_id=opportunity.id,
-            max_buildings=300,
-            max_work_areas=2,
-        )
-        grouper.cluster_work_areas()
-
-        groups = WorkAreaGroup.objects.filter(opportunity=opportunity)
-        assert groups.count() == 2
-        for group in groups:
-            assert group.workarea_set.count() == 2
-
-        for work_area in work_areas:
-            work_area.refresh_from_db()
-            assert work_area.work_area_group is not None
-
-    def test_cluster_no_bridging_across_wide_gap(self, opportunity):
-        """Two pairs of edge-sharing WAs separated by a ~33m gap should produce 2 groups, not 1.
-
-        Input coordinates are in EPSG:4326 (degrees); the clustering algorithm projects them
-        to EPSG:3857 (Web Mercator meters) for distance math. At the equator the conversion
-        is ~0.0003° longitude → ~33 m of projected distance — wider than the default
-        buffer_distance (10 m) but narrower than the previous default (100 m). Pins the fix
-        for CCCT-2392 Part 1: clusters must not bridge realistic inter-region gaps."""
-        size = 0.001  # 4326 degrees; projects to ~111 m squares in EPSG:3857
-        gap = 0.0003  # 4326 degrees; ~33 m gap in EPSG:3857 — between new (10 m) and old (100 m) defaults
-
-        start_a = 77.0
-        start_b = start_a + 2 * size + gap
-
-        for x_start, slug in [
-            (start_a, "a1"),
-            (start_a + size, "a2"),
-            (start_b, "b1"),
-            (start_b + size, "b2"),
-        ]:
-            x_end = x_start + size
-            WorkAreaFactory(
-                opportunity=opportunity,
-                slug=f"area-{slug}",
-                ward="ward-1",
-                centroid=Point(x_start + size / 2, 28.0 + size / 2, srid=SRID),
-                boundary=Polygon(
-                    ((x_start, 28.0), (x_end, 28.0), (x_end, 28.0 + size), (x_start, 28.0 + size), (x_start, 28.0)),
-                    srid=SRID,
-                ),
-                building_count=50,
-            )
-
-        grouper = WorkAreaGrouper(opportunity_id=opportunity.id)
-        grouper.cluster_work_areas()
-
-        groups = WorkAreaGroup.objects.filter(opportunity=opportunity)
-        assert groups.count() == 2
-        for group in groups:
-            assert group.workarea_set.count() == 2
-
-    def test_cluster_does_not_bridge_across_intervening_wa(self, opportunity):
-        """5 WAs in a row, all sharing edges (A1-A2-X-B1-B2). X has a high building count
-        that prevents BFS expansion through it.
-
-        Without the blocker check: A2↔B1 forms an over-the-top adjacency edge (their nearest
-        corners are within buffer_distance), letting BFS from A1 reach B1 by skipping over X.
-        That would cluster {A1, A2, B1} together — physically separated by X — which is the
-        bug this test pins.
-
-        With the blocker check: the line from A2's nearest point to B1's nearest point passes
-        through X's polygon, so the A2↔B1 edge is filtered. BFS routes only through shared
-        edges. Result: {A1, A2}, {X}, {B1, B2}."""
-        size = 0.00008  # 4326 degrees; ~8.9 m in EPSG:3857 — within default buffer_distance=10m
-        layout = [
-            ("a1", 0, 50),
-            ("a2", 1, 50),
-            ("x", 2, 200),
-            ("b1", 3, 50),
-            ("b2", 4, 50),
-        ]
-
-        created = []
-        for slug, idx, buildings in layout:
-            x_start = idx * size
-            x_end = x_start + size
-            wa = WorkAreaFactory(
-                opportunity=opportunity,
-                slug=f"area-{slug}",
-                ward="ward-1",
-                centroid=Point(x_start + size / 2, 28.0 + size / 2, srid=SRID),
-                boundary=Polygon(
-                    (
-                        (x_start, 28.0),
-                        (x_end, 28.0),
-                        (x_end, 28.0 + size),
-                        (x_start, 28.0 + size),
-                        (x_start, 28.0),
-                    ),
-                    srid=SRID,
-                ),
-                building_count=buildings,
-            )
-            created.append(wa)
-
-        grouper = WorkAreaGrouper(opportunity_id=opportunity.id, max_buildings=150)
-        grouper.cluster_work_areas()
-
-        for wa in created:
-            wa.refresh_from_db()
-        a1, a2, x, b1, b2 = created
-
-        assert a1.work_area_group_id == a2.work_area_group_id
-        assert b1.work_area_group_id == b2.work_area_group_id
-        assert a1.work_area_group_id != b1.work_area_group_id
-        assert x.work_area_group_id != a1.work_area_group_id
-        assert x.work_area_group_id != b1.work_area_group_id
-        assert WorkAreaGroup.objects.filter(opportunity=opportunity).count() == 3


### PR DESCRIPTION
## Product Description

No user-facing changes. This affects how work areas are grouped together internally when a admin triggers clustering.

## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-2453

Reverts all changes from PR #1164 (CCCT-2392). The original algorithm has been restored. Additionally, the maximum building count per cluster has been reduced from 300 to 200.

## Safety Assurance

### Safety story

This revert restores a version of the algorithm that was already live and stable prior to PR #1164. Additionally, reducing the maximum building count per cluster from 300 to 200 results in smaller clusters, which is the intended behaviour.

### Automated test coverage
All tests are passing.

### QA Plan
Not required

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
