### PR TITLE
Show User Error on Inaccessibility Review Submit Failure

### DIFF
--- a/commcare_connect/static/js/review_inaccessibility_modal.js
+++ b/commcare_connect/static/js/review_inaccessibility_modal.js
@@ -83,3 +83,10 @@ function initReviewInaccessibilityMap() {
 }
 
 initReviewInaccessibilityMap();
+
+function reviewFormResponseError(event) {
+  const el = document.getElementById('review-inaccessibility-error');
+  if (event.detail.xhr.responseText)
+    el.textContent = event.detail.xhr.responseText;
+  el.classList.remove('hidden');
+}

--- a/commcare_connect/static/js/review_inaccessibility_modal.js
+++ b/commcare_connect/static/js/review_inaccessibility_modal.js
@@ -84,6 +84,17 @@ function initReviewInaccessibilityMap() {
 
 initReviewInaccessibilityMap();
 
+function reviewFormBeforeRequest(form) {
+  form.querySelectorAll('button').forEach((b) => (b.disabled = true));
+  document
+    .getElementById('review-inaccessibility-error')
+    .classList.add('hidden');
+}
+
+function reviewFormAfterRequest(form) {
+  form.querySelectorAll('button').forEach((b) => (b.disabled = false));
+}
+
 function reviewFormResponseError(event) {
   const el = document.getElementById('review-inaccessibility-error');
   if (event.detail.xhr.responseText)

--- a/commcare_connect/templates/microplanning/review_inaccessibility_modal.html
+++ b/commcare_connect/templates/microplanning/review_inaccessibility_modal.html
@@ -51,6 +51,8 @@
     <form hx-post="{% url 'microplanning:act_on_inaccessibility_request' request.org.slug request.opportunity.opportunity_id work_area.id %}"
           hx-swap="none"
           hx-indicator="#review-submit-spinner"
+          hx-on:htmx:before-request="reviewFormBeforeRequest(this)"
+          hx-on:htmx:after-request="reviewFormAfterRequest(this)"
           hx-on:htmx:response-error="reviewFormResponseError(event)">
         <div class="mt-6 flex justify-between gap-3">
             <button type="button"

--- a/commcare_connect/templates/microplanning/review_inaccessibility_modal.html
+++ b/commcare_connect/templates/microplanning/review_inaccessibility_modal.html
@@ -43,11 +43,15 @@
         {% endif %}
     </div>
 
+    <div id="review-inaccessibility-error"
+         class="hidden mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+        {% translate "Something went wrong. Please try again." %}
+    </div>
+
     <form hx-post="{% url 'microplanning:act_on_inaccessibility_request' request.org.slug request.opportunity.opportunity_id work_area.id %}"
           hx-swap="none"
           hx-indicator="#review-submit-spinner"
-          hx-on:htmx:before-request="this.querySelectorAll('button').forEach(b => b.disabled = true)"
-          hx-on:htmx:after-request="this.querySelectorAll('button').forEach(b => b.disabled = false)">
+          hx-on:htmx:response-error="reviewFormResponseError(event)">
         <div class="mt-6 flex justify-between gap-3">
             <button type="button"
                     @click="showReviewInaccessibilityModal = false"


### PR DESCRIPTION
## Product Description

When the approve/deny form in the Review Inaccessibility Request modal encounters an HTTP error, an inline error banner is now displayed beneath the photo evidence section. The banner shows the server's error message if one is provided, or a generic fallback message otherwise.

<img width="665" height="677" alt="Screenshot_20260528_155232" src="https://github.com/user-attachments/assets/e8f79db1-6e9d-4a2f-9634-0de10fd621cb" />

## Technical Summary

[CCCT-2454](https://dimagi.atlassian.net/browse/CCCT-2454)

This is a release path 3 feature — Experiments & early stage iterations of product area

The modal's form previously had no `htmx:response-error` handler, so server errors from the approve/deny action were silently swallowed. This PR adds an error banner and wires up the handler to show it. Inline htmx event handlers were also refactored into named functions in the accompanying JS file to keep the template readable.

- **Error banner:** A hidden `<div id="review-inaccessibility-error">` is pre-populated with a translated fallback message and shown on error; the server's `responseText` overrides the fallback when present.
- **Inline JS → JS file:** Three htmx event handlers (`before-request`, `after-request`, `response-error`) extracted from the template into `reviewFormBeforeRequest`, `reviewFormAfterRequest`, and `reviewFormResponseError` in `review_inaccessibility_modal.js`.
- **Button disabling:** Buttons are disabled for the duration of the request (pre-existing behaviour, now also correctly re-enabled after errors via the `after-request` handler).

## Safety Assurance

### Safety story

This is a purely frontend change — no models, views, or data are modified. The error handler is additive; the existing approve/deny endpoint behaviour is unchanged. Tested locally by submitting the form against a view that returns a 400.

### Automated test coverage

No new automated tests — there is no server-side logic change to cover. The affected code paths are frontend-only htmx event handling.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Open the microplanning map and click into a work area with a pending inaccessibility request
- [ ] Open the Review Inaccessibility Request modal
- [ ] Simulate a server error (e.g. temporarily break the endpoint or use devtools to block the request) and submit the form
- [ ] Confirm the red error banner appears with an appropriate message
- [ ] Confirm the buttons are re-enabled after the error so the user can retry
- [ ] Confirm the error banner is hidden when the form is submitted again
- [ ] Confirm normal approve/deny flow still works without showing the banner

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2454]: https://dimagi.atlassian.net/browse/CCCT-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ