### PR TITLE
Fix flw summary double counting stats

### DIFF
--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -338,13 +338,13 @@
                                 <div class="grid grid-cols-2 items-center gap-2 text-sm">
                                     <dt class="text-gray-500">{% translate "Count of Assigned Buildings" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_buildings + getQueuedStatsForAssignee().buildings + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStats().buildings : 0)"></dd>
+                                        x-text="flwSummary.assigned_buildings + getQueuedStatsForAssignee().buildings + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().buildings : 0)"></dd>
                                     <dt class="text-gray-500">{% translate "Count of Assigned Visits" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_visits + getQueuedStatsForAssignee().visits + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStats().visits : 0)"></dd>
+                                        x-text="flwSummary.assigned_visits + getQueuedStatsForAssignee().visits + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().visits : 0)"></dd>
                                     <dt class="text-gray-500">{% translate "Count of Assigned Work Areas" %}</dt>
                                     <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                                        x-text="flwSummary.assigned_work_areas + getQueuedStatsForAssignee().workAreas + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? selectedWorkAreas.size : 0)"></dd>
+                                        x-text="flwSummary.assigned_work_areas + getQueuedStatsForAssignee().workAreas + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().workAreas : 0)"></dd>
                                 </div>
                             </dl>
                             <div class="flex gap-2 mt-3">

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -331,6 +331,27 @@
                 return { buildings, visits };
             },
 
+            getSelectedStatsForSummary() {
+                // Live preview of pending changes for the FLW summary. Only count
+                // selected work areas that are NOT already assigned to this FLW.
+                // selectByAssignee() auto-selects the FLW's existing areas (tracked in
+                // flwFilterWorkAreaIds); those are already reflected in flwSummary, so
+                // including them here would double-count buildings/visits/work areas.
+                let buildings = 0;
+                let visits = 0;
+                let workAreas = 0;
+                for (const id of this.selectedWorkAreas) {
+                    if (this.flwFilterWorkAreaIds.has(id)) continue;
+                    const props = this.workAreaProperties.get(id);
+                    if (props) {
+                        buildings += parseInt(props.building_count) || 0;
+                        visits += parseInt(props.expected_visit_count) || 0;
+                    }
+                    workAreas += 1;
+                }
+                return { buildings, visits, workAreas };
+            },
+
             getQueuedStatsForAssignee() {
                 let buildings = 0;
                 let visits = 0;


### PR DESCRIPTION
## Product Description
This PR fixes the code for flw summary tab, earlier it was double counting the stats. 
Picking an FLW in the "Select new Assignee" dropdown runs selectByAssignee(), which auto-selects all of that FLW's already-assigned work areas on the map. The FLW Summary then counted those areas twice — once from the server total (flwSummary.assigned_*) and again from the selection preview term — so buildings, visits, and work areas all showed ~double.

Old: 
<img width="472" height="391" alt="image" src="https://github.com/user-attachments/assets/192633e7-4a7f-44d0-b4f7-6a1d0d0c80ea" />
Fixed:
<img width="472" height="391" alt="image" src="https://github.com/user-attachments/assets/9bf7b8f1-69fc-4013-b358-05b520481160" />

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/QA-8531)

## Safety Assurance
### Safety story
- Tested Locally

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
