### PR TITLE
Deny Duplicate Inacessibility Requests

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -297,6 +297,9 @@ def process_work_area_update(user: User, opportunity: Opportunity, xform: XForm,
         except WorkArea.DoesNotExist:
             raise ProcessingError("Work area not found")
 
+        if WorkAreaInaccessibilityRequest.objects.filter(work_area=work_area).exists():
+            raise ProcessingError("Only one inaccessibility request per work area")
+
         if work_area.opportunity_access_id != access.id:
             raise ProcessingError("User is not assigned to this work area")
 
@@ -322,16 +325,14 @@ def process_work_area_update(user: User, opportunity: Opportunity, xform: XForm,
         additional_details = block.get("additional_details", "")
         location = _parse_xform_location(xform.metadata.location)
 
-        WorkAreaInaccessibilityRequest.objects.get_or_create(
+        WorkAreaInaccessibilityRequest.objects.create(
             work_area=work_area,
-            defaults={
-                "opportunity_access": access,
-                "xform_id": xform.id,
-                "date_of_visit": xform.metadata.timeStart.date(),
-                "location": location,
-                "reason": reason,
-                "additional_details": additional_details,
-            },
+            opportunity_access=access,
+            xform_id=xform.id,
+            date_of_visit=xform.metadata.timeStart.date(),
+            location=location,
+            reason=reason,
+            additional_details=additional_details,
         )
         all_attachments = xform.raw_form.get("attachments", {})
         photo_attachments = {name: meta for name, meta in all_attachments.items() if name == photo_evidence}


### PR DESCRIPTION
## Product Description

When a mobile worker submits an inaccessibility request form for a work area that already has one on record, the system now rejects the duplicate with a processing error instead of silently ignoring the second submission. This enforces the one-request-per-work-area constraint at the application layer.

## Technical Summary

Link to related PR [here](https://github.com/dimagi/commcare-connect/pull/1225).
This is a release path 3 feature — Experiments & early stage iterations of product area.

Previously, `process_work_area_update` used `get_or_create` when saving a `WorkAreaInaccessibilityRequest`, which silently dropped any follow-up submissions for the same work area. This PR replaces that with a guard check that raises a `ProcessingError` before attempting to create, paired with a plain `create` call. This makes the duplicate-rejection explicit and observable (the error surfaces in the form receiver pipeline) rather than a silent no-op.

- **Guard check:** `WorkAreaInaccessibilityRequest.objects.filter(work_area=work_area).exists()` raises `ProcessingError("Only one inaccessibility request per work area")` before any write attempt
- **Simplified create:** `get_or_create` replaced with `create` now that duplicates are rejected upstream — no `defaults` dict needed

## Safety Assurance

### Safety story

The change only affects the write path for inaccessibility requests. Existing records are untouched. The `ProcessingError` raised on a duplicate follows the same error-handling path already used for other invalid submissions (e.g. work area not found, user not assigned), so error reporting and observability are unchanged. The `unique_work_area_inaccessibility` DB constraint (added in migration `0012`) remains as a final safety net.

### Automated test coverage

No new tests were added in this commit. The existing integration tests in `commcare_connect/form_receiver/tests/test_receiver_integration.py` cover the happy-path form processing flow. A test for the duplicate-rejection path should be added — see QA plan below.

### QA Plan

No QA.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
