### PR TITLE
CI-684: Reduce FLW Summary Endpoint to Single Query

### DIFF
--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -695,19 +695,19 @@ def get_flw_summary_for_assignment(request, org_slug, opp_id):
     if not assignee_id:
         return JsonResponse({"error": "assignee_id required"}, status=400)
 
-    qs = WorkArea.objects.filter(
+    stats = WorkArea.objects.filter(
         opportunity=request.opportunity,
         opportunity_access_id=assignee_id,
-    )
-    stats = qs.aggregate(
+    ).aggregate(
         buildings=Sum("building_count"),
         visits=Sum("expected_visit_count"),
+        work_areas=Count("id"),
     )
     return JsonResponse(
         {
             "assigned_buildings": stats["buildings"] or 0,
             "assigned_visits": stats["visits"] or 0,
-            "assigned_work_areas": qs.count(),
+            "assigned_work_areas": stats["work_areas"],
         }
     )
 


### PR DESCRIPTION
## Product Description

No user-facing changes. This is an internal performance improvement to the FLW assignment summary endpoint used in the microplanning assignment mode.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-684)

This is a release path 3 feature — Experiments & early stage iterations of product area

In `get_flw_summary_for_assignment`, the queryset was evaluated twice: once via `aggregate()` and once via `count()`, resulting in two separate SQL queries per request. These have been collapsed into a single `aggregate()` call by adding `Count("id")` alongside the existing `Sum` annotations, reducing it to one round-trip to the database.

- **Optimisation:** `Count("id")` added to the existing `aggregate()` call, replacing a separate `.count()` call on the same queryset.

## Safety Assurance

### Safety story

The change is semantically equivalent — `COUNT(id)` in an aggregate produces the same result as `.count()` on the same filtered queryset. No data is written, no schema changes, and the JSON response keys and values are unchanged. Verified by manual inspection of the before/after diff.

### Automated test coverage

No existing tests cover this view. The change is low-risk given the mathematical equivalence of the two approaches.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Navigate to an opportunity with microplanning enabled and enter assignment mode
- [ ] Select an FLW who has work areas assigned
- [ ] Confirm the summary panel shows the correct assigned buildings, visits, and work area count
- [ ] Select an FLW with no assigned work areas and confirm all values show 0

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
