### PR TITLE
Minor Query Optimizations

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -131,7 +131,7 @@ class Opportunity(BaseModel):
 
     @property
     def is_setup_complete(self):
-        if not (self.paymentunit_set.count() > 0 and self.total_budget and self.start_date and self.end_date):
+        if not (self.paymentunit_set.exists() and self.total_budget and self.start_date and self.end_date):
             return False
         for pu in self.paymentunit_set.all():
             if not (pu.max_total and pu.max_daily):

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -410,7 +410,7 @@ class OpportunityFinalize(OpportunityObjectMixin, OrganizationProgramManagerMixi
 
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
-        if self.object.paymentunit_set.count() == 0:
+        if not self.object.paymentunit_set.exists():
             messages.warning(request, "Please configure payment units before setting budget")
             return redirect(
                 "opportunity:add_payment_units", org_slug=request.org.slug, opp_id=self.object.opportunity_id

--- a/commcare_connect/utils/db.py
+++ b/commcare_connect/utils/db.py
@@ -31,7 +31,7 @@ def slugify_uniquely(value, model, slugfield="slug"):
         if suffix:
             potential = "-".join([base, str(suffix)])
 
-        if not model.objects.filter(**{slugfield: potential}).count():
+        if not model.objects.filter(**{slugfield: potential}).exists():
             return potential
         # we hit a conflicting slug, so bump the suffix & try again
         suffix += 1


### PR DESCRIPTION
## Product Description

No user-facing changes. Internal query optimization only.

## Technical Summary

[CI-687](https://dimagi.atlassian.net/browse/CI-687)

Replace `.count()`-based existence checks with `.exists()`. `.count()` runs a `COUNT(*)` over all matching rows; `.exists()` emits `SELECT 1 ... LIMIT 1` and short-circuits at the first match. Applied to:
- `Opportunity.is_setup_complete`
- `slugify_uniquely`'s uniqueness loop
- `OpportunityFinalizeView.dispatch`'s payment-unit guard

This is a minor improvement that was made mostly to test a new automated Jira process for the Interrupt board.

## Safety Assurance

### Safety story

Inherently low-risk, behavior-preserving refactor. `.exists()` and `.count() > 0`/`== 0` are semantically equivalent for boolean checks. No schema or data migrations. No existing data is affected.

### Automated test coverage

Existing tests for the touched apps pass (85 passed across opportunity, organization, program, and commcarehq API). `slugify_uniquely` is exercised via `Organization.save()` in the organization test suite.

### QA Plan

Release path 3 — no QA needed.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-687]: https://dimagi.atlassian.net/browse/CI-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ