### PR TITLE
Sanitize Sentry release name to remove slashes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set release identifier
-        run: echo "APP_RELEASE=${GITHUB_REF_NAME}.${GITHUB_SHA}" >> "$GITHUB_ENV"
+        run: |
+          # Sentry release versions cannot contain slashes, so sanitize the ref name
+          SAFE_REF_NAME="${GITHUB_REF_NAME//\//-}"
+          echo "APP_RELEASE=${SAFE_REF_NAME}.${GITHUB_SHA}" >> "$GITHUB_ENV"
 
       - name: Set up Ruby
         uses: actions/setup-ruby@v1


### PR DESCRIPTION
## Summary

Sanitize the deploy release identifier by replacing `/` with `-` before it's used as the Sentry release version.

Sentry release versions cannot contain slashes, so deploys from hotfix branches like `mk/hotfix-3-3-2026` failed to create a Sentry release:

```
error: invalid value 'mk/hotfix-3-3-2026.<sha>' for '<VERSION>': Invalid release version. Slashes and certain whitespace characters are not permitted.
```

The deploy itself was unaffected (the Sentry step is non-fatal and runs after `kamal deploy`); only the release tagging was skipped.

## Notes

- No-op for slash-free branches like `main`.
- `APP_RELEASE` is the single source for both creating the Sentry release and tagging the running app's error events, so sanitizing at this one point keeps them consistent.
