### PR TITLE
use pm org in generated urls

### DIFF
--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -2,12 +2,13 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _l
-from django_tables2 import columns, tables
+from django_tables2 import columns
 
 from commcare_connect.audit.models import AuditReport, AuditReportEntry
+from commcare_connect.utils.tables import OrgContextTable
 
 
-class AuditReportTable(tables.Table):
+class AuditReportTable(OrgContextTable):
     audit_id = columns.Column(
         accessor="serial",
         verbose_name=_l("Audit ID"),
@@ -46,7 +47,7 @@ class AuditReportTable(tables.Table):
         url = reverse(
             "opportunity:audit:audit_report_detail",
             kwargs={
-                "org_slug": self.opportunity.organization.slug,
+                "org_slug": self.org_slug,
                 "opp_id": self.opportunity.opportunity_id,
                 "audit_report_id": record.audit_report_id,
             },
@@ -69,7 +70,7 @@ class AuditReportTable(tables.Table):
         url = reverse(
             "opportunity:audit:audit_report_detail",
             kwargs={
-                "org_slug": self.opportunity.organization.slug,
+                "org_slug": self.org_slug,
                 "opp_id": self.opportunity.opportunity_id,
                 "audit_report_id": record.audit_report_id,
             },
@@ -118,7 +119,7 @@ class ActionColumn(columns.Column):
             url = reverse(
                 "opportunity:audit:audit_report_task_modal",
                 kwargs={
-                    "org_slug": table.opportunity.organization.slug,
+                    "org_slug": table.org_slug,
                     "opp_id": table.opportunity.opportunity_id,
                     "audit_report_id": table.report.audit_report_id,
                     "entry_id": record.audit_report_entry_id,
@@ -135,7 +136,7 @@ class ActionColumn(columns.Column):
         return ""
 
 
-class AuditReportEntryTable(tables.Table):
+class AuditReportEntryTable(OrgContextTable):
     user = columns.Column(
         accessor="opportunity_access__user__name",
         verbose_name=_l("Connect Worker"),

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -47,7 +47,7 @@ def audit_report_list(request, org_slug, opp_id):
     pending_count = queryset.filter(status=AuditReport.Status.PENDING).count()
     completed_count = queryset.filter(status=AuditReport.Status.COMPLETED).count()
 
-    table = AuditReportTable(queryset, opportunity=opportunity)
+    table = AuditReportTable(queryset, opportunity=opportunity, org_slug=org_slug)
     RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(table)
 
     path = [
@@ -109,10 +109,20 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
     reviewed_count = sum(1 for e in all_entries if e.flagged and e.reviewed)
 
     review_table = AuditReportEntryTable(
-        to_review, opportunity=opportunity, report=report, columns_spec=columns_spec, prefix="review-"
+        to_review,
+        opportunity=opportunity,
+        report=report,
+        columns_spec=columns_spec,
+        prefix="review-",
+        org_slug=org_slug,
     )
     no_action_table = AuditReportEntryTable(
-        no_action, opportunity=opportunity, report=report, columns_spec=columns_spec, prefix="noaction-"
+        no_action,
+        opportunity=opportunity,
+        report=report,
+        columns_spec=columns_spec,
+        prefix="noaction-",
+        org_slug=org_slug,
     )
     RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(review_table)
     RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(no_action_table)


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
URLs throughout the audit app were redirecting to the NM org (since they used the opp org rather than the PM org). This changes them to use the org slug from the request, by using existing table utilities.


## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Internal use only, and just changes url program

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
