### PR TITLE
Fix Empty Space Issue on smaller screens on the Micro planning Page.

### DIFF
--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -152,7 +152,7 @@
                 </form>
             </aside>
 
-            <aside id="lower-sidebar" class="bg-white shadow-md p-4 xl:flex-1 min-h-0">
+            <aside id="lower-sidebar" class="bg-white shadow-md p-4 xl:flex-1 min-h-0 overflow-auto">
                 {{ status_meta|json_script:"status-meta-data" }}
                 <h2 class="text-lg font-semibold mb-2">{% translate "Select Work Area" %}</h2>
                 <template x-if="!selectedFeature">

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -156,7 +156,7 @@
                 {{ status_meta|json_script:"status-meta-data" }}
                 <h2 class="text-lg font-semibold mb-2">{% translate "Select Work Area" %}</h2>
                 <template x-if="!selectedFeature">
-                    <div class="flex flex-col items-center justify-center h-full text-center text-gray-400 gap-2 py-8">
+                    <div class="flex flex-col items-center justify-center h-[80%] text-center text-gray-400 gap-2 py-8">
                         <i class="fa-regular fa-map text-3xl"></i>
                         <p class="text-sm">{% translate "Click a work area on the map to view details." %}</p>
                     </div>


### PR DESCRIPTION
## Product Description
This PR fixes an empty space issue observed on the microplanning page. Added the overflow-auto parameter to the aside element for the Select Work Area section, this adds a scroll bar to that element whenever there is not enough screen space to display the full information.

## Technical Summary
[QA Ticket Link](https://dimagi.atlassian.net/browse/QA-8525)

## Safety Assurance
### Safety story
Tested Locally

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
