### PR TITLE
Fix a UI bug in exclude-work-areas UI

### DIFF
--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -591,7 +591,9 @@ def exclude_work_areas(request, org_slug, opp_id):
         exclusion_reason=exclusion_reason,
     )
     response = HttpResponse('<div id="exclude-progress"></div>')
-    response.headers["HX-Trigger"] = json.dumps({"work_areas_excluded": {"excluded": result["excluded_ids"]}})
+    response.headers["HX-Trigger"] = json.dumps(
+        {"work_areas_excluded": {"excluded": result["excluded_ids"], "skipped": result["skipped"]}}
+    )
     return response
 
 

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -669,7 +669,7 @@ def get_work_areas_for_assignment(request, org_slug, opp_id, group_id):
         WorkArea.objects.filter(
             opportunity=request.opportunity,
             work_area_group_id=group_id,
-        ).values("id", "building_count", "expected_visit_count")
+        ).values("id", "building_count", "expected_visit_count", "status")
     )
     return JsonResponse({"work_areas": work_areas})
 
@@ -683,7 +683,7 @@ def get_flw_work_areas_for_assignment(request, org_slug, opp_id, assignee_id):
         WorkArea.objects.filter(
             opportunity=request.opportunity,
             opportunity_access_id=assignee_id,
-        ).values("id", "building_count", "expected_visit_count")
+        ).values("id", "building_count", "expected_visit_count", "status")
     )
     return JsonResponse({"work_areas": work_areas})
 

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -520,6 +520,7 @@
 
                 document.addEventListener('work_areas_excluded', (e) => {
                     const excluded = e.detail?.excluded ?? [];
+                    const skipped = e.detail?.skipped ?? 0;
                     for (const id of excluded) {
                         this.map.setFeatureState(
                             { source: 'workareas', sourceLayer: 'workareas', id },
@@ -529,7 +530,13 @@
                     }
                     this.showExcludeModal = false;
                     this.clearSelection();
-                    this.showToast(`{% translate "Work area(s) excluded successfully." %}`);
+                    if (excluded.length > 0 && skipped === 0) {
+                        this.showToast(`{% translate "Work area(s) excluded successfully." %}`);
+                    } else if (excluded.length > 0 && skipped > 0) {
+                        this.showToast(`${excluded.length} {% translate "excluded" %}, ${skipped} {% translate "skipped (already excluded or not 'Not Visited')." %}`);
+                    } else if (skipped > 0) {
+                        this.showToast(`{% translate "No work areas were excluded. Only 'Not Visited' work areas can be excluded." %}`, true);
+                    }
                 });
             },
 


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CI-694

## Technical Summary

- Fixes a bug  where already-excluded work areas could be re-submitted
  for exclusion
- Fixes the success toast firing unconditionally even when all selected work areas were skipped, and adds a distinct error message for that case.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tested locally
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
