### PR TITLE
Fix Task Types Incorrectly Hidden From Dropdown After Worker Completes Them

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1965,10 +1965,11 @@ class CreateTaskForm(forms.Form):
         if opportunity is not None:
             task_qs = TaskType.objects.filter(app=opportunity.deliver_app, is_active=True)
             if access is not None:
-                task_qs = task_qs.exclude(
-                    assignedtask__opportunity_access=access,
-                    assignedtask__status=AssignedTaskStatus.ASSIGNED,
-                )
+                already_assigned = AssignedTask.objects.filter(
+                    opportunity_access=access,
+                    status=AssignedTaskStatus.ASSIGNED,
+                ).values_list("task_type_id", flat=True)
+                task_qs = task_qs.exclude(pk__in=already_assigned)
             self.fields["task"].queryset = task_qs
             self.fields["access"].queryset = OpportunityAccess.objects.filter(
                 opportunity=opportunity,

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -914,6 +914,20 @@ class TestCreateTaskForm:
         )
         assert (task_type in task_queryset) == in_queryset
 
+    def test_task_queryset_excludes_only_assigned_to_worker(self, opportunity, task_type):
+        """Worker B's completed tasks should not hide a task type when another worker currently has it assigned."""
+        worker_b_access = OpportunityAccessFactory(opportunity=opportunity, accepted=True, suspended=False)
+        worker_a_access = OpportunityAccessFactory(opportunity=opportunity, accepted=True, suspended=False)
+        AssignedTaskFactory(
+            task_type=task_type, opportunity_access=worker_b_access, status=AssignedTaskStatus.COMPLETED
+        )
+        AssignedTaskFactory(
+            task_type=task_type, opportunity_access=worker_a_access, status=AssignedTaskStatus.ASSIGNED
+        )
+
+        task_queryset = CreateTaskForm(opportunity=opportunity, access=worker_b_access).fields["task"].queryset
+        assert task_type in task_queryset
+
     def test_flw_queryset_filtering(self, opportunity):
         active = OpportunityAccessFactory(opportunity=opportunity, accepted=True, suspended=False)
         unaccepted = OpportunityAccessFactory(opportunity=opportunity, accepted=False, suspended=False)


### PR DESCRIPTION
## Product Description

Fixes a bug where task types already completed by a worker would incorrectly disappear from the task creation dropdown, preventing managers from assigning that task type to the same worker again.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/QA-8503)

This is a release path 3 feature — Experiments & early stage iterations of product area

Django's `exclude()` on multi-valued relationships (reverse FKs) does not require all conditions in a single call to match the *same* related row — unlike `filter()`. The original code used `exclude(assignedtask__opportunity_access=access, assignedtask__status=ASSIGNED)`, which Django evaluates by checking each condition independently: a task type was incorrectly excluded whenever the worker had *any* prior `AssignedTask` for that type (e.g. a completed one) *and* any other worker currently had it `ASSIGNED`. The fix replaces this with a subquery — `exclude(pk__in=AssignedTask.objects.filter(opportunity_access=access, status=ASSIGNED).values_list(...))` — so both conditions are always evaluated against the same row.

- **Root cause:** Django multi-valued `exclude()` pitfall — conditions span independently across related rows rather than a single row
- **Fix:** Subquery via `pk__in` forces both `opportunity_access` and `status` constraints to the same `AssignedTask` row
- **Affected form:** `CreateTaskForm.__init__` in `commcare_connect/opportunity/forms.py`

## Safety Assurance

### Safety story

The change only affects which task types appear in the creation dropdown. It cannot cause data loss or incorrect assignments — it strictly widens availability back to the correct set. The fix is a drop-in ORM query replacement with no schema or model changes.

### Automated test coverage

- `TestCreateTaskForm.test_task_queryset_excludes_only_assigned_to_worker` — directly replicates the prod failure: worker B has a completed task of type X, worker A has it assigned; asserts type X is still visible for worker B
- `TestCreateTaskForm.test_task_queryset_filtering` (existing) — continues to cover the base cases: assigned-excluded, completed-included, no-access-unfiltered

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Create an opportunity with at least one task type
- [ ] Assign the task type to worker A (status: assigned)
- [ ] Assign the same task type to worker B and mark it completed
- [ ] Open the task creation form for worker B — confirm the task type appears in the dropdown
- [ ] Confirm the task type does **not** appear for worker B if they already have it in `assigned` status

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
