### PR TITLE
Minor Dependency Bumps Smoke Test

### DIFF
--- a/commcare_connect/users/management/commands/smoke_dependencies.py
+++ b/commcare_connect/users/management/commands/smoke_dependencies.py
@@ -1,0 +1,167 @@
+"""
+Staging smoke-test for the dependency bumps that the unit suite can't reach
+(production-only or never-called paths). Run against a staging deploy:
+
+    ./manage.py smoke_dependencies --email-to you@dimagi.com --sms-to +15555550123
+
+Each check is independent and non-fatal: a failure is reported, not raised, so
+one broken integration doesn't hide the others. Exit code is non-zero if any
+selected check fails (CI/deploy-gate friendly).
+"""
+
+import base64
+import io
+import uuid
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "Smoke-test production-path dependency bumps (anymail/SES, twilio, S3, whitenoise, sentry, pillow+weasyprint)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--email-to", help="Recipient for the anymail/SES test send. Skipped if omitted.")
+        parser.add_argument("--sms-to", help="E.164 number for the twilio test SMS. Skipped if omitted.")
+        parser.add_argument(
+            "--static-path",
+            default="admin/css/base.css",
+            help="A static asset path to resolve via the manifest storage (whitenoise). "
+            "Defaults to a Django admin asset that is always present after collectstatic.",
+        )
+        parser.add_argument("--keep-s3", action="store_true", help="Don't delete the test object written to storage.")
+
+    def handle(self, *args, **opts):
+        self.results = []
+        self._check_storage(keep=opts["keep_s3"])
+        self._check_whitenoise(opts["static_path"])
+        self._check_pillow_weasyprint()
+        self._check_sentry()
+        self._check_email(opts["email_to"])
+        self._check_sms(opts["sms_to"])
+
+        self.stdout.write("\n" + "=" * 60)
+        failed = [name for name, status, _ in self.results if status == "FAIL"]
+        for name, status, detail in self.results:
+            style = {"OK": self.style.SUCCESS, "FAIL": self.style.ERROR, "SKIP": self.style.WARNING}[status]
+            self.stdout.write(f"{style(status.ljust(4))} {name:24} {detail}")
+        self.stdout.write("=" * 60)
+        if failed:
+            self.stderr.write(self.style.ERROR(f"\n{len(failed)} check(s) failed: {', '.join(failed)}"))
+            raise SystemExit(1)
+        self.stdout.write(self.style.SUCCESS("\nAll selected checks passed."))
+
+    # --- helpers ---------------------------------------------------------
+
+    def _record(self, name, status, detail=""):
+        self.results.append((name, status, detail))
+
+    def _run(self, name, fn, skip_reason=None):
+        if skip_reason:
+            self._record(name, "SKIP", skip_reason)
+            return
+        try:
+            detail = fn() or ""
+            self._record(name, "OK", detail)
+        except Exception as e:  # noqa: BLE001 - smoke test reports failures, never raises
+            self._record(name, "FAIL", f"{type(e).__name__}: {e}")
+
+    # --- checks ----------------------------------------------------------
+
+    def _check_storage(self, keep):
+        """django-storages 1.13->1.14: write + read-back + delete via default storage (S3 in prod)."""
+
+        def fn():
+            from django.core.files.base import ContentFile
+            from django.core.files.storage import default_storage
+
+            key = f"smoke/dep-check-{uuid.uuid4().hex}.txt"
+            payload = b"smoke-test"
+            saved = default_storage.save(key, ContentFile(payload))
+            try:
+                with default_storage.open(saved) as fh:
+                    assert fh.read() == payload, "read-back mismatch"
+                return f"backend={type(default_storage).__module__} key={saved}"
+            finally:
+                if not keep:
+                    default_storage.delete(saved)
+
+        self._run("storages (S3)", fn)
+
+    def _check_whitenoise(self, static_path):
+        """whitenoise 6.5->6.12: resolve a hashed URL via the manifest storage (requires collectstatic)."""
+
+        def fn():
+            from django.contrib.staticfiles.storage import staticfiles_storage
+
+            url = staticfiles_storage.url(static_path)
+            assert staticfiles_storage.exists(
+                staticfiles_storage.stored_name(static_path)
+            ), f"{static_path} not collected"
+            return f"{static_path} -> {url}"
+
+        self._run("whitenoise (static)", fn)
+
+    def _check_pillow_weasyprint(self):
+        """pillow 10->12 (+ django-weasyprint): render a raster image into a PDF."""
+
+        def fn():
+            from PIL import Image
+            from PIL import __version__ as pil_version
+            from weasyprint import HTML
+
+            buf = io.BytesIO()
+            Image.new("RGB", (4, 4), (200, 30, 30)).save(buf, format="PNG")
+            data = base64.b64encode(buf.getvalue()).decode()
+            pdf = HTML(string=f'<img src="data:image/png;base64,{data}">').write_pdf()
+            assert pdf[:4] == b"%PDF", "weasyprint did not emit a PDF"
+            return f"pillow={pil_version} pdf_bytes={len(pdf)}"
+
+        self._run("pillow + weasyprint", fn)
+
+    def _check_sentry(self):
+        """sentry-sdk 1->2: confirm the SDK is initialised and can flush an event."""
+        import sentry_sdk
+
+        get_client = getattr(sentry_sdk, "get_client", None)
+        client = get_client() if get_client else sentry_sdk.Hub.current.client
+        if client is None or not getattr(client, "dsn", None):
+            self._record("sentry-sdk", "SKIP", "no DSN configured in this environment")
+            return
+
+        def fn():
+            event_id = sentry_sdk.capture_message("smoke_dependencies: sentry-sdk 2.x check")
+            sentry_sdk.flush(timeout=5)
+            return f"event_id={event_id}"
+
+        self._run("sentry-sdk", fn)
+
+    def _check_email(self, to):
+        """django-anymail 10->14 (SES v1->v2): real send through the configured EMAIL_BACKEND."""
+
+        def fn():
+            from django.core.mail import send_mail
+
+            sent = send_mail(
+                subject="[smoke] dependency bump check",
+                message="anymail/SES v2 smoke test from smoke_dependencies.",
+                from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+                recipient_list=[to],
+                fail_silently=False,
+            )
+            return f"backend={settings.EMAIL_BACKEND} sent={sent} to={to}"
+
+        self._run("anymail (SES)", fn, skip_reason=None if to else "pass --email-to to enable")
+
+    def _check_sms(self, to):
+        """twilio 8->9: exercise utils.sms.send_sms (Client(...).messages.create)."""
+
+        def fn():
+            from commcare_connect.utils.sms import send_sms
+
+            msg = send_sms(to=to, body="[smoke] twilio 9.x dependency check")
+            return f"sid={getattr(msg, 'sid', msg)} to={to}"
+
+        self._run("twilio (SMS)", fn, skip_reason=None if to else "pass --sms-to to enable")

--- a/commcare_connect/users/management/commands/smoke_dependencies.py
+++ b/commcare_connect/users/management/commands/smoke_dependencies.py
@@ -83,7 +83,10 @@ class Command(BaseCommand):
             try:
                 with default_storage.open(saved) as fh:
                     assert fh.read() == payload, "read-back mismatch"
-                return f"backend={type(default_storage).__module__} key={saved}"
+                # default_storage is a LazyObject proxy; .__class__ resolves to the real
+                # backend (e.g. MediaRootS3Boto3Storage), whereas type() returns the proxy.
+                backend = default_storage.__class__
+                return f"backend={backend.__module__}.{backend.__qualname__} key={saved}"
             finally:
                 if not keep:
                     default_storage.delete(saved)

--- a/commcare_connect/utils/tests/test_sms.py
+++ b/commcare_connect/utils/tests/test_sms.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+import pytest
+
+from commcare_connect.utils.sms import SMSException, get_sms_sender, send_sms
+
+
+@pytest.mark.parametrize(
+    "number,expected",
+    [
+        ("+265123456", "ConnectID"),
+        ("+258999000", "ConnectID"),
+        ("+232111222", "ConnectID"),
+        ("+44777888999", "ConnectID"),
+        ("+15555550123", None),
+        ("+27821234567", None),
+    ],
+)
+def test_get_sms_sender(number, expected):
+    assert get_sms_sender(number) == expected
+
+
+def test_send_sms_raises_without_credentials(settings):
+    settings.TWILIO_ACCOUNT_SID = None
+    settings.TWILIO_AUTH_TOKEN = "token"
+    settings.TWILIO_MESSAGING_SERVICE = "svc"
+    with pytest.raises(SMSException):
+        send_sms(to="+15555550123", body="hi")
+
+
+@mock.patch("commcare_connect.utils.sms.Client")
+def test_send_sms_invokes_twilio_client(mock_client_cls, settings):
+    """Pins the twilio call surface (Client init + messages.create kwargs) so a
+    breaking twilio major bump is caught in CI rather than only in staging."""
+    settings.TWILIO_ACCOUNT_SID = "sid"
+    settings.TWILIO_AUTH_TOKEN = "token"
+    settings.TWILIO_MESSAGING_SERVICE = "MGxxxx"
+    messages = mock_client_cls.return_value.messages
+
+    result = send_sms(to="+265123456", body="test message")
+
+    mock_client_cls.assert_called_once_with("sid", "token")
+    messages.create.assert_called_once()
+    kwargs = messages.create.call_args.kwargs
+    assert kwargs["body"] == "test message"
+    assert kwargs["to"] == "+265123456"
+    assert kwargs["from_"] == "ConnectID"  # +265 maps to the ConnectID alpha sender
+    assert kwargs["messaging_service_sid"] == "MGxxxx"
+    assert "sms_status_callback" in kwargs["status_callback"]
+    assert result is messages.create.return_value


### PR DESCRIPTION
# Dependency-bump validation — smoke-test tooling (evidence)

> ⚠️ **This branch is not intended to be merged.** It exists solely as a record of the dependency-bump validation work: the smoke-test tooling that was written and the staging run that exercised it. The dependency bumps themselves are tracked/landed separately; this PR documents *how they were validated*.

## Product Description

No user-facing changes. This adds developer/ops tooling only — a Django management command and a unit test used to validate a batch of dependency upgrades against staging.

## Technical Summary

[Link to dependency PR here](https://github.com/dimagi/commcare-connect/pull/1243)

This is a release path 1 feature — Improvements to existing features & quick wins.

Adds `manage.py smoke_dependencies`, a staging smoke-test that exercises the production-path libraries our unit suite structurally can't reach (anymail/SES, django-storages/S3, whitenoise static, sentry-sdk, pillow+weasyprint), plus a mocked unit test pinning the `twilio` `send_sms` call surface. These were written to validate a separate dependency-bump batch; the command doubles as reusable tooling for future bumps. The branch is kept only as evidence of the validation that was performed.

- **`smoke_dependencies` management command** (`commcare_connect/users/management/commands/smoke_dependencies.py`): runs six independent checks, each reporting `OK` / `FAIL` / `SKIP`. Failures are caught and reported rather than raised, so one broken integration doesn't mask the others; the command exits non-zero if any check fails, so it can act as a deploy gate.
  - **storages (S3)**: write → read-back → delete round-trip via `default_storage`.
  - **whitenoise (static)**: resolves a hashed asset through the manifest storage.
  - **pillow + weasyprint**: generates a PNG with Pillow, embeds it, renders a PDF.
  - **sentry-sdk**: confirms the SDK is initialised, captures + flushes an event.
  - **anymail (SES)**: opt-in real send via `--email-to` (validates the SES v1→v2 path).
  - **twilio (SMS)**: opt-in real send via `--sms-to`.
- **Storage backend label fix** (`343466a2`): `default_storage` is a Django `LazyObject` proxy, so `type(default_storage)` reported the `DefaultStorage` proxy rather than the configured backend. Switched to `default_storage.__class__` so the real backend (e.g. `MediaRootS3Boto3Storage`) is named. The round-trip check was always valid; only the displayed label was wrong.
- **Twilio unit test** (`commcare_connect/utils/tests/test_sms.py`): pins `utils.sms.send_sms` (`Client` init + `messages.create` kwargs) so a breaking `twilio` major is caught in CI rather than only in staging.
- **Placement**: lives in the already-registered `users` app, since `commcare_connect.utils` is a plain package (not an installed app) and would not have its management commands discovered.

## Safety Assurance

### Safety story

- **The branch is not merged**, so it has zero production impact on its own.
- The command is **read-mostly and non-destructive**: the S3 check cleans up after itself (`--keep-s3` to retain); real email/SMS sends are **opt-in** behind explicit `--email-to` / `--sms-to` flags and `SKIP` otherwise.
- Every check is isolated in a try/except that reports failures instead of raising, and the command is purely additive (no changes to application code paths).

### Automated test coverage

- `commcare_connect/utils/tests/test_sms.py` — **8 tests**, run green:
  - `test_get_sms_sender` (parametrized) — verifies the prefix→alpha-sender map (`+265/+258/+232/+44` → `ConnectID`, others → `None`).
  - `test_send_sms_raises_without_credentials` — asserts `SMSException` when Twilio settings are missing.
  - `test_send_sms_invokes_twilio_client` — mocks `twilio.rest.Client` and asserts the `Client(sid, token)` init and `messages.create(...)` kwargs (`body`, `to`, `from_`, `messaging_service_sid`, `status_callback`).
- The `smoke_dependencies` command itself was exercised locally (3/6 checks pass in dev: pillow+weasyprint, whitenoise after `collectstatic`, storages via local FS) and end-to-end on staging (below).

### QA Plan

QA will not be performed for this change (evidence-only branch, not for merge). The validation that **was** executed on staging is recorded below.

**Staging smoke-test outcome** — `./manage.py smoke_dependencies --email-to valid_email --sms-to valid_number`:

```
OK   storages (S3)
OK   whitenoise (static)
OK   pillow + weasyprint
OK   sentry-sdk
OK   anymail (SES)
OK   twilio (SMS) 
```

All six checks returned `OK`, and the "accepted ≠ delivered" integrations were confirmed out-of-band:

- [x] **Email delivered** — received (validates anymail SES v1→v2 + IAM)
- [x] **SMS delivered** — received
- [x] **Sentry event visible** —  appeared in the project
- [x] **S3 round-trip** — object written/read/deleted in the staging media bucket (the `backend=django.core.files.storage` label was the pre-fix `LazyObject` cosmetic issue, since corrected in `343466a2`; the command ran under staging settings, where `default_storage` is `MediaRootS3Boto3Storage`)
- [x] **WhiteNoise manifest** — hashed asset resolved (`base.523eb49842a7.css`)
- [x] **Pillow + WeasyPrint** — PDF rendered on `pillow=12.2.0`

Validated by deploy + this run (no further QA required):

- [x] Build/install (`uv sync --frozen --group production`) succeeded → prod deps installed
- [x] Deploy migration step (`migrate_multi`) succeeded → gevent 24→26 exercised
- [x] Container serving → gunicorn 21→26 boot confirmed

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
