### PR TITLE
Pin python 3.11 for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+        language_version: python3.11
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Pins the flake8 pre-commit hook to python3.11 so it always runs under the Python version the project targets, rather than whatever interpreter pre-commit happens to pick up locally. This keeps lint results consistent across contributors' machines and CI, avoiding spurious failures or discrepancies caused by running flake8 under a different Python version.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
