### PR TITLE
fix(mobile): delivery_progress must not 500 on an unclaimed access

### DIFF
--- a/commcare_connect/opportunity/api/serializers/mobile.py
+++ b/commcare_connect/opportunity/api/serializers/mobile.py
@@ -310,14 +310,28 @@ class DeliveryProgressSerializer(serializers.Serializer):
     payments = serializers.SerializerMethodField()
     max_payments = serializers.SerializerMethodField()
     payment_accrued = serializers.IntegerField()
-    end_date = serializers.DateField(source="opportunityclaim.end_date")
+    end_date = serializers.SerializerMethodField()
     assigned_tasks = serializers.SerializerMethodField()
 
+    def _get_claim(self, obj):
+        # opportunityclaim is a reverse one-to-one: accessing it raises
+        # RelatedObjectDoesNotExist when the access has not been claimed yet.
+        # The mobile app can hit this endpoint before the claim exists, so
+        # degrade gracefully instead of 500ing.
+        try:
+            return obj.opportunityclaim
+        except OpportunityClaim.DoesNotExist:
+            return None
+
+    def get_end_date(self, obj):
+        claim = self._get_claim(obj)
+        return claim.end_date if claim is not None else None
+
     def get_max_payments(self, obj):
-        return (
-            obj.opportunityclaim.opportunityclaimlimit_set.aggregate(max_visits=Sum("max_visits")).get("max_visits", 0)
-            or -1
-        )
+        claim = self._get_claim(obj)
+        if claim is None:
+            return -1
+        return claim.opportunityclaimlimit_set.aggregate(max_visits=Sum("max_visits")).get("max_visits", 0) or -1
 
     def get_payments(self, obj):
         return PaymentSerializer(obj.payment_set.all(), many=True).data

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -297,6 +297,34 @@ def test_delivery_progress_assigned_tasks_filtered_by_user(
         assert assigned_task_data["due_date"] == str(assigned_task.due_date)
 
 
+def test_delivery_progress_no_claim_degrades_gracefully(mobile_user: User, api_client: APIClient):
+    """An OpportunityAccess with no OpportunityClaim must return 200, not 500.
+
+    The mobile app can poll /delivery_progress before the worker has claimed the
+    opportunity (e.g. the claim POST failed, or the screen is opened pre-claim).
+    DeliveryProgressSerializer previously assumed ``obj.opportunityclaim`` always
+    exists (via the ``end_date`` source and ``get_max_payments``), so an unclaimed
+    access raised ``OpportunityAccess.opportunityclaim.RelatedObjectDoesNotExist``
+    — an unhandled 500 that surfaced on mobile as an opaque error. The endpoint
+    must degrade gracefully instead: ``end_date=None`` and ``max_payments=-1``
+    (the same "no limit" sentinel ``get_max_payments`` already returns).
+    """
+    opportunity, opportunity_access = _setup_opportunity_and_access(
+        mobile_user, total_budget=1000, end_date=datetime.date.today() + datetime.timedelta(days=100)
+    )
+    assert not OpportunityClaim.objects.filter(opportunity_access=opportunity_access).exists()
+
+    api_client.force_authenticate(mobile_user)
+    response = api_client.get(f"/api/opportunity/{opportunity.id}/delivery_progress")
+
+    assert response.status_code == 200
+    assert response.data.keys() == DeliveryProgressSerializer().get_fields().keys()
+    assert response.data["end_date"] is None
+    assert response.data["max_payments"] == -1
+    assert response.data["payments"] == []
+    assert response.data["deliveries"] == []
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "endpoint_func, payload_func",


### PR DESCRIPTION
## Problem

`DeliveryProgressSerializer` assumes `obj.opportunityclaim` always exists — via the `end_date` `DateField(source="opportunityclaim.end_date")` and `get_max_payments` (`obj.opportunityclaim.opportunityclaimlimit_set...`). When an `OpportunityAccess` has **no** `OpportunityClaim`, the reverse one-to-one accessor raises `OpportunityAccess.opportunityclaim.RelatedObjectDoesNotExist`, which is an **unhandled 500**.

This is reachable in normal mobile use: the app can call `GET /api/opportunity/{id}/delivery_progress` before the worker has claimed the opportunity — e.g. the deliver screen is opened pre-claim, or the claim `POST` itself failed (a budget-too-small opportunity can return zero claimable slots, leaving the access claimless). The 500 surfaces on-device as an opaque error.

Observed in Sentry:
```
OpportunityAccess.opportunityclaim.RelatedObjectDoesNotExist:
OpportunityAccess has no opportunityclaim.
  GET /api/opportunity/<id>/delivery_progress
```

## Fix

Degrade gracefully instead of 500ing. A shared `_get_claim()` helper catches `OpportunityClaim.DoesNotExist` and returns `None`:

- `end_date` → `null` when there is no claim (moves from `DateField` to a `SerializerMethodField`; **field name unchanged**, so the response shape is identical for claimed accesses).
- `max_payments` → `-1`, the same "no limit" sentinel `get_max_payments` already returns when a claim exists but has no limits.

`deliveries`, `payments`, `payment_accrued`, and `assigned_tasks` are already claim-independent.

## Test

`test_delivery_progress_no_claim_degrades_gracefully` builds an `OpportunityAccess` with no claim (via the existing `_setup_opportunity_and_access` helper) and asserts the endpoint returns **200** with `end_date=None`, `max_payments=-1`, and empty `payments`/`deliveries` — previously this raised the 500 above. Existing `delivery_progress` tests (which use the claim-creating `mobile_user_with_connect_link` fixture) are unaffected, since the field set is unchanged.

> Note: I was unable to run the postgis-backed suite locally (Docker would not start on my machine; `uv` also choked on a malformed `django-celery-beat==2.5.0` wheel during re-resolution). Syntax is validated and the change is the canonical Django reverse-one-to-one guard; relying on CI for the full DB-backed run.

## Context

Found while debugging an ACE-orchestrated Connect opportunity whose `total_budget` funded `<1` worker, so the claim never succeeded and every subsequent `delivery_progress` poll 500'd. The root misconfiguration is being fixed on the ACE side; this PR is the defense-in-depth half so a claimless access never 500s regardless of how it got there.