### PR TITLE
Fix Incorrect NM Pending Payment Amount

### DIFF
--- a/commcare_connect/program/tests/test_views.py
+++ b/commcare_connect/program/tests/test_views.py
@@ -229,7 +229,7 @@ class TestNetworkManagerPendingPayments:
 
         # accrued (100 + 50) - paid (30 + 30 + 20) = 70.
         # The fan-out bug would instead report (100 + 100 + 50) - (30 + 30 + 20) = 170.
-        assert self._pending_payment_count(opportunity) == f"{opportunity.currency_code} 70"
+        assert self._pending_payment_count(opportunity) == f"{opportunity.currency_code} 70.00"
 
     def test_pending_payment_with_no_payments(self):
         """No payments yet: the full accrued amount is still pending."""

--- a/commcare_connect/program/tests/test_views.py
+++ b/commcare_connect/program/tests/test_views.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseRedirect
 from django.test import Client
 from django.urls import reverse
 
-from commcare_connect.opportunity.tests.factories import DeliveryTypeFactory
+from commcare_connect.opportunity.tests.factories import DeliveryTypeFactory, OpportunityAccessFactory, PaymentFactory
 from commcare_connect.organization.models import Organization
 from commcare_connect.program.models import Program, ProgramApplication, ProgramApplicationStatus
 from commcare_connect.program.tests.factories import (
@@ -188,3 +188,61 @@ class TestProgramHomeBudgetData(BaseProgramTest):
         for application in applications:
             expected_budget = self.expected_application_budgets[application.organization_id]
             assert application.current_budget == expected_budget
+
+
+@pytest.mark.django_db
+class TestNetworkManagerPendingPayments:
+    """The network manager home (`network_manager_home`) is served to non-program-manager
+    org admins. It surfaces a "Pending Payments" figure per managed opportunity, computed as
+    sum(payment_accrued) - sum(payment.amount) across the opportunity's accesses."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, organization: Organization, org_user_admin: User, client: Client):
+        # A regular (non program-manager) org admin lands on the network manager home.
+        self.organization = organization
+        self.client = client
+        client.force_login(org_user_admin)
+        self.url = reverse("program:home", kwargs={"org_slug": self.organization.slug})
+
+    def _pending_payment_count(self, opportunity):
+        response = self.client.get(self.url)
+        assert response.status_code == HTTPStatus.OK
+        pending_payments = next(
+            section["rows"]
+            for section in response.context["recent_activities"]
+            if section["title"] == "Pending Payments"
+        )
+        row = next((r for r in pending_payments if r["opportunity__name"] == opportunity.name), None)
+        return row["count"] if row else None
+
+    def test_pending_payment_not_inflated_by_payment_fan_out(self):
+        """Regression: with multiple payments on a single access, joining payment_accrued and
+        payment.amount in one query multiplies payment_accrued by the number of payment rows.
+        The figure must reflect each sum computed independently."""
+        opportunity = ManagedOpportunityFactory.create(organization=self.organization)
+        # access_a has TWO payments -> this is what triggered the fan-out double-counting.
+        access_a = OpportunityAccessFactory.create(opportunity=opportunity, payment_accrued=100)
+        access_b = OpportunityAccessFactory.create(opportunity=opportunity, payment_accrued=50)
+        PaymentFactory.create(opportunity_access=access_a, amount=30)
+        PaymentFactory.create(opportunity_access=access_a, amount=30)
+        PaymentFactory.create(opportunity_access=access_b, amount=20)
+
+        # accrued (100 + 50) - paid (30 + 30 + 20) = 70.
+        # The fan-out bug would instead report (100 + 100 + 50) - (30 + 30 + 20) = 170.
+        assert self._pending_payment_count(opportunity) == f"{opportunity.currency_code} 70"
+
+    def test_pending_payment_with_no_payments(self):
+        """No payments yet: the full accrued amount is still pending."""
+        opportunity = ManagedOpportunityFactory.create(organization=self.organization)
+        OpportunityAccessFactory.create(opportunity=opportunity, payment_accrued=100)
+        OpportunityAccessFactory.create(opportunity=opportunity, payment_accrued=50)
+
+        assert self._pending_payment_count(opportunity) == f"{opportunity.currency_code} 150"
+
+    def test_fully_paid_opportunity_excluded(self):
+        """Opportunities with a negative pending balance (overpaid) are filtered out."""
+        opportunity = ManagedOpportunityFactory.create(organization=self.organization)
+        access = OpportunityAccessFactory.create(opportunity=opportunity, payment_accrued=100)
+        PaymentFactory.create(opportunity_access=access, amount=150)
+
+        assert self._pending_payment_count(opportunity) is None

--- a/commcare_connect/program/views.py
+++ b/commcare_connect/program/views.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.db.models import CharField, Count, F, Max, Prefetch, Q, Sum, Value
+from django.db.models import CharField, Count, F, IntegerField, Max, OuterRef, Prefetch, Q, Subquery, Sum, Value
 from django.db.models.functions import Coalesce, Concat
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -392,10 +392,23 @@ def network_manager_home(request, org):
     pending_review = _make_recent_activity_data(pending_review_data, org.slug, "opportunity:worker_deliver")
     access_qs = OpportunityAccess.objects.filter(opportunity__managed=True, opportunity__organization=org)
 
+    payment_accrued_sum_sq = (
+        OpportunityAccess.objects.filter(opportunity_id=OuterRef("id"))
+        .values("opportunity_id")
+        .annotate(total=Sum("payment_accrued"))
+        .values("total")[:1]
+    )
+    payment_amount_sum_sq = (
+        OpportunityAccess.objects.filter(opportunity_id=OuterRef("id"))
+        .values("opportunity_id")
+        .annotate(total=Sum("payment__amount"))
+        .values("total")[:1]
+    )
     pending_payments_data_opps = (
         Opportunity.objects.filter(managed=True, organization=org)
         .annotate(
-            pending_payment=Sum("opportunityaccess__payment_accrued") - Sum("opportunityaccess__payment__amount")
+            pending_payment=Coalesce(Subquery(payment_accrued_sum_sq), 0, output_field=IntegerField())
+            - Coalesce(Subquery(payment_amount_sum_sq), 0, output_field=IntegerField())
         )
         .filter(pending_payment__gte=0)
     )

--- a/commcare_connect/program/views.py
+++ b/commcare_connect/program/views.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.db.models import CharField, Count, F, IntegerField, Max, OuterRef, Prefetch, Q, Subquery, Sum, Value
+from django.db.models import CharField, Count, DecimalField, F, Max, OuterRef, Prefetch, Q, Subquery, Sum, Value
 from django.db.models.functions import Coalesce, Concat
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -407,8 +407,8 @@ def network_manager_home(request, org):
     pending_payments_data_opps = (
         Opportunity.objects.filter(managed=True, organization=org)
         .annotate(
-            pending_payment=Coalesce(Subquery(payment_accrued_sum_sq), 0, output_field=IntegerField())
-            - Coalesce(Subquery(payment_amount_sum_sq), 0, output_field=IntegerField())
+            pending_payment=Coalesce(Subquery(payment_accrued_sum_sq), 0, output_field=DecimalField())
+            - Coalesce(Subquery(payment_amount_sum_sq), 0, output_field=DecimalField())
         )
         .filter(pending_payment__gte=0)
     )


### PR DESCRIPTION
## Product Description
This PR fixes a bug related to the Pending Payment Amount calculation on the network manager home page.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CI-697)

## Safety Assurance
### Safety story
Tested Locally

### Automated test coverage
Automated Tests have been added.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
