### PR TITLE
Fix Pre-Commit Hook Failure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   rules: {
     'no-console': 'error',
     'no-unused-vars': 'error',
+    'no-empty': ['error', { allowEmptyCatch: true }],
   },
   ignorePatterns: [
     'node_modules/',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,9 @@ repos:
     rev: v1.36.4
     hooks:
       - id: djlint-reformat-django
+        exclude: commcare_connect/templates/prelogin/home.html
       - id: djlint-django
+        exclude: commcare_connect/templates/prelogin/home.html
 
   - repo: https://github.com/adamchainz/django-upgrade
     rev: '1.13.0'

--- a/commcare_connect/static/prelogin/app.js
+++ b/commcare_connect/static/prelogin/app.js
@@ -913,10 +913,7 @@ document.addEventListener('click', (e) => {
 
     if (!flwTabs.length) return;
 
-    var currentFlw = 0;
-
     function activateFlw(idx) {
-      currentFlw = idx;
       flwTabs.forEach(function (t, i) {
         t.setAttribute('aria-selected', i === idx ? 'true' : 'false');
       });


### PR DESCRIPTION
## Product Description

No user-facing changes. This PR fixes pre-commit hook failures introduced when the prelogin marketing site was updated in #1244.

## Technical Summary

[CCCT-2388](https://dimagi.atlassian.net/browse/CCCT-2388)
This is a release path 1 feature — Improvements to existing features & quick wins

Three linting issues surfaced after #1244 merged new marketing site assets that had never been linted under the hooks added in #1165:

- **Exclude `home.html` from djlint hooks (`.pre-commit-config.yaml`):** `prelogin/home.html` is a ~450KB / 3,550-line vendored SPA template — djlint was taking ~10 minutes to process it on every run. Since it's authored upstream and not a standard Django template, there's no value in linting or reformatting it. Excluded via pre-commit's `exclude` on both `djlint-reformat-django` and `djlint-django` hooks.
- **ESLint `no-empty` configured to allow empty catches (`.eslintrc.js`):** `app.js` has five `catch (_) {}` blocks that intentionally swallow errors from `history.replaceState` and `sessionStorage` calls, which throw in restricted environments (file://, private browsing). `allowEmptyCatch: true` is the standard ESLint escape hatch for this pattern.
- **Removed write-only `currentFlw` variable (`app.js`):** The variable was declared and assigned inside `activateFlw()` but never read — a genuine unused-variable bug caught by `no-unused-vars`.

## Safety Assurance

### Safety story

Config-only and dead-code changes — no logic altered. The djlint and eslint rule changes are scoped to specific patterns that are verified intentional. The `currentFlw` removal is safe: the variable was write-only and had no effect on behaviour.

### Automated test coverage

No new tests required — no logic changed. Existing prelogin view tests (`commcare_connect/prelogin/tests/test_views.py`) continue to cover all marketing routes.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Run `prek run -a` and confirm all hooks pass with exit code 0
- [ ] Load the prelogin marketing site locally and verify navigation between SPA routes (`/`, `/platform`, `/portfolio`, `/insights`, etc.) works correctly
- [ ] Confirm no JS console errors on page load

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2388]: https://dimagi.atlassian.net/browse/CCCT-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ