### PR TITLE
Redirect SMS invite link to Play Store with opp referrer

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -139,8 +139,7 @@ def update_user_and_send_invite(user: ConnectIdUser, opp_id):
 def invite_user(user_id, opportunity_access_id):
     user = User.objects.get(pk=user_id)
     opportunity_access = OpportunityAccess.objects.get(pk=opportunity_access_id)
-    invite_id = opportunity_access.invite_id
-    location = reverse("users:accept_invite", args=(invite_id,))
+    location = reverse("users:invite_redirect", args=(opportunity_access.opportunity.opportunity_id,))
     url = build_absolute_uri(None, location)
     body = f"You have been invited to a job in Connect. Click the link to accept {url}"
     if not user.phone_number:

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -837,6 +837,10 @@ class TestResendUserInvites:
         assert self.old_invite.status == UserInviteStatus.invited
         assert self.old_invite.notification_date is not None
 
+        sms_body = mock_send_sms.call_args.args[1]
+        expected_path = reverse("users:invite_redirect", args=(self.access2.opportunity.opportunity_id,))
+        assert expected_path in sms_body
+
     def test_no_user_ids(self, mock_send_event):
         response = self.client.post(self.url, data={})
         assert response.status_code == 400

--- a/commcare_connect/users/tests/test_views.py
+++ b/commcare_connect/users/tests/test_views.py
@@ -109,6 +109,21 @@ class TestCreateUserLinkView:
         assert user_link.commcare_username == "abc"
 
 
+class TestInviteRedirectView:
+    def test_redirects_to_play_store_with_opp_referrer(self, opportunity, client):
+        opportunity_uuid = opportunity.opportunity_id
+        url = reverse("users:invite_redirect", args=(opportunity_uuid,))
+
+        response = client.get(url)
+
+        expected = (
+            "https://play.google.com/store/apps/details"
+            f"?id=org.commcare.dalvik&hl=en_US&referrer=opp%3D{opportunity_uuid}"
+        )
+        assert response.status_code == 302
+        assert response.url == expected
+
+
 class TestRetrieveUserOTPView:
     @property
     def url(self):

--- a/commcare_connect/users/urls.py
+++ b/commcare_connect/users/urls.py
@@ -4,6 +4,7 @@ from commcare_connect.users import views
 from commcare_connect.users.views import (
     AcceptInviteView,
     CheckInvitedUserView,
+    InviteRedirectView,
     ResendInvitesView,
     RetrieveUserOTPView,
     SMSStatusCallbackView,
@@ -22,6 +23,7 @@ urlpatterns = [
     path("create_user_link/", view=create_user_link_view, name="create_user_link"),
     path("start_learn_app/", view=start_learn_app, name="start_learn_app"),
     path("accept_invite/<slug:invite_id>/", view=AcceptInviteView.as_view(), name="accept_invite"),
+    path("invite_redirect/<uuid:opportunity_uuid>/", view=InviteRedirectView.as_view(), name="invite_redirect"),
     path("demo_users/", view=demo_user_tokens, name="demo_users"),
     path("sms_status_callback/", SMSStatusCallbackView.as_view(), name="sms_status_callback"),
     path("api_keys/", views.get_api_keys, name="get_api_keys"),

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -140,16 +140,18 @@ def start_learn_app(request):
     return Response()
 
 
-class InviteRedirectView(View):
-    def get(self, request, opportunity_uuid):
-        # The <uuid:> URL converter already rejects non-UUIDs with a 404, so this
-        # try/except is unreachable in practice. It's kept to satisfy CodeQL's
-        # py/url-redirection rule, which doesn't model Django URL converters as
-        # sanitizers.
+class InviteRedirectView(RedirectView):
+    permanent = False
+
+    def get_redirect_url(self, *args, **kwargs):
+        # The <uuid:> URL converter already rejects non-UUIDs with a 404, so
+        # this try/except is unreachable in practice. It's kept to satisfy
+        # CodeQL's py/url-redirection rule, which doesn't model Django URL
+        # converters as sanitizers.
         try:
-            opportunity_uuid = str(uuid.UUID(str(opportunity_uuid)))
+            opportunity_uuid = str(uuid.UUID(str(kwargs["opportunity_uuid"])))
         except (ValueError, TypeError):
-            return HttpResponse("Invalid opportunity id", status=400)
+            return None
         params = urlencode(
             {
                 "id": "org.commcare.dalvik",
@@ -157,7 +159,7 @@ class InviteRedirectView(View):
                 "referrer": f"opp={opportunity_uuid}",
             }
         )
-        return redirect(f"https://play.google.com/store/apps/details?{params}")
+        return f"https://play.google.com/store/apps/details?{params}"
 
 
 class AcceptInviteView(View):

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -1,3 +1,4 @@
+import uuid
 from urllib.parse import urlencode
 
 from allauth.account.models import transaction
@@ -141,6 +142,14 @@ def start_learn_app(request):
 
 class InviteRedirectView(View):
     def get(self, request, opportunity_uuid):
+        # The <uuid:> URL converter already rejects non-UUIDs with a 404, so this
+        # try/except is unreachable in practice. It's kept to satisfy CodeQL's
+        # py/url-redirection rule, which doesn't model Django URL converters as
+        # sanitizers.
+        try:
+            opportunity_uuid = str(uuid.UUID(str(opportunity_uuid)))
+        except (ValueError, TypeError):
+            return HttpResponse("Invalid opportunity id", status=400)
         params = urlencode(
             {
                 "id": "org.commcare.dalvik",

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from allauth.account.models import transaction
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -135,6 +137,18 @@ def start_learn_app(request):
         user_invite.status = UserInviteStatus.accepted
         user_invite.save()
     return Response()
+
+
+class InviteRedirectView(View):
+    def get(self, request, opportunity_uuid):
+        params = urlencode(
+            {
+                "id": "org.commcare.dalvik",
+                "hl": "en_US",
+                "referrer": f"opp={opportunity_uuid}",
+            }
+        )
+        return redirect(f"https://play.google.com/store/apps/details?{params}")
 
 
 class AcceptInviteView(View):


### PR DESCRIPTION
  ## Product Description

The CommCare Connect job invite SMS no longer drops users on the in-browser invite-accept page. The SMS link now redirects to the Google Play Store listing for the CommCare app, with a `referrer=opp=<opportunity_uuid>` parameter so the Play Store install carries the opportunity context through to first launch on mobile.

The existing in-browser `accept_invite` flow is untouched — only the URL placed in the outgoing SMS changes.

  ## Technical Summary

  Ticket: https://dimagi.atlassian.net/browse/CCCT-2403
  - A defensive `uuid.UUID(str(...))` round-trip was added in the view to satisfy
    CodeQL `py/url-redirection`. The `<uuid:>` URL converter already rejects
    non-UUIDs with a 404, so the try/except is unreachable in practice — an
    inline comment documents that it's purely to silence the static analyzer.

  ## Safety Assurance

  ### Safety story

  - Existing `AcceptInviteView` and its URL pattern are unchanged; the old
    flow continues to work for any in-flight invites with the old link.
  - The redirect target is a hard-coded Play Store URL. The only piece of the
    URL derived from request input is the `referrer` query value, which is
    bound to be a UUID by Django's `<uuid:>` converter (and re-validated by
    the view), so attacker-controlled hosts are not reachable.


  ### Automated test coverage

new tests added

  ### QA Plan

  ### Labels & Review

  - [x] The set of people pinged as reviewers is appropriate for the level of risk of the change