### PR TITLE
Changed Hint text in Opp Edit Form

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -248,8 +248,10 @@ class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
                             heading=_("Manage Credentials"),
                             hint=format_html(
                                 _(
-                                    "Configure credential requirements for learning and delivery. For more "
-                                    "information, please refer to the {link_start}following documentation{link_end}."
+                                    "Configure credential requirements for learning and delivery."
+                                    " Disabling this section means no credential requirements will"
+                                    " be set for the opportunity. For more information,"
+                                    " please refer to the {link_start}following documentation{link_end}."
                                 ),
                                 link_start=format_html(
                                     '<a href="{}" target="_blank" class="text-blue-600 hover:underline">',


### PR DESCRIPTION
## Product Description
The credential management section on the opportunity edit page now tells admins that turning it off leaves the opportunity with no credential requirements.

## Technical Summary
https://dimagi.slack.com/archives/C09H7D1V1NK/p1780916112737489?thread_ts=1780901666.284349&cid=C09H7D1V1NK

Follow-up to PR #1209 

Reworded the hint text only; no logic, fields, or behaviour changed.

## Safety Assurance

### Safety story

This is a static text change with no effect on data or behaviour, so the blast radius is the wording shown on one form section.

### Automated test coverage

No tests added; the change is display text only.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
