### PR TITLE
Fix get or create issue for auto verification

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -354,7 +354,14 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
     side effect (e.g., resetting duplicate status when the duplicate flag is disabled).
     """
     flags = []
-    opportunity_flags, _ = OpportunityVerificationFlags.objects.get_or_create(opportunity=user_visit.opportunity)
+    if user_visit.opportunity.automatic_visit_verification:
+        auto_verify_defaults = {"location": 0, "gps": False, "duplicate": False, "catchment_areas": False}
+    else:
+        auto_verify_defaults = {}
+    opportunity_flags, _ = OpportunityVerificationFlags.objects.get_or_create(
+        opportunity=user_visit.opportunity,
+        defaults=auto_verify_defaults,
+    )
     if user_visit.status == VisitValidationStatus.duplicate:
         if opportunity_flags.duplicate:
             flags.append(["duplicate", "A beneficiary with the same identifier already exists"])

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -354,10 +354,10 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
     side effect (e.g., resetting duplicate status when the duplicate flag is disabled).
     """
     flags = []
+    auto_verify_defaults = {}
     if user_visit.opportunity.automatic_visit_verification:
         auto_verify_defaults = {"location": 0, "gps": False, "duplicate": False, "catchment_areas": False}
-    else:
-        auto_verify_defaults = {}
+        
     opportunity_flags, _ = OpportunityVerificationFlags.objects.get_or_create(
         opportunity=user_visit.opportunity,
         defaults=auto_verify_defaults,

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -357,7 +357,7 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
     auto_verify_defaults = {}
     if user_visit.opportunity.automatic_visit_verification:
         auto_verify_defaults = {"location": 0, "gps": False, "duplicate": False, "catchment_areas": False}
-        
+
     opportunity_flags, _ = OpportunityVerificationFlags.objects.get_or_create(
         opportunity=user_visit.opportunity,
         defaults=auto_verify_defaults,

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -450,6 +450,25 @@ def test_automatic_visit_verification_does_not_reject_clean_visit(
     assert visit.status == VisitValidationStatus.approved
 
 
+@pytest.mark.django_db
+def test_automatic_visit_verification_no_flags_row_does_not_flag_location(
+    user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
+):
+    assert not OpportunityVerificationFlags.objects.filter(opportunity=opportunity).exists()
+    opportunity.automatic_visit_verification = True
+    opportunity.auto_approve_visits = True
+    opportunity.save()
+    oauth_application = opportunity.hq_server.oauth_application
+    form_json = _create_opp_and_form_json(opportunity, user=user_with_connectid_link)
+    form_json["metadata"]["timeEnd"] = "2023-06-07T12:36:10.178000Z"
+    make_request(api_client, form_json, user_with_connectid_link, oauth_application=oauth_application)
+    visit = UserVisit.objects.get(user=user_with_connectid_link)
+    assert not visit.flagged
+    assert visit.status == VisitValidationStatus.approved
+    flags_row = OpportunityVerificationFlags.objects.get(opportunity=opportunity)
+    assert flags_row.location == 0
+
+
 def _trigger_over_limit_visit(opportunity, user, api_client):
     form_json = _create_opp_and_form_json(opportunity, user=user, daily_max_per_user=0)
     deliver_unit = opportunity.deliver_app.deliver_units.first()

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -454,7 +454,9 @@ def test_automatic_visit_verification_does_not_reject_clean_visit(
 def test_automatic_visit_verification_no_flags_row_does_not_flag_location(
     user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
 ):
-    assert not OpportunityVerificationFlags.objects.filter(opportunity=opportunity).exists()
+    # The opportunity fixture always creates a flags row; delete it to simulate the case
+    # where automatic_visit_verification is enabled before the config form has ever been saved.
+    OpportunityVerificationFlags.objects.filter(opportunity=opportunity).delete()
     opportunity.automatic_visit_verification = True
     opportunity.auto_approve_visits = True
     opportunity.save()


### PR DESCRIPTION
## Product Description

No user facing change.

## Technical Summary
https://dimagi.atlassian.net/browse/CI-713

Updated the form processor so that when OpportunityVerificationFlags is created first time for an auto-verification opportunity, all verification checks (duplicate visits, GPS, location, and catchment area checks) are initialised as disabled, rather than inheriting the model field defaults. This prevents checks from being unintentionally enabled by default.


## Safety Assurance

### Safety story

The change only affects the defaults argument on a single get_or_create call. Existing flag records are unchanged, and opportunities without automatic verification work the same as before.


### Automated test coverage

Added a test for this case 

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
