### PR TITLE
Fixed two broken actions in the audit review modal

### DIFF
--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -295,6 +295,37 @@ def test_modal_submit_rejects_already_reviewed(client, program_manager_org_user_
 
 
 @pytest.mark.django_db
+def test_modal_submit_returns_400_when_task_already_assigned(client, program_manager_org_user_admin, audit_opp):
+    """Re-assigning an already-assigned task type returns 400 with a user-friendly message."""
+    client.force_login(program_manager_org_user_admin)
+    report = AuditReportFactory(opportunity=audit_opp)
+    entry = _entry(report, audit_opp, flagged=True)
+    task_type = TaskTypeFactory(opportunity=audit_opp, name="Refresher Module A")
+
+    # First submission — succeeds.
+    client.post(
+        _action_url(audit_opp, report, entry),
+        data={"action": "tasks_assigned", "task_type_ids": [str(task_type.pk)]},
+    )
+    assert AssignedTask.objects.filter(task_type=task_type).count() == 1
+
+    # Reset entry so the guard checks pass, then try to assign the same task again.
+    entry.reviewed = False
+    entry.review_action = None
+    entry.save(update_fields=["reviewed", "review_action"])
+
+    response = client.post(
+        _action_url(audit_opp, report, entry),
+        data={"action": "tasks_assigned", "task_type_ids": [str(task_type.pk)]},
+    )
+    assert response.status_code == 400
+    assert "already assigned" in response.content.decode()
+    assert "not completed" in response.content.decode()
+    # No duplicate task created.
+    assert AssignedTask.objects.filter(task_type=task_type).count() == 1
+
+
+@pytest.mark.django_db
 def test_modal_submit_rejects_cross_opportunity_task_type(
     client, program_manager_org_user_admin, audit_opp, opportunity
 ):

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -15,6 +15,7 @@ from commcare_connect.audit.models import AuditReport, AuditReportEntry
 from commcare_connect.audit.tables import AuditReportEntryTable, AuditReportTable
 from commcare_connect.flags.flag_names import WEEKLY_PERFORMANCE_REPORT
 from commcare_connect.flags.models import Flag
+from commcare_connect.opportunity.exceptions import TaskAlreadyAssignedError
 from commcare_connect.opportunity.models import AssignedTask, TaskType
 from commcare_connect.organization.decorators import opportunity_required, org_program_manager_required
 
@@ -207,25 +208,30 @@ def audit_report_task_action(request, org_slug, opp_id, audit_report_id, entry_i
         task_types = TaskType.objects.filter(pk__in=task_type_ids, opportunity=opportunity)
         due_date = timezone.now().date() + timedelta(days=DEFAULT_TASK_DUE_DAYS)
         for task_type in task_types:
-            AssignedTask.assign(
-                task_type=task_type,
-                opportunity_access=entry.opportunity_access,
-                due_date=due_date,
-                assigned_by=request.user,
-            )
+            try:
+                AssignedTask.assign(
+                    task_type=task_type,
+                    opportunity_access=entry.opportunity_access,
+                    due_date=due_date,
+                    assigned_by=request.user,
+                )
+            except TaskAlreadyAssignedError:
+                return HttpResponseBadRequest(
+                    _("Task assignment not completed: '%(name)s' is already assigned to this worker.")
+                    % {"name": task_type.name}
+                )
         entry.review_action = AuditReportEntry.ReviewAction.TASKS_ASSIGNED
     elif action == "none":
         entry.review_action = AuditReportEntry.ReviewAction.NONE
     else:
-        return HttpResponseBadRequest("Unknown action.")
+        return HttpResponseBadRequest(_("Unknown action."))
 
     entry.reviewed = True
     entry.save(update_fields=["reviewed", "review_action", "date_modified"])
 
-    # Empty 200. The modal's client-side handler closes the modal and triggers
-    # `refreshDetail` on document.body, which causes `#detail-body` to re-fetch
-    # itself and render the updated tables.
-    return HttpResponse(status=200)
+    response = HttpResponse(status=200)
+    response["HX-Trigger"] = "refreshDetail"
+    return response
 
 
 @opportunity_required

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.db import transaction
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
@@ -207,19 +208,20 @@ def audit_report_task_action(request, org_slug, opp_id, audit_report_id, entry_i
         task_type_ids = request.POST.getlist("task_type_ids")
         task_types = TaskType.objects.filter(pk__in=task_type_ids, opportunity=opportunity)
         due_date = timezone.now().date() + timedelta(days=DEFAULT_TASK_DUE_DAYS)
-        for task_type in task_types:
-            try:
-                AssignedTask.assign(
-                    task_type=task_type,
-                    opportunity_access=entry.opportunity_access,
-                    due_date=due_date,
-                    assigned_by=request.user,
-                )
-            except TaskAlreadyAssignedError:
-                return HttpResponseBadRequest(
-                    _("Task assignment not completed: '%(name)s' is already assigned to this worker.")
-                    % {"name": task_type.name}
-                )
+        try:
+            with transaction.atomic():
+                for task_type in task_types:
+                    AssignedTask.assign(
+                        task_type=task_type,
+                        opportunity_access=entry.opportunity_access,
+                        due_date=due_date,
+                        assigned_by=request.user,
+                    )
+        except TaskAlreadyAssignedError:
+            return HttpResponseBadRequest(
+                _("Task assignment not completed: '%(name)s' is already assigned to this worker.")
+                % {"name": task_type.name}
+            )
         entry.review_action = AuditReportEntry.ReviewAction.TASKS_ASSIGNED
     elif action == "none":
         entry.review_action = AuditReportEntry.ReviewAction.NONE

--- a/commcare_connect/templates/audit/audit_report_task_modal.html
+++ b/commcare_connect/templates/audit/audit_report_task_modal.html
@@ -1,9 +1,11 @@
 {% load i18n %}
-<div x-data="{ open: true, confirm: false, action: null, error: '' }"
+<div x-data="{ open: true, confirm: false, error: '' }"
+     x-ref="modal"
      x-show="open"
      x-cloak
      @click.self="open = false"
      @keydown.escape.window="open = false"
+     @htmx:after-request="if (!event.detail.successful) { error = event.detail.xhr.responseText || '{% trans "Something went wrong. Please try again." %}'; confirm = false; }"
      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
   <div class="bg-white rounded-lg shadow-lg w-full max-w-3xl overflow-hidden relative">
     <div class="metric-container px-6 py-4">
@@ -12,11 +14,13 @@
       </h3>
       <p class="text-sm text-gray-100">{{ report.period_start }} – {{ report.period_end }}</p>
     </div>
-    <form method="post"
+    <form x-ref="form"
+          method="post"
           hx-post="{% url 'opportunity:audit:audit_report_task_action' org_slug=opportunity.organization.slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id entry_id=entry.audit_report_entry_id %}"
           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-          hx-swap="none"
-          hx-on:htmx:after-request="if (event.detail.successful) { document.getElementById('modal-root').innerHTML = ''; htmx.trigger(document.body, 'refreshDetail'); } else { error = event.detail.xhr.responseText || '{% trans "Something went wrong. Please try again." %}'; confirm = false; }">
+          hx-target="#modal-root"
+          hx-swap="innerHTML">
+      <input type="hidden" name="action" x-ref="actionInput" />
       <div class="grid grid-cols-2 gap-6 p-6">
         <div>
           <h4 class="font-semibold mb-2">{% trans "Audit Results" %}</h4>
@@ -56,17 +60,18 @@
            role="alert"
            class="mx-6 mb-4 p-3 rounded-lg border border-message-error-border bg-message-error text-message-error-text text-sm"
            x-text="error"></div>
-      <input type="hidden" name="action" :value="action" />
       <div class="px-6 pb-6 flex justify-end gap-2">
         <button type="button"
                 class="button button-md outline-style"
                 @click="open = false">{% trans "Cancel" %}</button>
-        <button type="submit"
+        <button type="button"
                 class="button button-md outline-style"
-                @click="action='none'">{% trans "No Action Needed" %}</button>
+                @click="$refs.actionInput.value = 'none'; $refs.form.requestSubmit()">
+          {% trans "No Action Needed" %}
+        </button>
         <button type="button"
                 class="button button-md primary-dark"
-                @click="action='tasks_assigned'; confirm = true;">{% trans "Complete Review" %}</button>
+                @click="confirm = true">{% trans "Complete Review" %}</button>
       </div>
       <!-- Confirmation overlay -->
       <div x-show="confirm"
@@ -80,7 +85,11 @@
             <button type="button"
                     class="button button-md outline-style"
                     @click="confirm=false">{% trans "Cancel" %}</button>
-            <button type="submit" class="button button-md primary-dark">{% trans "Assign Tasks" %}</button>
+            <button type="button"
+                    class="button button-md primary-dark"
+                    @click="$refs.actionInput.value = 'tasks_assigned'; $refs.form.requestSubmit()">
+              {% trans "Assign Tasks" %}
+            </button>
           </div>
         </div>
       </div>

--- a/commcare_connect/templates/audit/audit_report_task_modal.html
+++ b/commcare_connect/templates/audit/audit_report_task_modal.html
@@ -2,10 +2,10 @@
 <div x-data="{ open: true, confirm: false, action: null, error: '' }"
      x-show="open"
      x-cloak
+     @click.self="open = false"
      @keydown.escape.window="open = false"
      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-  <div @click.outside="open = false"
-       class="bg-white rounded-lg shadow-lg w-full max-w-3xl overflow-hidden relative">
+  <div class="bg-white rounded-lg shadow-lg w-full max-w-3xl overflow-hidden relative">
     <div class="metric-container px-6 py-4">
       <h3 class="text-lg font-semibold text-white">
         {% blocktrans with name=entry.opportunity_access.user.name %}{{ name }}: Weekly Performance Report{% endblocktrans %}
@@ -56,13 +56,14 @@
            role="alert"
            class="mx-6 mb-4 p-3 rounded-lg border border-message-error-border bg-message-error text-message-error-text text-sm"
            x-text="error"></div>
+      <input type="hidden" name="action" :value="action" />
       <div class="px-6 pb-6 flex justify-end gap-2">
         <button type="button"
                 class="button button-md outline-style"
                 @click="open = false">{% trans "Cancel" %}</button>
-        <button type="button"
+        <button type="submit"
                 class="button button-md outline-style"
-                @click="action='none'; confirm = true;">{% trans "No Action Needed" %}</button>
+                @click="action='none'">{% trans "No Action Needed" %}</button>
         <button type="button"
                 class="button button-md primary-dark"
                 @click="action='tasks_assigned'; confirm = true;">{% trans "Complete Review" %}</button>
@@ -73,9 +74,8 @@
            class="absolute inset-0 bg-black/40 flex items-center justify-center">
         <div class="bg-white rounded-lg shadow p-6 w-96">
           <p class="text-sm mb-4">
-            {% trans "Completing this review will assign the selected tasks to the Connect Worker. Are you sure you want to proceed?" %}
+            {% trans "This will assign the selected tasks to the Connect Worker. Are you sure you want to proceed?" %}
           </p>
-          <input type="hidden" name="action" :value="action" />
           <div class="flex justify-end gap-2">
             <button type="button"
                     class="button button-md outline-style"


### PR DESCRIPTION
## Product Description
<video controls class="w-full" src="https://github.com/user-attachments/assets/cb3e759f-d0fb-4f9b-904c-f58287e64530"></video>


## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-2478
https://dimagi.atlassian.net/browse/CCCT-2477

Fixed the "No Action Needed" flow to submit directly with action=none instead of incorrectly showing the confirmation modal.
Replaced the broken hx-on:htmx:after-request handler with an HX-Trigger response header and native HTMX modal close/page refresh behaviour.


## Safety Assurance

### Safety story

UI-layer only. No data logic changed. The one server-side change wraps the existing assign call in a try/except for the already-assigned case, returning a 400 with a message rather than failing silently.

### Automated test coverage
Test added for the duplicate assignment 400 response; all existing audit view tests pass.

### QA Plan
No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
