### PR TITLE
Filter by delivery type in indicators

### DIFF
--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -43,6 +43,7 @@ VACCINE_CARD_LINK_FIELD = "child_vaccine_group__vaccine_photo_folder__photo_link
 MUAC_BIN_EDGES = [9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5]
 AGE_HEAPING_VALUES = ["12", "24", "36", "48"]
 MAX_VISITS_PER_BUILDING = 12  # threshold above which a WA is flagged as "camping"
+SERVICE_DELIVERY_SLUG = "services_delivery_unit"
 
 
 def _percent(numerator: int, denominator: int) -> float:
@@ -138,6 +139,7 @@ class CampingRatio(AuditCalculation):
                 visit_date__date__range=(period_start, period_end),
                 work_area__isnull=False,
                 work_area__building_count__gt=0,
+                deliver_unit__slug=SERVICE_DELIVERY_SLUG,
             )
             .values("work_area_id", "work_area__building_count")
             .annotate(visit_count=Count("id"))
@@ -169,6 +171,7 @@ class GenderRatioDeviation(AuditCalculation):
         result = UserVisit.objects.filter(
             opportunity_access=opportunity_access,
             visit_date__date__range=(period_start, period_end),
+            deliver_unit__slug=SERVICE_DELIVERY_SLUG,
         ).aggregate(
             total=Count("id"),
             female=Count("id", filter=Q(**{f"form_json__form__{GENDER_FIELD}": FEMALE})),
@@ -197,6 +200,7 @@ class MUACPhotoCompliance(AuditCalculation):
             UserVisit.objects.filter(
                 opportunity_access=opportunity_access,
                 visit_date__date__range=(period_start, period_end),
+                deliver_unit__slug=SERVICE_DELIVERY_SLUG,
             )
             .annotate(age_months=_json_int(AGE_FIELD))
             .filter(age_months__gt=6)
@@ -228,6 +232,7 @@ class AgeHeaping(AuditCalculation):
         result = UserVisit.objects.filter(
             opportunity_access=opportunity_access,
             visit_date__date__range=(period_start, period_end),
+            deliver_unit__slug=SERVICE_DELIVERY_SLUG,
             **{f"form_json__form__{AGE_FIELD}__isnull": False},
         ).aggregate(
             total=Count("id"),
@@ -267,7 +272,10 @@ class WACoverageToVisitRatio(AuditCalculation):
         total_eligible = wa_stats["total_eligible"] or 0
         expected_visits = wa_stats["expected_visits"] or 0
         actual_visits = UserVisit.objects.filter(
-            opportunity_access=opportunity_access, visit_date__date__lte=period_end, work_area__isnull=False
+            opportunity_access=opportunity_access,
+            visit_date__date__lte=period_end,
+            work_area__isnull=False,
+            deliver_unit__slug=SERVICE_DELIVERY_SLUG,
         ).count()
 
         if not (total_eligible and expected_visits and actual_visits):
@@ -362,6 +370,7 @@ class VaccineRate(AuditCalculation):
         result = UserVisit.objects.filter(
             opportunity_access=opportunity_access,
             visit_date__date__range=(period_start, period_end),
+            deliver_unit__slug=SERVICE_DELIVERY_SLUG,
         ).aggregate(
             total=Count("id"),
             vaccinated=Count("id", filter=Q(**{f"form_json__form__{VACCINE_FIELD}": YES})),
@@ -390,6 +399,7 @@ class VaccineCardPhotoCompliance(AuditCalculation):
         result = UserVisit.objects.filter(
             opportunity_access=opportunity_access,
             visit_date__date__range=(period_start, period_end),
+            deliver_unit__slug=SERVICE_DELIVERY_SLUG,
             **{f"form_json__form__{VACCINE_FIELD}": YES},
         ).aggregate(
             total=Count("id"),
@@ -513,6 +523,7 @@ class MUACDistributionPatternIndex(AuditCalculation):
         raw = UserVisit.objects.filter(
             opportunity_access=opportunity_access,
             visit_date__date__range=(period_start, period_end),
+            deliver_unit__slug=SERVICE_DELIVERY_SLUG,
             **{f"form_json__form__{MUAC_MEASUREMENT_FIELD}__isnull": False},
         ).values_list(f"form_json__form__{MUAC_MEASUREMENT_FIELD}", flat=True)
 

--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -87,7 +87,8 @@ def _find_active_wag(opportunity_access, period_end) -> WorkAreaGroup | None:
         .annotate(
             last_visit=Max(
                 "workarea__uservisit__visit_date",
-                filter=Q(workarea__uservisit__visit_date__date__lte=period_end),
+                filter=Q(workarea__uservisit__visit_date__date__lte=period_end)
+                & Q(workarea__uservisit__deliver_unit__slug=SERVICE_DELIVERY_SLUG),
             )
         )
         .filter(last_visit__isnull=False)
@@ -111,7 +112,8 @@ def _find_last_closed_wag(opportunity_access, period_end) -> WorkAreaGroup | Non
             ),
             last_visit=Max(
                 "workarea__uservisit__visit_date",
-                filter=Q(workarea__uservisit__visit_date__date__lte=period_end),
+                filter=Q(workarea__uservisit__visit_date__date__lte=period_end)
+                & Q(workarea__uservisit__deliver_unit__slug=SERVICE_DELIVERY_SLUG),
             ),
         )
         .filter(total=F("closed_count"), last_visit__isnull=False)

--- a/commcare_connect/audit/tests/test_chc_indicators.py
+++ b/commcare_connect/audit/tests/test_chc_indicators.py
@@ -8,6 +8,7 @@ import pytest
 
 from commcare_connect.audit.chc_indicators import (
     FEMALE,
+    SERVICE_DELIVERY_SLUG,
     YES,
     AgeHeaping,
     CampingRatio,
@@ -22,7 +23,7 @@ from commcare_connect.audit.chc_indicators import (
 )
 from commcare_connect.microplanning.models import WorkArea, WorkAreaStatus
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
-from commcare_connect.opportunity.tests.factories import OpportunityAccessFactory, UserVisitFactory
+from commcare_connect.opportunity.tests.factories import DeliverUnitFactory, OpportunityAccessFactory, UserVisitFactory
 
 PERIOD_START = datetime.date(2026, 4, 13)  # Monday
 PERIOD_END = datetime.date(2026, 4, 19)  # Sunday
@@ -32,6 +33,7 @@ AFTER_PERIOD = datetime.datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
 
 
 def make_visit(access, work_area=None, visit_date=IN_PERIOD, **kwargs):
+    kwargs.setdefault("deliver_unit", DeliverUnitFactory(slug=SERVICE_DELIVERY_SLUG))
     return UserVisitFactory(
         opportunity=access.opportunity,
         user=access.user,


### PR DESCRIPTION
## Product Description

No user-facing change.

## Technical Summary

Follow-up to #1177 , addressing review comments deferred from that PR.

Each CHC audit calculation now filters visits to those with deliver_unit__slug = "services_delivery_unit", so non-service-delivery visits no longer count toward any metric.

I intentionally didn't use completed work because if another visit comes in for the same FLW and the same entity ID, it would be ignored. Since duplicates will also be approved under the new verification flow, those visits should be counted as well.


## Safety Assurance

### Safety story

Adding the filter narrows the visit set; it doesn't change how any metric is computed. Tests were updated to set the correct deliver unit slug on test visits, so all existing assertions still pass.

### Automated test coverage

Tests updated in test_chc_indicators.py; all pass.

### QA Plan
Not Required

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
