### PR TITLE
Redirect Signed In User with No Memberships to Home

### DIFF
--- a/commcare_connect/users/tests/test_views.py
+++ b/commcare_connect/users/tests/test_views.py
@@ -81,7 +81,7 @@ class TestUserRedirectView:
         request.org = None
 
         view.request = request
-        assert view.get_redirect_url() == "/"
+        assert view.get_redirect_url() == "/home/"
 
     def test_get_redirect_url_for_org_user(
         self, organization: Organization, org_user_member: User, rf: RequestFactory

--- a/commcare_connect/users/views.py
+++ b/commcare_connect/users/views.py
@@ -73,7 +73,7 @@ class UserRedirectView(LoginRequiredMixin, RedirectView):
 
     def get_redirect_url(self):
         if not self.request.user.memberships.exists():
-            return reverse("prelogin:home")
+            return reverse("home")
         organization = self.request.org
         if organization:
             return reverse("opportunity:list", kwargs={"org_slug": organization.slug})

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ from . import views
 
 urlpatterns = [
     path("", include("commcare_connect.prelogin.urls")),
+    path("home/", TemplateView.as_view(template_name="pages/home.html"), name="home"),
     path("about/", TemplateView.as_view(template_name="pages/about.html"), name="about"),
     # Marketing robots.txt + sitemap.xml. Exported (verbatim) from
     # dimagi-internal/connect-prelogin into templates/prelogin/ by


### PR DESCRIPTION
## Product Description

Authenticated users who have no organisation memberships are now redirected to the app's internal home page (`/home/`) instead of the marketing prelogin home. The internal home page shows a "Welcome to Connect" message with guidance to request an invite from their administrator.

Old:
<img width="1918" height="1034" alt="redirect-old" src="https://github.com/user-attachments/assets/624077d2-b878-4b6f-922a-7236049637ae" />

New:
<img width="1898" height="1034" alt="redirect-new" src="https://github.com/user-attachments/assets/f908dd16-44db-49f2-97d4-85add774320a" />

## Technical Summary

This is a release path 1 feature — Improvements to existing features & quick wins.

- **New URL route:** Added `path("home/", TemplateView.as_view(template_name="pages/home.html"), name="home")` in `config/urls.py`, giving the existing `pages/home.html` template a named, addressable URL.
- **Redirect update:** `UserRedirectView.get_redirect_url()` in `users/views.py` now resolves `"home"` instead of `"prelogin:home"` for membership-less users, sending them to the authenticated home view rather than the public marketing page.

## Safety Assurance

### Safety story

The change only affects the redirect destination for authenticated users with no memberships — a narrow, well-defined code path. The `pages/home.html` template already handles both authenticated and unauthenticated states, so no new rendering edge cases are introduced. The new URL route is a simple `TemplateView` with no side effects.

### Automated test coverage

- `TestUserRedirectView.test_get_redirect_url` — updated expected URL from `"/"` to `"/home/"` to match the new redirect target, confirming membership-less users land on the correct page.
- `TestUserRedirectView.test_get_redirect_url_for_org_user` — unchanged; verifies org users are still redirected to the opportunity list.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Log in as a user with no organisation memberships
- [ ] Visit `/users/~redirect/` (or any page that triggers `UserRedirectView`)
- [ ] Confirm you are redirected to `/home/` and see the "Welcome to Connect" message with the invite guidance text
- [ ] Log in as a user with at least one organisation membership and confirm the redirect still goes to the opportunity list as expected

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
