### PR TITLE
Fix microplanning map being hidden on smaller browsers

### DIFF
--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -106,7 +106,7 @@
       <!-- Map section -->
       <div id="map-wrapper"
            x-ref="mapContainer"
-           class="relative min-w-0 flex-1 shadow-md h-[max(calc(100vh-300px),200px)] xl:h-full">
+           class="relative min-w-0 xl:flex-1 shadow-md h-[max(calc(100vh-300px),200px)] xl:h-full">
         <div id="toast-container"
              class="absolute top-4 right-4 z-50 flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg text-sm text-white opacity-0 transition-opacity duration-300">
           <i id="toast-icon" class="text-lg"></i>


### PR DESCRIPTION
## Product Description
Fixed flex layout on the Microplanning page to allow showing the map on smaller screens.


## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CI-719)

## Safety Assurance
### Safety story
Tested Locally

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
