### PR TITLE
Surface org invite form errors instead of silently redirecting

### DIFF
--- a/commcare_connect/organization/tests/test_forms.py
+++ b/commcare_connect/organization/tests/test_forms.py
@@ -58,6 +58,24 @@ class TestAddMembersView:
             membership = organization.memberships.get(**membership_filter)
             assert membership.role == expected_role
 
+    @pytest.mark.django_db
+    def test_invalid_invite_shows_error_message(self):
+        response = self.client.post(self.url, {"email": "nonexistent@example.com", "role": "member"}, follow=True)
+
+        messages = list(response.context["messages"])
+        assert len(messages) == 1
+        assert messages[0].level_tag == "error"
+        assert "does not exist or is already a member" in str(messages[0])
+
+    @pytest.mark.django_db
+    def test_valid_invite_shows_success_message(self):
+        UserFactory(email="newmember@example.com")
+        response = self.client.post(self.url, {"email": "newmember@example.com", "role": "member"}, follow=True)
+
+        messages = list(response.context["messages"])
+        assert len(messages) == 1
+        assert messages[0].level_tag == "success"
+
 
 @pytest.mark.django_db
 class TestOrganizationChangeForm:

--- a/commcare_connect/organization/views.py
+++ b/commcare_connect/organization/views.py
@@ -69,6 +69,10 @@ def add_members_form(request, org_slug):
         form.instance.organization = org
         form.save()
         send_org_invite(membership_id=form.instance.pk, host_user_id=request.user.pk)
+        messages.success(request, gettext("Invite sent to {email}.").format(email=form.cleaned_data["email"]))
+    else:
+        error = next(iter(form.errors.values()))[0] if form.errors else gettext("Unable to send invite.")
+        messages.error(request, error)
     url = reverse("organization:home", args=(org_slug,)) + "?active_tab=members"
     return redirect(url)
 


### PR DESCRIPTION
(The PR is an ad-hoc improvement, so no ticket)

Org member invites previously redirected with no feedback on an invalid form, so inviting an unregistered/already-member email just refreshed the page. `add_members_form` now shows a success or error message after submission.

Example error when no user is found on the system:
<img width="1646" height="658" alt="image" src="https://github.com/user-attachments/assets/7e31a471-4803-4419-a504-58d0158a3894" />
