### PR TITLE
fix the wrong org_slug for pm action

### DIFF
--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -155,6 +155,7 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
         "can_complete": total_flagged == reviewed_count and report.status == AuditReport.Status.PENDING,
         "name_filter": name_filter,
         "path": path,
+        "org_slug": org_slug,
     }
 
     template = (
@@ -185,6 +186,7 @@ def audit_report_task_modal(request, org_slug, opp_id, audit_report_id, entry_id
             "entry": entry,
             "failed": failed,
             "task_types": task_types,
+            "org_slug": org_slug,
         },
     )
 

--- a/commcare_connect/templates/audit/audit_report_body.html
+++ b/commcare_connect/templates/audit/audit_report_body.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load django_tables2 %}
 <div id="detail-body"
-     hx-get="{% url 'opportunity:audit:audit_report_detail' org_slug=opportunity.organization.slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
+     hx-get="{% url 'opportunity:audit:audit_report_detail' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
      hx-trigger="refreshDetail from:body"
      hx-swap="outerHTML"
      class="flex flex-col gap-4">
@@ -21,7 +21,7 @@
            value="{{ name_filter }}"
            placeholder="{% trans 'Filter by worker name' %}"
            class="base-input w-64"
-           hx-get="{% url 'opportunity:audit:audit_report_detail' org_slug=opportunity.organization.slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
+           hx-get="{% url 'opportunity:audit:audit_report_detail' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
            hx-trigger="input changed delay:200ms, search"
            hx-target="#detail-body"
            hx-swap="outerHTML"
@@ -35,7 +35,7 @@
     <button type="button"
             class="button button-md primary-dark"
             {% if not can_complete %}disabled{% endif %}
-            hx-post="{% url 'opportunity:audit:audit_report_complete' org_slug=opportunity.organization.slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
+            hx-post="{% url 'opportunity:audit:audit_report_complete' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
             hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
             hx-swap="none"
             hx-on::after-request="if (event.detail.successful) window.location.reload()">

--- a/commcare_connect/templates/audit/audit_report_task_modal.html
+++ b/commcare_connect/templates/audit/audit_report_task_modal.html
@@ -16,7 +16,7 @@
     </div>
     <form x-ref="form"
           method="post"
-          hx-post="{% url 'opportunity:audit:audit_report_task_action' org_slug=opportunity.organization.slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id entry_id=entry.audit_report_entry_id %}"
+          hx-post="{% url 'opportunity:audit:audit_report_task_action' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id entry_id=entry.audit_report_entry_id %}"
           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
           hx-target="#modal-root"
           hx-swap="innerHTML">


### PR DESCRIPTION
## Issue

PM users received a 404 error when trying to assign tasks from the Audit Report Review modal. The page loaded correctly, but submitting the action failed.

## Technical Summary
https://dimagi.atlassian.net/browse/CI-721
The audit report templates were hardcoding `opportunity.organization.slug` in the HTMX action URLs, which always resolves to the NM organization slug. As a result, when a PM user submitted the action, the `org_slug` parameter was set to the NM organization. Our decorator then rejected the request and returned a 404 because the user did not belong to that organization.


## Safety Assurance

### Safety story

The @org_program_manager_required decorator already validates the slug against the user's membership, so using the request's org_slug can't grant access beyond what was already permitted to load the page.

### Automated test coverage
Existing audit view tests pass with no changes needed.

### QA Plan

Verified locally

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
