### PR TITLE
Automated Dependency Management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,51 @@
-# Config for Dependabot updates. See Documentation here:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Config for Dependabot updates. See documentation here:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  # Update GitHub actions in workflows
-  - package-ecosystem: 'github-actions'
+  # Python dependencies (uv reads pyproject.toml + uv.lock)
+  - package-ecosystem: uv
     directory: '/'
-    # Every weekday
     schedule:
-      interval: 'daily'
+      interval: weekly
+      day: monday
+      time: '09:00'
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    # Group all minor/patch bumps into one PR to cut noise; major bumps get
+    # individual PRs so each breaking change can be assessed on its own.
+    groups:
+      python-non-major:
+        update-types:
+          - minor
+          - patch
+    # Internal Dimagi git-sourced packages have no PyPI versions to track.
+    ignore:
+      - dependency-name: xml2json
+      - dependency-name: git-build-branch
 
-  # Enable version updates for Python/Pip - Production
-  - package-ecosystem: 'pip'
-    # Look for a `requirements.txt` in the `root` directory
-    # also 'setup.cfg', 'runtime.txt' and 'requirements/*.txt'
+  # Frontend dependencies
+  - package-ecosystem: npm
     directory: '/'
-    # Every weekday
     schedule:
-      interval: 'daily'
+      interval: weekly
+      day: monday
+      time: '09:00'
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      npm-non-major:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,54 @@
+name: Security Audit
+
+on:
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Export production requirements
+        run: uv export --format requirements-txt --no-dev --group production -o /tmp/requirements.txt
+
+      - name: Run pip-audit
+        run: uvx pip-audit -r /tmp/requirements.txt
+
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit --audit-level=high

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,0 +1,106 @@
+# Dependency Management
+
+## Overview
+
+Python dependencies are managed with [uv](https://docs.astral.sh/uv/). Direct dependencies are declared in `pyproject.toml` using minimum-version ranges (`>=`); the full resolved dependency graph (including transitive deps) is recorded in `uv.lock` and committed to the repo.
+
+Two automated systems keep dependencies up to date and secure:
+
+| Tool | Purpose | Runs |
+|------|---------|------|
+| **Dependabot** | Opens PRs to bump outdated packages | Weekly (Monday mornings) |
+| **pip-audit** | Blocks PRs that introduce known CVEs (Python) | On every PR touching `pyproject.toml` / `uv.lock` |
+| **npm audit** | Blocks PRs that introduce known CVEs (JS) | On every PR touching `package.json` / `package-lock.json` |
+
+This mirrors the setup used in [commcare-hq](https://github.com/dimagi/commcare-hq), which also runs Dependabot with the native `uv` ecosystem — keeping dependency tooling consistent across Dimagi repos.
+
+---
+
+## Dependabot
+
+Config: [`.github/dependabot.yml`](../.github/dependabot.yml)
+
+Dependabot reads `pyproject.toml` / `uv.lock` (via the native `uv` ecosystem), `package.json`, and the workflow files under `.github/workflows/`, then opens pull requests when newer versions are available.
+
+**Behaviour:**
+- Python minor and patch updates are **grouped into a single weekly PR** (`python-non-major`) to reduce noise
+- npm minor and patch updates are **grouped into a single weekly PR** (`npm-non-major`)
+- Major version bumps get **individual PRs** so each breaking change can be assessed separately
+- GitHub Actions are updated weekly
+- Up to 5 concurrent open PRs per ecosystem
+- Internal Dimagi git-sourced packages (`xml2json`, `git-build-branch`) are excluded — they have no PyPI versions to track
+
+**Reviewing a Dependabot PR:**
+1. Check the linked changelog for breaking changes
+2. Confirm the CI `Security Audit` and `CI` jobs pass
+3. For major bumps, check whether any direct call sites in our code are affected (Dependabot links to release notes)
+
+---
+
+## pip-audit and npm audit (Security Audit CI job)
+
+Config: [`.github/workflows/security.yml`](../.github/workflows/security.yml)
+
+Runs on every pull request that modifies `pyproject.toml`, `uv.lock`, `package.json`, or `package-lock.json`.
+
+- **pip-audit:** exports the production Python dependency set (`uv export --no-dev --group production`) and runs `uvx pip-audit` against it. Dev-only dependencies (`[dependency-groups.dev]`) are excluded.
+- **npm audit:** runs `npm audit --audit-level=high` against the frontend dependency tree.
+
+Both jobs fail if any package has a known vulnerability in the OSV / PyPI / npm advisory databases.
+
+---
+
+## Dependency groups
+
+`pyproject.toml` uses three groups:
+
+| Group | Location | Contents |
+|-------|----------|----------|
+| Runtime | `[project.dependencies]` | Core app dependencies needed in all environments |
+| `production` | `[dependency-groups.production]` | Production-only deps (gunicorn, psycopg2, anymail, storages, allow-cidr) |
+| `dev` | `[dependency-groups.dev]` | Development and test-only deps |
+
+pip-audit scans runtime + production. Dev deps are not scanned.
+
+---
+
+## Updating dependencies manually
+
+```bash
+# Bump a single package
+uv add "<package>>=<version>"
+
+# Regenerate the lock after editing pyproject.toml directly
+uv lock
+
+# Verify the lock is consistent without changing it
+uv lock --check
+
+# Sync your local environment to the current lock
+uv sync
+```
+
+After bumping, run the full test suite before committing:
+
+```bash
+uv run pytest
+uv run pre-commit run -a
+```
+
+---
+
+## Adding a new dependency
+
+```bash
+uv add <package>                        # runtime dependency
+uv add --dev <package>                  # dev/test-only dependency
+uv add --group production <package>     # production-only dependency
+```
+
+`uv` will update both `pyproject.toml` and `uv.lock` automatically.
+
+---
+
+## Periodic full audit
+
+For a deeper review (major version bumps, EoL packages, CVE triage), run the `/audit-dependencies` skill in Claude Code.


### PR DESCRIPTION
## Product Description

No user-facing changes. This PR updates repository tooling only — dependency-update automation (Dependabot), a CI security-audit gate, and developer documentation. End users and the running application are unaffected.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2387)

This is a release path 1 feature — Improvements to existing features & quick wins.

Fixes our dependency automation, which was effectively only covering GitHub Actions. The previous Dependabot config targeted the `pip` ecosystem against a `requirements.txt` that doesn't exist in this repo (we use `uv` + `pyproject.toml` + `uv.lock`), so Python bumps never ran and npm wasn't covered at all. Rather than introduce a new tool, this aligns us with the proven Dependabot + native `uv` setup already running in commcare-hq, keeping dependency tooling consistent across Dimagi repos. A blocking CI vulnerability gate and developer docs round out the change.

## Safety Assurance

### Safety story

Inherently low risk — the change touches only CI/automation configuration and documentation, with no application code, models, migrations, or runtime behavior affected. The Dependabot config governs how update PRs are *proposed*; every resulting bump still arrives as its own reviewable PR that must pass full CI before merge, so there is no automatic change to installed dependencies. The new security workflow is additive and only adds a gate to PRs that modify dependency manifests. Both config files were validated by the repo's pre-commit hooks (YAML + prettier).

### Automated test coverage

No application tests are applicable, as there is no code change. The security workflow itself acts as the verification mechanism: `pip-audit` and `npm audit` run in CI on any dependency-manifest change. The Dependabot YAML and workflow YAML are validated by the `check-yaml` and `prettier` pre-commit hooks.

### QA Plan

QA will not be performed for this change.


### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
