### PR TITLE
Remove standalone opportunity creation

### DIFF
--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -9,8 +9,6 @@ from commcare_connect.opportunity.views import (
     OpportunityDashboard,
     OpportunityEdit,
     OpportunityFinalize,
-    OpportunityInit,
-    OpportunityInitUpdate,
     OpportunityList,
     OpportunityPaymentUnitTableView,
     TaskTypesConfig,
@@ -61,9 +59,7 @@ from commcare_connect.opportunity.views import (
 app_name = "opportunity"
 urlpatterns = [
     path("", view=OpportunityList.as_view(), name="list"),
-    path("init/", view=OpportunityInit.as_view(), name="init"),
     path("add_api_key/", views.add_api_key, name="add_api_key"),
-    path("<slug:opp_id>/init/edit/", view=OpportunityInitUpdate.as_view(), name="init_edit"),
     path("<slug:opp_id>/finalize/", view=OpportunityFinalize.as_view(), name="finalize"),
     path("<slug:opp_id>/edit", view=OpportunityEdit.as_view(), name="edit"),
     path("<slug:opp_id>/", view=OpportunityDashboard.as_view(), name="detail"),

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -316,7 +316,7 @@ class OpportunityInit(OrganizationProgramManagerMixin, CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["api_key_form"] = HQApiKeyCreateForm(auto_id="api_key_form_id_for_%s")
-        context["is_update"] = False
+        context["opportunity_created"] = False
         return context
 
     def form_valid(self, form: OpportunityInitForm):
@@ -358,7 +358,7 @@ class OpportunityInitUpdate(OpportunityObjectMixin, OrganizationProgramManagerMi
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["api_key_form"] = HQApiKeyCreateForm(auto_id="api_key_form_id_for_%s")
-        context["is_update"] = True
+        context["opportunity_created"] = True
         return context
 
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -440,6 +440,13 @@ class OpportunityFinalize(OpportunityObjectMixin, OrganizationProgramManagerMixi
         kwargs["cumulative_pu_budget_per_user"] = cumulative_pu_budget_per_user
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        opportunity = self.object
+        if opportunity.managed:
+            context["program"] = opportunity.managedopportunity.program
+        return context
+
     def form_valid(self, form):
         opportunity = form.instance
         opportunity.modified_by = self.request.user.email
@@ -809,11 +816,13 @@ def payment_import(request, org_slug=None, opp_id=None):
 def add_payment_units(request, org_slug=None, opp_id=None):
     if request.POST:
         return add_payment_unit(request, org_slug=org_slug, opp_id=opp_id)
-    paymentunit_count = PaymentUnit.objects.filter(opportunity=request.opportunity).count()
+    opportunity = request.opportunity
+    paymentunit_count = PaymentUnit.objects.filter(opportunity=opportunity).count()
+    program = opportunity.managedopportunity.program if opportunity.managed else None
     return render(
         request,
         "opportunity/add_payment_units.html",
-        dict(opportunity=request.opportunity, paymentunit_count=paymentunit_count),
+        dict(opportunity=opportunity, paymentunit_count=paymentunit_count, program=program),
     )
 
 

--- a/commcare_connect/program/tests/test_views.py
+++ b/commcare_connect/program/tests/test_views.py
@@ -246,3 +246,35 @@ class TestNetworkManagerPendingPayments:
         PaymentFactory.create(opportunity_access=access, amount=150)
 
         assert self._pending_payment_count(opportunity) is None
+
+
+@pytest.mark.django_db
+class TestManagedOpportunityInitViews(BaseProgramTest):
+    """program:opportunity_init and program:opportunity_init_edit must still work."""
+
+    @pytest.fixture(autouse=True)
+    def test_setup(self):
+        self.program = ProgramFactory.create(organization=self.organization)
+        self.init_url = reverse(
+            "program:opportunity_init",
+            kwargs={"org_slug": self.organization.slug, "pk": self.program.program_id},
+        )
+
+    def test_opportunity_init_get_shows_program_notice(self):
+        response = self.client.get(self.init_url)
+        assert response.status_code == HTTPStatus.OK
+        assert self.program.name.encode() in response.content
+
+    def test_opportunity_init_edit_get(self):
+        opportunity = ManagedOpportunityFactory.create(organization=self.organization, program=self.program)
+        edit_url = reverse(
+            "program:opportunity_init_edit",
+            kwargs={
+                "org_slug": self.organization.slug,
+                "pk": self.program.program_id,
+                "opp_id": opportunity.opportunity_id,
+            },
+        )
+        response = self.client.get(edit_url)
+        assert response.status_code == HTTPStatus.OK
+        assert self.program.name.encode() in response.content

--- a/commcare_connect/program/views.py
+++ b/commcare_connect/program/views.py
@@ -152,6 +152,11 @@ class ManagedOpportunityViewMixin:
             send_opportunity_created_email(self.object.id)
         return response
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["program"] = self.program
+        return context
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["program"] = self.program

--- a/commcare_connect/templates/opportunity/add_payment_units.html
+++ b/commcare_connect/templates/opportunity/add_payment_units.html
@@ -6,7 +6,7 @@
 {% block title %}{{ request.org }} - Payment Units{% endblock %}
 {% block content %}
   <div class="container md:max-w-screen-lg mx-auto flex flex-col gap-8">
-    {% include "opportunity/steps.html" with step='step2' org_slug=request.org.slug pk=opportunity.opportunity_id is_update=True %}
+    {% include "opportunity/steps.html" with step='step2' org_slug=request.org.slug pk=opportunity.opportunity_id opportunity_created=True %}
     <div class="card_bg space-y-4 !p-2">
       <div hx-get="{% url 'opportunity:payment_unit_table' org_slug=request.org.slug opp_id=opportunity.opportunity_id %}{% querystring %}"
            hx-trigger="load"

--- a/commcare_connect/templates/opportunity/add_payment_units.html
+++ b/commcare_connect/templates/opportunity/add_payment_units.html
@@ -6,7 +6,7 @@
 {% block title %}{{ request.org }} - Payment Units{% endblock %}
 {% block content %}
   <div class="container md:max-w-screen-lg mx-auto flex flex-col gap-8">
-    {% include "opportunity/steps.html" with step='step2' org_slug=request.org.slug pk=opportunity.opportunity_id opportunity_created=True %}
+    {% include "opportunity/steps.html" with step='step2' org_slug=request.org.slug pk=opportunity.opportunity_id opportunity_created=True program=program %}
     <div class="card_bg space-y-4 !p-2">
       <div hx-get="{% url 'opportunity:payment_unit_table' org_slug=request.org.slug opp_id=opportunity.opportunity_id %}{% querystring %}"
            hx-trigger="load"

--- a/commcare_connect/templates/opportunity/add_payment_units.html
+++ b/commcare_connect/templates/opportunity/add_payment_units.html
@@ -6,7 +6,7 @@
 {% block title %}{{ request.org }} - Payment Units{% endblock %}
 {% block content %}
   <div class="container md:max-w-screen-lg mx-auto flex flex-col gap-8">
-    {% include "opportunity/steps.html" with step='step2' org_slug=request.org.slug pk=opportunity.opportunity_id %}
+    {% include "opportunity/steps.html" with step='step2' org_slug=request.org.slug pk=opportunity.opportunity_id is_update=True %}
     <div class="card_bg space-y-4 !p-2">
       <div hx-get="{% url 'opportunity:payment_unit_table' org_slug=request.org.slug opp_id=opportunity.opportunity_id %}{% querystring %}"
            hx-trigger="load"

--- a/commcare_connect/templates/opportunity/opportunities_list.html
+++ b/commcare_connect/templates/opportunity/opportunities_list.html
@@ -40,12 +40,6 @@
               </span>
             {% endif %}
           </button>
-          {% if request.org.program_manager and request.org_membership.is_admin %}
-            <a class="button button-md primary-dark"
-               href="{% url 'opportunity:init' request.org.slug %}">Add Opportunity</a>
-          {% else %}
-            <button disabled class="button button-md primary-dark">Add Opportunity</button>
-          {% endif %}
           <div x-show="showFilterModal" class="modal-backdrop">
             <div class="modal">
               <div class="header text-lg font-semibold text-brand-deep-purple">

--- a/commcare_connect/templates/opportunity/opportunity_finalize.html
+++ b/commcare_connect/templates/opportunity/opportunity_finalize.html
@@ -5,7 +5,7 @@
 {% block title %}{{ request.org }} - Opportunity Budget{% endblock %}
 {% block content %}
   <div class="md:max-w-screen-lg mx-auto flex flex-col gap-8">
-    {% include "opportunity/steps.html" with step='step3' org_slug=request.org.slug pk=opportunity.opportunity_id is_update=True %}
+    {% include "opportunity/steps.html" with step='step3' org_slug=request.org.slug pk=opportunity.opportunity_id opportunity_created=True %}
     <div class="card_bg">{% include "components/partial_form.html" %}</div>
   </div>
 {% endblock content %}

--- a/commcare_connect/templates/opportunity/opportunity_finalize.html
+++ b/commcare_connect/templates/opportunity/opportunity_finalize.html
@@ -5,7 +5,7 @@
 {% block title %}{{ request.org }} - Opportunity Budget{% endblock %}
 {% block content %}
   <div class="md:max-w-screen-lg mx-auto flex flex-col gap-8">
-    {% include "opportunity/steps.html" with step='step3' org_slug=request.org.slug pk=opportunity.opportunity_id %}
+    {% include "opportunity/steps.html" with step='step3' org_slug=request.org.slug pk=opportunity.opportunity_id is_update=True %}
     <div class="card_bg">{% include "components/partial_form.html" %}</div>
   </div>
 {% endblock content %}

--- a/commcare_connect/templates/opportunity/opportunity_finalize.html
+++ b/commcare_connect/templates/opportunity/opportunity_finalize.html
@@ -5,7 +5,7 @@
 {% block title %}{{ request.org }} - Opportunity Budget{% endblock %}
 {% block content %}
   <div class="md:max-w-screen-lg mx-auto flex flex-col gap-8">
-    {% include "opportunity/steps.html" with step='step3' org_slug=request.org.slug pk=opportunity.opportunity_id opportunity_created=True %}
+    {% include "opportunity/steps.html" with step='step3' org_slug=request.org.slug pk=opportunity.opportunity_id opportunity_created=True program=program %}
     <div class="card_bg">{% include "components/partial_form.html" %}</div>
   </div>
 {% endblock content %}

--- a/commcare_connect/templates/opportunity/opportunity_init.html
+++ b/commcare_connect/templates/opportunity/opportunity_init.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 {% load crispy_forms_tags %}
 {% load duration_minutes %}
 {% load tailwind_filters %}
@@ -15,6 +16,12 @@
   <div class="container md:max-w-screen-lg mx-auto flex flex-col gap-8"
        x-data="{ showAddApiKeyModal: false }">
     {% include "opportunity/steps.html" with step='step1' org_slug=request.org.slug pk=form.instance.opportunity_id %}
+    {% if program %}
+      <div class="flex items-center gap-2 p-4 rounded-lg border-[0.5px] bg-message-info text-message-info-text border-message-info-border">
+        <i class="fa-solid fa-circle-info"></i>
+        <span class="text-sm">{% blocktranslate with name=program.name %}This opportunity will be created under the <strong>{{ name }}</strong> program.{% endblocktranslate %}</span>
+      </div>
+    {% endif %}
     <h6 class="title">
       {% if is_update %}
         Edit Details

--- a/commcare_connect/templates/opportunity/opportunity_init.html
+++ b/commcare_connect/templates/opportunity/opportunity_init.html
@@ -6,7 +6,7 @@
 {% load tailwind_filters %}
 {% block title %}
   {{ request.org }} -
-  {% if is_update %}
+  {% if opportunity_created %}
     Edit Opportunity
   {% else %}
     Create Opportunity
@@ -23,7 +23,7 @@
       </div>
     {% endif %}
     <h6 class="title">
-      {% if is_update %}
+      {% if opportunity_created %}
         Edit Details
       {% else %}
         Create Details

--- a/commcare_connect/templates/opportunity/steps.html
+++ b/commcare_connect/templates/opportunity/steps.html
@@ -4,7 +4,7 @@
   <a class="{% if step == 'step1' %}active{% endif %}"
      id="step1-tab"
      data-toggle="tab"
-     {% if pk and org_slug %}href="{% url 'opportunity:init_edit' org_slug=org_slug opp_id=pk %}"{% endif %}>
+     {% if pk and org_slug and program and is_update %}href="{% url 'program:opportunity_init_edit' org_slug=org_slug pk=program.program_id opp_id=pk %}"{% endif %}>
     <h6>1</h6>
     <span>Create Opportunity</span>
   </a>
@@ -12,7 +12,7 @@
   <a class="{% if step == 'step2' %}active{% endif %}"
      id="step2-tab"
      data-toggle="tab"
-     href="{% if pk %} {% url 'opportunity:add_payment_units' org_slug=org_slug opp_id=pk %}{% endif %}">
+     href="{% if pk and is_update %} {% url 'opportunity:add_payment_units' org_slug=org_slug opp_id=pk %}{% endif %}">
     <h6>2</h6>
     <span>Payment Unit</span>
   </a>
@@ -20,7 +20,7 @@
   <a class="{% if step == 'step3' %}active{% endif %}"
      id="step3-tab"
      data-toggle="tab"
-     href="{% if pk %} {% url 'opportunity:finalize' org_slug=org_slug opp_id=pk %}{% endif %}">
+     href="{% if pk and is_update %} {% url 'opportunity:finalize' org_slug=org_slug opp_id=pk %}{% endif %}">
     <h6>3</h6>
     <span>Budget</span>
   </a>

--- a/commcare_connect/templates/opportunity/steps.html
+++ b/commcare_connect/templates/opportunity/steps.html
@@ -4,7 +4,7 @@
   <a class="{% if step == 'step1' %}active{% endif %}"
      id="step1-tab"
      data-toggle="tab"
-     {% if pk and org_slug and program and is_update %}href="{% url 'program:opportunity_init_edit' org_slug=org_slug pk=program.program_id opp_id=pk %}"{% endif %}>
+     {% if pk and org_slug and program and opportunity_created %}href="{% url 'program:opportunity_init_edit' org_slug=org_slug pk=program.program_id opp_id=pk %}"{% endif %}>
     <h6>1</h6>
     <span>Create Opportunity</span>
   </a>
@@ -12,7 +12,7 @@
   <a class="{% if step == 'step2' %}active{% endif %}"
      id="step2-tab"
      data-toggle="tab"
-     href="{% if pk and is_update %} {% url 'opportunity:add_payment_units' org_slug=org_slug opp_id=pk %}{% endif %}">
+     href="{% if pk and opportunity_created %} {% url 'opportunity:add_payment_units' org_slug=org_slug opp_id=pk %}{% endif %}">
     <h6>2</h6>
     <span>Payment Unit</span>
   </a>
@@ -20,7 +20,7 @@
   <a class="{% if step == 'step3' %}active{% endif %}"
      id="step3-tab"
      data-toggle="tab"
-     href="{% if pk and is_update %} {% url 'opportunity:finalize' org_slug=org_slug opp_id=pk %}{% endif %}">
+     href="{% if pk and opportunity_created %} {% url 'opportunity:finalize' org_slug=org_slug opp_id=pk %}{% endif %}">
     <h6>3</h6>
     <span>Budget</span>
   </a>


### PR DESCRIPTION
## Product Description

The "Add Opportunity" button is removed from the opportunities list. Opportunity creation now only goes through the program flow, and the creation wizard shows which program the new opportunity will belong to.

## Technical Summary

- [CCCT-2499](https://dimagi.atlassian.net/browse/CCCT-2499)
- Removed standalone `opportunity:init` and `opportunity:init_edit` routes; creation only goes through `program:opportunity_init`
- Added `program` to template context in `ManagedOpportunityViewMixin.get_context_data`, which powers the program notice banner and correct step 1 navigation
- Stepper steps 2 and 3 only link forward once an opportunity exists (`is_update=True`); step 1 points to the program-scoped edit route

<img width="1718" height="995" alt="image" src="https://github.com/user-attachments/assets/e80f7866-e8d5-4bab-aba2-b6d208738c73" />


## Safety Assurance

### Safety story

Only the creation entry point changes. Existing opportunities, dashboards, and all post-creation flows are unaffected.

### Automated test coverage

Tests added for program-scoped opportunity init and edit views; passing.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CCCT-2499]: https://dimagi.atlassian.net/browse/CCCT-2499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ