### PR TITLE
Audits page UX updates to match Connect Workers formatting

### DIFF
--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -34,6 +34,7 @@ class AuditReportTable(OrgContextTable):
         empty_text = _l("No audits have been generated yet.")
         order_by = ("-period_end",)
         attrs = {"class": "table table-hover"}
+        row_attrs = {"class": "group"}
 
     def __init__(self, *args, opportunity=None, **kwargs):
         self.opportunity = opportunity
@@ -60,7 +61,14 @@ class AuditReportTable(OrgContextTable):
                 "audit_report_id": record.audit_report_id,
             },
         )
-        return format_html('<a href="{}" aria-label="{}">&rsaquo;</a>', url, _("View audit"))
+        return format_html(
+            '<div class="opacity-0 group-hover:opacity-100 transition-opacity duration-200 text-end">'
+            '<a href="{}" aria-label="{}">'
+            '<i class="fa-solid fa-chevron-right text-brand-deep-purple"></i>'
+            "</a></div>",
+            url,
+            _("View audit"),
+        )
 
 
 class CalcColumn(columns.Column):

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -5,15 +5,11 @@ from django.utils.translation import gettext_lazy as _l
 from django_tables2 import columns
 
 from commcare_connect.audit.models import AuditReport, AuditReportEntry
-from commcare_connect.utils.tables import OrgContextTable
+from commcare_connect.utils.tables import IndexColumn, OrgContextTable
 
 
 class AuditReportTable(OrgContextTable):
-    audit_id = columns.Column(
-        accessor="serial",
-        verbose_name=_l("Audit ID"),
-        order_by=("period_end",),
-    )
+    index = IndexColumn()
     date = columns.Column(
         accessor="period_end",
         verbose_name=_l("Date"),
@@ -34,7 +30,7 @@ class AuditReportTable(OrgContextTable):
 
     class Meta:
         model = AuditReport
-        fields = ("audit_id", "date", "status", "reviewer", "view")
+        fields = ("index", "date", "status", "reviewer", "view")
         empty_text = _l("No audits have been generated yet.")
         order_by = ("-period_end",)
         attrs = {"class": "table table-hover"}
@@ -42,17 +38,6 @@ class AuditReportTable(OrgContextTable):
     def __init__(self, *args, opportunity=None, **kwargs):
         self.opportunity = opportunity
         super().__init__(*args, **kwargs)
-
-    def render_audit_id(self, record):
-        url = reverse(
-            "opportunity:audit:audit_report_detail",
-            kwargs={
-                "org_slug": self.org_slug,
-                "opp_id": self.opportunity.opportunity_id,
-                "audit_report_id": record.audit_report_id,
-            },
-        )
-        return format_html('<a class="text-brand-deep-purple hover:underline" href="{}">#{}</a>', url, record.serial)
 
     def render_date(self, value):
         return value.strftime("%b %-d, %Y")

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -33,7 +33,6 @@ class AuditReportTable(OrgContextTable):
         fields = ("index", "date", "status", "reviewer", "view")
         empty_text = _l("No audits have been generated yet.")
         order_by = ("-period_end",)
-        attrs = {"class": "table table-hover"}
         row_attrs = {"class": "group"}
 
     def __init__(self, *args, opportunity=None, **kwargs):

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -5,15 +5,16 @@ from django.utils.translation import gettext_lazy as _l
 from django_tables2 import columns
 
 from commcare_connect.audit.models import AuditReport, AuditReportEntry
-from commcare_connect.utils.tables import IndexColumn, OrgContextTable
+from commcare_connect.utils.tables import DMYTColumn, IndexColumn, OrgContextTable
 
 
 class AuditReportTable(OrgContextTable):
     index = IndexColumn()
-    date = columns.Column(
-        accessor="period_end",
-        verbose_name=_l("Date"),
+    date = DMYTColumn(
+        accessor="date_created",
+        verbose_name=_l("Generation Date"),
         orderable=True,
+        order_by=("date_created",),
     )
     status = columns.Column(verbose_name=_l("Status"))
     reviewer = columns.Column(
@@ -32,15 +33,12 @@ class AuditReportTable(OrgContextTable):
         model = AuditReport
         fields = ("index", "date", "status", "reviewer", "view")
         empty_text = _l("No audits have been generated yet.")
-        order_by = ("-period_end",)
+        order_by = ("-date_created",)
         row_attrs = {"class": "group"}
 
     def __init__(self, *args, opportunity=None, **kwargs):
         self.opportunity = opportunity
         super().__init__(*args, **kwargs)
-
-    def render_date(self, value):
-        return value.strftime("%b %-d, %Y")
 
     def render_status(self, record):
         if record.status == AuditReport.Status.COMPLETED:

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -31,8 +31,9 @@ def test_list_view_shows_reports(client, program_manager_org_user_admin, audit_o
     html = response.content.decode()
     # Numbering column header
     assert ">#</span>" in html
-    # Period end rendered in the Date column.
-    assert report.period_end.strftime("%b") in html
+    # Generation Date column header and date_created value are rendered.
+    assert "Generation Date" in html
+    assert report.date_created.strftime("%b") in html
 
 
 @pytest.mark.django_db

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -29,8 +29,8 @@ def test_list_view_shows_reports(client, program_manager_org_user_admin, audit_o
     response = client.get(url)
     assert response.status_code == 200
     html = response.content.decode()
-    # Audit ID rendered as a 1-based serial number, not the pk.
-    assert "#1" in html
+    # Numbering column header
+    assert ">#</span>" in html
     # Period end rendered in the Date column.
     assert report.period_end.strftime("%b") in html
 

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -1,8 +1,6 @@
 from datetime import timedelta
 
 from django.db import transaction
-from django.db.models import F, Window
-from django.db.models.functions import RowNumber
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -38,12 +36,7 @@ def _require_feature_flag(opportunity):
 def audit_report_list(request, org_slug, opp_id):
     opportunity = request.opportunity
     _require_feature_flag(opportunity)
-    # Annotate each row with its chronological position
-    queryset = (
-        AuditReport.objects.filter(opportunity=opportunity)
-        .select_related("completed_by")
-        .annotate(serial=Window(expression=RowNumber(), order_by=F("period_end").asc()))
-    )
+    queryset = AuditReport.objects.filter(opportunity=opportunity).select_related("completed_by")
 
     total_count = queryset.count()
     pending_count = queryset.filter(status=AuditReport.Status.PENDING).count()


### PR DESCRIPTION
## Product Description

UX updates to the Audits page table to match the Connect Workers > Deliver page formatting:

- Numbering column replaced with `#` (plain sequential index, matching Deliver page)
- Right arrow replaced with a hover-reveal chevron icon (`fa-chevron-right`)
- Header font/styling now matches Connect Workers (removed custom `attrs` override)
- Date column renamed to **Generation Date**, now shows when the audit was generated (`date_created`) rather than the period end date

**Before**

<img width="3255" height="1228" alt="image" src="https://github.com/user-attachments/assets/dbdb0b58-1b61-4ae3-b259-94730d69497b" />


**After**

<img width="3255" height="1228" alt="image" src="https://github.com/user-attachments/assets/e61afe48-21e2-4b1b-a278-cc0b96c41393" />


## Technical Summary

[Ticket](https://dimagi.atlassian.net/browse/CCCT-2479)

All changes are in `commcare_connect/audit/tables.py` and `audit/views.py`:


## Safety Assurance

### Safety story

Read-only table rendering change — no model, migration, or business logic changes. Existing audit data is unaffected. The only behavioral change is which field is displayed in the date column (`date_created` instead of `period_end`).

### Automated test coverage

Existing view tests updated to assert the new column header (`#`, `Generation Date`) and that `date_created` is rendered. All 14 audit view tests pass.

### QA Plan
None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change