### PR TITLE
Weekly Performance Report Display Improvements

### DIFF
--- a/commcare_connect/audit/calculations.py
+++ b/commcare_connect/audit/calculations.py
@@ -8,6 +8,21 @@ _REGISTRY: list[AuditCalculation] = []
 
 
 @dataclass
+class Measurement:
+    """Raw result of a calculation's ``compute()``: a ``value`` over a sample.
+
+    ``sample_size`` is the gating quantity compared against ``min_sample_size``.
+    ``denominator`` overrides the displayed fraction's denominator for percentage
+    calculations whose rate is taken over a different population than the gate;
+    when ``None`` the denominator defaults to ``sample_size``.
+    """
+
+    value: Any
+    sample_size: int
+    denominator: int | None = None
+
+
+@dataclass
 class CalculationResult:
     name: str
     label: str
@@ -58,14 +73,15 @@ class AuditCalculation(ABC):
     upper_bound: ClassVar[float | None] = None
 
     @abstractmethod
-    def compute(self, opportunity_access, period_start, period_end) -> tuple[Any, int]:
-        """Return ``(value, sample_size)``. ``value`` may be ``None`` when
-        ``sample_size == 0``.
+    def compute(self, opportunity_access, period_start, period_end) -> Measurement:
+        """Return a :class:`Measurement`. ``value`` may be ``None`` when
+        ``sample_size == 0``. Set ``denominator`` only when a percentage's rate
+        is taken over a different population than the gating ``sample_size``.
         """
 
     def run(self, opportunity_access, period_start, period_end) -> CalculationResult:
-        value, sample_size = self.compute(opportunity_access, period_start, period_end)
-        has_sufficient_data = sample_size >= self.min_sample_size
+        m = self.compute(opportunity_access, period_start, period_end)
+        has_sufficient_data = m.sample_size >= self.min_sample_size
         if not has_sufficient_data:
             return CalculationResult(
                 name=self.name,
@@ -76,15 +92,17 @@ class AuditCalculation(ABC):
             )
         numerator = None
         denominator = None
-        if self.is_percentage and value is not None:
-            denominator = sample_size
-            numerator = round(value * sample_size / 100)
+        if self.is_percentage and m.value is not None:
+            # Denominator defaults to the gating sample unless compute() overrode
+            # it; the numerator is derived from value so the two never diverge.
+            denominator = m.sample_size if m.denominator is None else m.denominator
+            numerator = round(m.value * denominator / 100)
         return CalculationResult(
             name=self.name,
             label=self.label,
-            value=value,
+            value=m.value,
             has_sufficient_data=True,
-            in_range=self._in_range(value),
+            in_range=self._in_range(m.value),
             numerator=numerator,
             denominator=denominator,
         )

--- a/commcare_connect/audit/calculations.py
+++ b/commcare_connect/audit/calculations.py
@@ -51,6 +51,7 @@ class AuditCalculation(ABC):
 
     name: ClassVar[str]
     label: ClassVar[str]
+    tooltip: ClassVar[str] = ""
     is_percentage: ClassVar[bool] = False
     min_sample_size: ClassVar[int] = 1
     lower_bound: ClassVar[float | None] = None

--- a/commcare_connect/audit/calculations.py
+++ b/commcare_connect/audit/calculations.py
@@ -14,14 +14,21 @@ class CalculationResult:
     value: Any
     has_sufficient_data: bool
     in_range: bool
+    numerator: int | None = None
+    denominator: int | None = None
 
     def to_dict(self) -> dict:
-        return {
+        d = {
             "value": self.value,
             "has_sufficient_data": self.has_sufficient_data,
             "in_range": self.in_range,
             "label": self.label,
         }
+        if self.numerator is not None:
+            d["numerator"] = self.numerator
+        if self.denominator is not None:
+            d["denominator"] = self.denominator
+        return d
 
 
 class AuditCalculation(ABC):
@@ -44,6 +51,7 @@ class AuditCalculation(ABC):
 
     name: ClassVar[str]
     label: ClassVar[str]
+    is_percentage: ClassVar[bool] = False
     min_sample_size: ClassVar[int] = 1
     lower_bound: ClassVar[float | None] = None
     upper_bound: ClassVar[float | None] = None
@@ -65,12 +73,19 @@ class AuditCalculation(ABC):
                 has_sufficient_data=False,
                 in_range=True,
             )
+        numerator = None
+        denominator = None
+        if self.is_percentage and value is not None:
+            denominator = sample_size
+            numerator = round(value * sample_size / 100)
         return CalculationResult(
             name=self.name,
             label=self.label,
             value=value,
             has_sufficient_data=True,
             in_range=self._in_range(value),
+            numerator=numerator,
+            denominator=denominator,
         )
 
     def _in_range(self, value) -> bool:

--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -165,6 +165,7 @@ class GenderRatioDeviation(AuditCalculation):
 
     name = "gender_ratio_deviation"
     label = "Gender Ratio Deviation"
+    is_percentage = True
     min_sample_size = 97
     lower_bound = 40
     upper_bound = 60
@@ -194,6 +195,7 @@ class MUACPhotoCompliance(AuditCalculation):
 
     name = "muac_photo_compliance"
     label = "MUAC Photo Compliance"
+    is_percentage = True
     min_sample_size = 70
     lower_bound = 72
 
@@ -227,6 +229,7 @@ class AgeHeaping(AuditCalculation):
 
     name = "age_heaping"
     label = "Age Heaping"
+    is_percentage = True
     min_sample_size = 97
     upper_bound = 19
 
@@ -297,6 +300,7 @@ class InaccessibleWARateEarlyWarning(AuditCalculation):
 
     name = "inaccessible_wa_rate_early_warning"
     label = "Inaccessible WA Rate – Early Warning"
+    is_percentage = True
     min_sample_size = 5
     upper_bound = 25
 
@@ -326,6 +330,7 @@ class InaccessibleWARateLastCompletedWAG(AuditCalculation):
 
     name = "inaccessible_wa_rate_last_completed_wag"
     label = "Inaccessible WA Rate – Last Completed WAG"
+    is_percentage = True
     min_sample_size = 5
     upper_bound = 15
 
@@ -365,6 +370,7 @@ class VaccineRate(AuditCalculation):
 
     name = "vaccine_rate"
     label = "Vaccine Rate"
+    is_percentage = True
     min_sample_size = 97
     lower_bound = 58
 
@@ -394,6 +400,7 @@ class VaccineCardPhotoCompliance(AuditCalculation):
 
     name = "vaccine_card_photo_compliance"
     label = "Vaccine Card Photo Compliance"
+    is_percentage = True
     min_sample_size = 97
     lower_bound = 38
 

--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -131,6 +131,7 @@ class CampingRatio(AuditCalculation):
 
     name = "camping_ratio"
     label = "Camping (Visit:Building Ratio)"
+    tooltip = "Flagged if visits exceed 12 per building in any single Work Area in the past week."
     min_sample_size = 1
     upper_bound = 0
 
@@ -165,6 +166,7 @@ class GenderRatioDeviation(AuditCalculation):
 
     name = "gender_ratio_deviation"
     label = "Gender Ratio Deviation"
+    tooltip = "Flagged if female or male ratio falls below 40% or exceeds 60%."
     is_percentage = True
     min_sample_size = 97
     lower_bound = 40
@@ -195,6 +197,7 @@ class MUACPhotoCompliance(AuditCalculation):
 
     name = "muac_photo_compliance"
     label = "MUAC Photo Compliance"
+    tooltip = "Flagged if MUAC photo taken in fewer than 72% of eligible visits (children ≥6 months)."
     is_percentage = True
     min_sample_size = 70
     lower_bound = 72
@@ -229,6 +232,7 @@ class AgeHeaping(AuditCalculation):
 
     name = "age_heaping"
     label = "Age Heaping"
+    tooltip = "Flagged if more than 19% of recorded ages are exactly 12, 24, 36, or 48 months."
     is_percentage = True
     min_sample_size = 97
     upper_bound = 19
@@ -260,6 +264,7 @@ class WACoverageToVisitRatio(AuditCalculation):
 
     name = "wa_coverage_to_visit_ratio"
     label = "WA Coverage to Visit Ratio"
+    tooltip = "Flagged if ratio falls below 0.6 or exceeds 1.4."
     min_sample_size = 1
     lower_bound = 0.6
     upper_bound = 1.4
@@ -300,6 +305,7 @@ class InaccessibleWARateEarlyWarning(AuditCalculation):
 
     name = "inaccessible_wa_rate_early_warning"
     label = "Inaccessible WA Rate – Early Warning"
+    tooltip = "Flagged if more than 25% of Work Areas in the current active WAG are marked Inaccessible."
     is_percentage = True
     min_sample_size = 5
     upper_bound = 25
@@ -330,6 +336,7 @@ class InaccessibleWARateLastCompletedWAG(AuditCalculation):
 
     name = "inaccessible_wa_rate_last_completed_wag"
     label = "Inaccessible WA Rate – Last Completed WAG"
+    tooltip = "Flagged if more than 15% of Work Areas in the most recently closed WAG are marked Inaccessible."
     is_percentage = True
     min_sample_size = 5
     upper_bound = 15
@@ -370,6 +377,7 @@ class VaccineRate(AuditCalculation):
 
     name = "vaccine_rate"
     label = "Vaccine Rate"
+    tooltip = "Flagged if fewer than 58% of visits record at least one vaccine received."
     is_percentage = True
     min_sample_size = 97
     lower_bound = 58
@@ -400,6 +408,7 @@ class VaccineCardPhotoCompliance(AuditCalculation):
 
     name = "vaccine_card_photo_compliance"
     label = "Vaccine Card Photo Compliance"
+    tooltip = "Flagged if vaccine card photo taken in fewer than 38% of visits where child was vaccinated."
     is_percentage = True
     min_sample_size = 97
     lower_bound = 38
@@ -525,6 +534,7 @@ class MUACDistributionPatternIndex(AuditCalculation):
 
     name = "muac_distribution_pattern_index"
     label = "MUAC Distribution Pattern Index (MDPI)"
+    tooltip = "Flagged if fewer than 5 of 6 distribution shape tests pass."
     min_sample_size = 100
     lower_bound = 5
 

--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -6,7 +6,7 @@ from django.db.models import Count, F, IntegerField, Max, Q, Sum, Value
 from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, NullIf
 
-from commcare_connect.audit.calculations import AuditCalculation, register_calculation
+from commcare_connect.audit.calculations import AuditCalculation, Measurement, register_calculation
 from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup, WorkAreaStatus
 from commcare_connect.opportunity.models import UserVisit
 
@@ -154,7 +154,7 @@ class CampingRatio(AuditCalculation):
             for row in wa_visit_counts
             if row["visit_count"] > MAX_VISITS_PER_BUILDING * row["work_area__building_count"]
         )
-        return camping_count, total_evaluated
+        return Measurement(camping_count, total_evaluated)
 
 
 @register_calculation
@@ -183,8 +183,8 @@ class GenderRatioDeviation(AuditCalculation):
         )
         total = result["total"]
         if not total:
-            return None, 0
-        return _percent(result["female"], total), total
+            return Measurement(None, 0)
+        return Measurement(_percent(result["female"], total), total)
 
 
 @register_calculation
@@ -218,8 +218,8 @@ class MUACPhotoCompliance(AuditCalculation):
         )
         total = result["total"]
         if not total:
-            return None, 0
-        return _percent(result["with_photo"], total), total
+            return Measurement(None, 0)
+        return Measurement(_percent(result["with_photo"], total), total)
 
 
 @register_calculation
@@ -249,8 +249,8 @@ class AgeHeaping(AuditCalculation):
         )
         total = result["total"]
         if not total:
-            return None, 0
-        return _percent(result["heaped"], total), total
+            return Measurement(None, 0)
+        return Measurement(_percent(result["heaped"], total), total)
 
 
 @register_calculation
@@ -289,11 +289,11 @@ class WACoverageToVisitRatio(AuditCalculation):
         ).count()
 
         if not (total_eligible and expected_visits and actual_visits):
-            return None, 0
+            return Measurement(None, 0)
 
         coverage_ratio = wa_stats["visited_count"] / total_eligible
         visit_ratio = actual_visits / expected_visits
-        return coverage_ratio / visit_ratio, total_eligible
+        return Measurement(coverage_ratio / visit_ratio, total_eligible)
 
 
 @register_calculation
@@ -313,7 +313,7 @@ class InaccessibleWARateEarlyWarning(AuditCalculation):
     def compute(self, opportunity_access, period_start, period_end):
         active_wag = _find_active_wag(opportunity_access, period_end)
         if active_wag is None:
-            return None, 0
+            return Measurement(None, 0)
 
         stats = WorkArea.objects.filter(work_area_group=active_wag, opportunity_access=opportunity_access).aggregate(
             total=Count("id"),
@@ -322,9 +322,16 @@ class InaccessibleWARateEarlyWarning(AuditCalculation):
         )
 
         if not stats["total"]:
-            return None, 0
+            return Measurement(None, 0)
 
-        return _percent(stats["inaccessible_count"], stats["total"]), stats["terminal_count"]
+        # Rate is over all assigned WAs (total), but evaluation is gated on ≥5
+        # terminal WAs — so the display denominator (total) differs from the
+        # gating sample_size (terminal_count).
+        return Measurement(
+            value=_percent(stats["inaccessible_count"], stats["total"]),
+            sample_size=stats["terminal_count"],
+            denominator=stats["total"],
+        )
 
 
 @register_calculation
@@ -344,7 +351,7 @@ class InaccessibleWARateLastCompletedWAG(AuditCalculation):
     def compute(self, opportunity_access, period_start, period_end):
         last_wag = _find_last_closed_wag(opportunity_access, period_end)
         if last_wag is None:
-            return None, 0
+            return Measurement(None, 0)
 
         stats = (
             WorkArea.objects.filter(
@@ -363,9 +370,9 @@ class InaccessibleWARateLastCompletedWAG(AuditCalculation):
 
         total = stats["total"]
         if total == 0:
-            return None, 0
+            return Measurement(None, 0)
 
-        return _percent(stats["inaccessible_count"], total), total
+        return Measurement(_percent(stats["inaccessible_count"], total), total)
 
 
 @register_calculation
@@ -393,8 +400,8 @@ class VaccineRate(AuditCalculation):
         )
         total = result["total"]
         if not total:
-            return None, 0
-        return _percent(result["vaccinated"], total), total
+            return Measurement(None, 0)
+        return Measurement(_percent(result["vaccinated"], total), total)
 
 
 @register_calculation
@@ -425,8 +432,8 @@ class VaccineCardPhotoCompliance(AuditCalculation):
         )
         total = result["total"]
         if not total:
-            return None, 0
-        return _percent(result["with_photo"], total), total
+            return Measurement(None, 0)
+        return Measurement(_percent(result["with_photo"], total), total)
 
 
 # ── MUAC distribution helpers (ported from MLFeatureAggregationReport.py) ────
@@ -571,7 +578,7 @@ class MUACDistributionPatternIndex(AuditCalculation):
 
         total = len(measurements)
         if total < self.min_sample_size:
-            return None, total
+            return Measurement(None, total)
 
         bin_counts = _muac_build_bins(measurements)
         max_count = max(bin_counts)
@@ -589,4 +596,4 @@ class MUACDistributionPatternIndex(AuditCalculation):
                 max_count / total <= 0.42,
             ]
         )
-        return score, total
+        return Measurement(score, total)

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -85,9 +85,22 @@ class CalcColumn(columns.Column):
     negative badge when ``in_range`` is False.
     """
 
-    def __init__(self, calc_name, **kw):
+    def __init__(self, calc_name, tooltip="", **kw):
         self.calc_name = calc_name
+        self.calc_tooltip = tooltip
         super().__init__(empty_values=(), orderable=False, **kw)
+
+    @property
+    def header(self):
+        label = self.verbose_name
+        if not self.calc_tooltip:
+            return label
+        return format_html(
+            '{} <span x-data x-tooltip.raw="{}" class="inline-flex items-center cursor-help">'
+            '<i class="fa-solid fa-circle-info text-xs text-gray-400"></i></span>',
+            label,
+            self.calc_tooltip,
+        )
 
     def render(self, record):
         r = record.results.get(self.calc_name, {})
@@ -159,6 +172,9 @@ class AuditReportEntryTable(OrgContextTable):
     def __init__(self, data, *, opportunity, report, columns_spec, **kw):
         self.opportunity = opportunity
         self.report = report
-        extra = [(name, CalcColumn(calc_name=name, verbose_name=label)) for name, label in columns_spec]
+        extra = [
+            (name, CalcColumn(calc_name=name, verbose_name=label, tooltip=tooltip))
+            for name, label, tooltip in columns_spec
+        ]
         extra.append(("action", ActionColumn()))
         super().__init__(data, extra_columns=extra, **kw)

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -93,8 +93,15 @@ class CalcColumn(columns.Column):
         r = record.results.get(self.calc_name, {})
         if not r.get("has_sufficient_data"):
             return format_html('<span class="text-gray-400">{}</span>', _("N/A"))
-        value = r.get("value", "-")
-        display = f"{value:.2f}" if isinstance(value, float) else str(value) if value is not None else ""
+        value = r.get("value")
+        if value is None:
+            display = "-"
+        elif r.get("numerator") is not None:
+            display = f"{round(value)}% ({r['numerator']}/{r['denominator']})"
+        elif isinstance(value, float):
+            display = f"{value:.2f}"
+        else:
+            display = str(value)
         if not r.get("in_range"):
             return format_html('<span class="badge badge-md negative-dark">{}</span>', display)
         return display

--- a/commcare_connect/audit/tests/test_calculations.py
+++ b/commcare_connect/audit/tests/test_calculations.py
@@ -1,5 +1,5 @@
 from commcare_connect.audit import calculations
-from commcare_connect.audit.calculations import AuditCalculation, CalculationResult, register_calculation
+from commcare_connect.audit.calculations import AuditCalculation, CalculationResult, Measurement, register_calculation
 
 
 def test_calculation_result_to_dict():
@@ -30,7 +30,7 @@ class _FakeCalc(AuditCalculation):
         self._sample_size = sample_size
 
     def compute(self, opportunity_access, period_start, period_end):
-        return self._value, self._sample_size
+        return Measurement(self._value, self._sample_size)
 
 
 def _run(value, sample_size):
@@ -61,6 +61,33 @@ def test_value_inside_bounds_is_in_range():
     assert result.in_range is True
 
 
+class _PctCalc(AuditCalculation):
+    name = "pct"
+    label = "Pct"
+    is_percentage = True
+    min_sample_size = 5
+
+    def __init__(self, measurement):
+        self._measurement = measurement
+
+    def compute(self, opportunity_access, period_start, period_end):
+        return self._measurement
+
+
+def test_percentage_denominator_defaults_to_sample_size():
+    result = _PctCalc(Measurement(25.0, 8)).run(None, None, None)
+    assert result.denominator == 8
+    assert result.numerator == 2  # round(25.0 * 8 / 100)
+
+
+def test_percentage_denominator_override_decouples_from_gating_sample():
+    # Gate on sample_size=6 (>= min 5), but report the rate over 8.
+    result = _PctCalc(Measurement(25.0, 6, denominator=8)).run(None, None, None)
+    assert result.has_sufficient_data is True
+    assert result.denominator == 8
+    assert result.numerator == 2  # round(25.0 * 8 / 100), derived from value not sample_size
+
+
 def test_register_calculation_appends_instance():
     original = list(calculations._REGISTRY)
     try:
@@ -72,7 +99,7 @@ def test_register_calculation_appends_instance():
             label = "Dummy"
 
             def compute(self, opportunity_access, period_start, period_end):
-                return 1, 1
+                return Measurement(1, 1)
 
         registered = calculations.get_registered_calculations()
         assert len(registered) == 1

--- a/commcare_connect/audit/tests/test_chc_indicators.py
+++ b/commcare_connect/audit/tests/test_chc_indicators.py
@@ -162,18 +162,17 @@ class BaseIndicatorTest:
         return self.calc.run(access, PERIOD_START, PERIOD_END)
 
     def assert_insufficient_data(self, access):
-        _, sample = self.compute(access)
-        assert sample == 0
+        assert self.compute(access).sample_size == 0
 
     def assert_compute_result(self, access, *, value=None, sample=None, in_range=None):
-        actual_value, actual_sample = self.compute(access)
+        m = self.compute(access)
         if sample is not None:
-            assert actual_sample == sample
+            assert m.sample_size == sample
         if value is not None:
-            assert actual_value == pytest.approx(value)
+            assert m.value == pytest.approx(value)
         if in_range is not None:
-            assert self.calc._in_range(actual_value) is in_range
-        return actual_value, actual_sample
+            assert self.calc._in_range(m.value) is in_range
+        return m
 
     def assert_insufficient_run(self, access):
         assert self.run(access).has_sufficient_data is False
@@ -212,7 +211,7 @@ class BaseIndicatorTest:
 )
 def test_fresh_access_returns_insufficient_data(calc):
     access = OpportunityAccessFactory()
-    _, sample = calc.compute(access, PERIOD_START, PERIOD_END)
+    sample = calc.compute(access, PERIOD_START, PERIOD_END).sample_size
     assert sample == 0
 
 
@@ -309,7 +308,7 @@ class TestMUACPhotoCompliance(BaseIndicatorTest):
     def test_no_consent_still_in_denominator(self):
         access = OpportunityAccessFactory()
         make_visit(access, form_json={"form": {"additional_case_info": {"childs_age_in_months": "12"}}})
-        _, sample = self.compute(access)
+        sample = self.compute(access).sample_size
         assert sample == 1  # consent is irrelevant; age ≥6 makes this visit eligible
 
     @pytest.mark.parametrize(
@@ -412,7 +411,7 @@ class TestWACoverageToVisitRatio(BaseIndicatorTest):
             expected_visit_count=100,
         )
         make_visit(access, work_area=wa)
-        value, _ = self.compute(access)
+        value = self.compute(access).value
         assert value > 1.4
 
     def test_low_coverage_high_visits_out_of_range(self):
@@ -425,7 +424,7 @@ class TestWACoverageToVisitRatio(BaseIndicatorTest):
             expected_visit_count=1,
         )
         make_visits(10, access, work_area=wa)
-        value, _ = self.compute(access)
+        value = self.compute(access).value
         assert value < 0.6
 
     def test_excluded_wa_not_counted_in_eligible_but_inaccessible_is(self):
@@ -494,16 +493,28 @@ class TestInaccessibleWARateEarlyWarning(BaseIndicatorTest):
     @pytest.mark.parametrize(
         "inaccessible, reached, not_visited, expected_value, in_range",
         [
-            (1, 5, 1, 14.29, True),  # ~14%, below 25% threshold
-            (4, 1, 1, 66.67, False),  # ~67%, above 25% threshold
+            (1, 5, 1, 14.29, True),  # 1/7 of all assigned WAs, below 25% threshold
+            (4, 1, 1, 66.67, False),  # 4/6 of all assigned WAs, above 25% threshold
+            (2, 4, 2, 25.0, True),  # exactly 25% (2/8) is in range — boundary is inclusive
         ],
-        ids=["below_threshold", "above_threshold"],
+        ids=["below_threshold", "above_threshold", "at_threshold"],
     )
     def test_inaccessible_rate_threshold(self, inaccessible, reached, not_visited, expected_value, in_range):
         access, wag = make_access_and_wag()
         first_wa = make_was(wag, access, inaccessible=inaccessible, reached=reached, not_visited=not_visited)
         make_visit(access, work_area=first_wa)  # visit needed so _find_active_wag can locate this WAG
+        # sample_size is the gating count (terminal WAs); the rate divides by all assigned WAs.
         self.assert_compute_result(access, sample=inaccessible + reached, value=expected_value, in_range=in_range)
+
+    def test_run_reports_numerator_over_all_assigned_was(self):
+        access, wag = make_access_and_wag()
+        first_wa = make_was(wag, access, inaccessible=2, reached=4, not_visited=2)
+        make_visit(access, work_area=first_wa)
+        result = self.run(access)
+        # numerator = inaccessible WAs; denominator = all assigned WAs (not the terminal sample).
+        assert result.numerator == 2
+        assert result.denominator == 8
+        assert result.value == pytest.approx(25.0)
 
     def test_fully_closed_wag_not_treated_as_active(self):
         access, wag = make_access_and_wag()
@@ -715,22 +726,23 @@ class TestMUACDistributionPatternIndex(BaseIndicatorTest):
     def test_realistic_distribution_passes_most_features(self):
         access = OpportunityAccessFactory()
         make_muac_visits(access)
-        value, sample = self.compute(access)
-        assert sample == 100
+        m = self.compute(access)
+        assert m.sample_size == 100
+        value = m.value
         assert value >= 5
         assert self.calc._in_range(value)
 
     def test_single_bin_distribution_fails_multiple_features(self):
         access = OpportunityAccessFactory()
         make_muac_visits(access, [13.0] * 100)
-        value, _ = self.compute(access)
+        value = self.compute(access).value
         assert value < 5
         assert not self.calc._in_range(value)
 
     def test_score_is_integer_between_0_and_6(self):
         access = OpportunityAccessFactory()
         make_muac_visits(access)
-        value, _ = self.compute(access)
+        value = self.compute(access).value
         assert isinstance(value, int)
         assert 0 <= value <= 6
 

--- a/commcare_connect/audit/tests/test_services.py
+++ b/commcare_connect/audit/tests/test_services.py
@@ -19,7 +19,7 @@ def isolated_registry():
 
 @pytest.fixture
 def fixed_calc(isolated_registry):
-    from commcare_connect.audit.calculations import AuditCalculation
+    from commcare_connect.audit.calculations import AuditCalculation, Measurement
 
     state = {"call_count": 0}
 
@@ -33,7 +33,7 @@ def fixed_calc(isolated_registry):
             state["call_count"] += 1
             # Even pk → value=1.0 (in range); odd pk → value=0.0 (out of range).
             value = 1.0 if opportunity_access.pk % 2 == 0 else 0.0
-            return value, 1
+            return Measurement(value, 1)
 
     calculations._REGISTRY.append(FakeCalc())
     return state

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -77,14 +77,14 @@ def audit_report_list(request, org_slug, opp_id):
 
 def _column_specs(entries):
     """Calculation columns to render, ordered by registry then by appearance."""
-    registry_names = [c.name for c in get_registered_calculations()]
+    registry = {c.name: c.tooltip for c in get_registered_calculations()}
     seen = {}
     for entry in entries:
         for name, result in entry.results.items():
             if name not in seen:
                 seen[name] = result.get("label", name)
-    ordered = [(name, seen[name]) for name in registry_names if name in seen]
-    leftovers = [(name, label) for name, label in seen.items() if name not in registry_names]
+    ordered = [(name, seen[name], registry.get(name, "")) for name in registry if name in seen]
+    leftovers = [(name, label, "") for name, label in seen.items() if name not in registry]
     return ordered + leftovers
 
 


### PR DESCRIPTION
## Product Description

The weekly performance report audit table has been improved with clearer, more informative metric displays:

- **Percentage metrics** now show both the rounded percentage and the underlying counts, e.g. `52% (50/97)`, instead of a raw decimal.
- **Float ratio metrics** (e.g. WA Coverage to Visit Ratio) now display to 2 decimal places, e.g. `0.87`.
- **Column headers** now show an info icon (ⓘ) with a tooltip on hover describing what each metric measures and what threshold triggers a flag.

**Old:**
<img width="1659" height="862" alt="Screenshot_20260616_142019" src="https://github.com/user-attachments/assets/29c350d3-437d-4545-8002-01d0418ddc8c" />

**New:**
<img width="1659" height="862" alt="Screenshot_20260616_142055" src="https://github.com/user-attachments/assets/38cc46ab-321a-4c72-9e04-1fe3f858cc62" />

## Technical Summary

[CCCT-2480](https://dimagi.atlassian.net/browse/CCCT-2480)

This is a release path 3 feature — Experiments & early stage iterations of product area


This PR builds out the audit report display: percentage calculations now carry a numerator and denominator through to the table, and indicator columns gained header tooltips. To support showing the fraction, a `Measurement` return type was added to the calculation framework so a calculation can report the displayed denominator independently of the sample size used to gate evaluation. This matters because some indicators are gated on one population but report a rate over another — for example, the Early Warning indicator only evaluates once ≥5 Work Areas (WAs) have reached terminal status, but its rate is over all assigned WAs. Keeping these two concerns separate lets the displayed `numerator/denominator` reflect the true rate while gating still uses the correct sample.

## Safety Assurance

### Safety story

- **Display-only blast radius for most of the change.** The numerator/denominator rendering and tooltips are presentation concerns; they do not alter stored audit data or which workers are flagged.
- **The `Measurement` migration is behavior-preserving.** Every existing calculation returns the same `value` and `sample_size` as before; the only one that sets the new `denominator` override is the Early Warning indicator, so its displayed fraction reflects its rate over all assigned WAs. All other indicators retain identical `value`/`sample_size`/`in_range` behavior — verified by the migrated test suite.
- **No data migration and no schema change.** Audit reports are recomputed from source data, so the change takes effect on the next report generation and is fully reversible by reverting the commit.
- **Single source of truth for the fraction.** Deriving the numerator from `value` (rather than passing it independently) structurally prevents the displayed `X% (n/d)` from contradicting the `X%`.

### Automated test coverage

- `test_calculations.py::test_percentage_denominator_defaults_to_sample_size` and `::test_percentage_denominator_override_decouples_from_gating_sample` — cover the new `Measurement` behavior: default denominator equals the gating sample, and an explicit `denominator` overrides it while the numerator is still derived from `value`.
- `TestInaccessibleWARateEarlyWarning.test_inaccessible_rate_threshold` — parametrized below/above/**at** threshold cases, asserting the rate is `inaccessible/total` (incl. the inclusive 25% boundary, `2/8`, staying in range).
- `TestInaccessibleWARateEarlyWarning.test_run_reports_numerator_over_all_assigned_was` — asserts `run()` reports `numerator = inaccessible` and `denominator = total` (the assigned population, not the terminal gating sample).
- Existing bound/insufficient-data tests (`test_value_below/above/inside_bounds…`, `test_insufficient_data_…`) continue to pass against the `Measurement` contract.
- The remaining audit calculations' tests in `test_chc_indicators.py` were migrated to the `Measurement` return type with unchanged assertions, confirming no behavior change.
- **Coverage gap (handled in QA plan):** the `tables.py` `X% (n/d)` rendering and the header tooltip HTML have no dedicated unit test; they are exercised manually below.

### QA Plan

QA will not be performed for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CCCT-2480]: https://dimagi.atlassian.net/browse/CCCT-2480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ