### PR TITLE
Add status popup for payment upload

### DIFF
--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -473,7 +473,7 @@ def bulk_update_payments_task(self, opportunity_id: int, file_path: str, file_fo
             status = bulk_update_payments(opportunity_id, headers, rows)
             return {
                 "success": True,
-                "users_paid": len(status),
+                "payments_processed": status.payments_created,
                 "missing_users_message": status.get_missing_message() if status.missing_users else None,
             }
         except ImportException as e:

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -477,7 +477,7 @@ def bulk_update_payments_task(self, opportunity_id: int, file_path: str, file_fo
                 "missing_users_message": status.get_missing_message() if status.missing_users else None,
             }
         except ImportException as e:
-            return {"success": False, "error_detail": e.rows or e.message}
+            return {"success": False, "error_detail": e.rows or [e.message]}
         finally:
             default_storage.delete(file_path)
 

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -464,7 +464,6 @@ def bulk_update_payments_task(self, opportunity_id: int, file_path: str, file_fo
     from commcare_connect.opportunity.visit_import import ImportException, bulk_update_payments, get_imported_dataset
 
     with cache.lock(get_payment_upload_key(opportunity_id), timeout=600):
-        set_task_progress(self, "Payment Record Import is in progress.")
         try:
             with default_storage.open(file_path, "rb") as f:
                 dataset = get_imported_dataset(f, file_format)
@@ -472,18 +471,15 @@ def bulk_update_payments_task(self, opportunity_id: int, file_path: str, file_fo
                 rows = list(dataset)
 
             status = bulk_update_payments(opportunity_id, headers, rows)
-            messages = [f"Payment status updated successfully for {len(status)} users."]
-            if status.missing_users:
-                messages.append(status.get_missing_message())
-
+            return {
+                "success": True,
+                "users_paid": len(status),
+                "missing_users_message": status.get_missing_message() if status.missing_users else None,
+            }
         except ImportException as e:
-            messages = [f"Payment Import failed: {e}"] + getattr(e, "invalid_rows", [])
-        except Exception as e:
-            messages = [f"Unexpected error during payment import: {e}"]
+            return {"success": False, "error_detail": e.rows or e.message}
         finally:
             default_storage.delete(file_path)
-
-        set_task_progress(self, "<br>".join(messages), is_complete=True)
 
 
 @celery_app.task(bind=True)

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -24,6 +24,7 @@ from commcare_connect.opportunity.tasks import (
     _get_inactive_message,
     add_connect_users,
     auto_deactivate_ended_opportunities,
+    bulk_update_payments_task,
     download_inaccessibility_request_attachments,
     download_user_visit_attachments,
     generate_automated_service_delivery_invoice,
@@ -51,6 +52,7 @@ from commcare_connect.opportunity.tests.factories import (
     TaskTypeFactory,
     UserVisitFactory,
 )
+from commcare_connect.opportunity.visit_import import ImportException, PaymentImportStatus
 from commcare_connect.users.models import User
 
 
@@ -590,3 +592,64 @@ def test_send_task_assignment_notification(send_message_patch):
             },
         )
     )
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.opportunity.tasks.cache")
+@mock.patch("commcare_connect.opportunity.tasks.default_storage")
+@mock.patch("commcare_connect.opportunity.visit_import.bulk_update_payments")
+@mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
+def test_bulk_update_payments_task_success(mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity):
+    mock_dataset.return_value = Dataset(headers=["username"])
+    mock_bulk.return_value = PaymentImportStatus(seen_users={"u1", "u2"}, missing_users=set())
+
+    result = bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"]).result
+
+    assert result == {"success": True, "users_paid": 2, "missing_users_message": None}
+    mock_storage.delete.assert_called_once_with("some/path")
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.opportunity.tasks.cache")
+@mock.patch("commcare_connect.opportunity.tasks.default_storage")
+@mock.patch("commcare_connect.opportunity.visit_import.bulk_update_payments")
+@mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
+def test_bulk_update_payments_task_with_missing_users(mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity):
+    mock_dataset.return_value = Dataset(headers=["username"])
+    mock_bulk.return_value = PaymentImportStatus(seen_users={"u1"}, missing_users={"missing1", "missing2"})
+
+    result = bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"]).result
+
+    assert result["success"] is True
+    assert result["users_paid"] == 1
+    assert "not found" in result["missing_users_message"]
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.opportunity.tasks.cache")
+@mock.patch("commcare_connect.opportunity.tasks.default_storage")
+@mock.patch("commcare_connect.opportunity.visit_import.bulk_update_payments")
+@mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
+def test_bulk_update_payments_task_import_error(mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity):
+    mock_dataset.return_value = Dataset(headers=["username"])
+    mock_bulk.side_effect = ImportException("2 rows have errors", "row error detail")
+
+    result = bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"]).result
+
+    assert result == {"success": False, "error_detail": "row error detail"}
+    mock_storage.delete.assert_called_once_with("some/path")
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.opportunity.tasks.cache")
+@mock.patch("commcare_connect.opportunity.tasks.default_storage")
+@mock.patch("commcare_connect.opportunity.visit_import.bulk_update_payments")
+@mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
+def test_bulk_update_payments_task_unexpected_error(mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity):
+    mock_dataset.return_value = Dataset(headers=["username"])
+    mock_bulk.side_effect = ValueError("boom")
+
+    with pytest.raises(ValueError):
+        bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"], throw=True)
+
+    mock_storage.delete.assert_called_once_with("some/path")

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -635,12 +635,30 @@ def test_bulk_update_payments_task_with_missing_users(mock_dataset, mock_bulk, m
 @mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
 def test_bulk_update_payments_task_import_error(mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity):
     mock_dataset.return_value = Dataset(headers=["username"])
-    mock_bulk.side_effect = ImportException("2 rows have errors", "row error detail")
+    row_errors = ["amount must be a number: alice, NOT_A_NUMBER, 2026-06-09, bank, op_b"]
+    mock_bulk.side_effect = ImportException("1 rows have errors", row_errors)
 
     result = bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"]).result
 
-    assert result == {"success": False, "error_detail": "row error detail"}
+    assert result == {"success": False, "error_detail": row_errors}
     mock_storage.delete.assert_called_once_with("some/path")
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.opportunity.tasks.cache")
+@mock.patch("commcare_connect.opportunity.tasks.default_storage")
+@mock.patch("commcare_connect.opportunity.visit_import.bulk_update_payments")
+@mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
+def test_bulk_update_payments_task_import_error_without_rows(
+    mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity
+):
+    # Structural errors (e.g. missing column) carry only a message; it is wrapped into a one-item list
+    mock_dataset.return_value = Dataset(headers=["username"])
+    mock_bulk.side_effect = ImportException("Missing required column(s): 'payment amount'")
+
+    result = bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"]).result
+
+    assert result == {"success": False, "error_detail": ["Missing required column(s): 'payment amount'"]}
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -601,11 +601,12 @@ def test_send_task_assignment_notification(send_message_patch):
 @mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
 def test_bulk_update_payments_task_success(mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity):
     mock_dataset.return_value = Dataset(headers=["username"])
-    mock_bulk.return_value = PaymentImportStatus(seen_users={"u1", "u2"}, missing_users=set())
+    # 2 users, 3 payment records created — the count reports payments, not users
+    mock_bulk.return_value = PaymentImportStatus(seen_users={"u1", "u2"}, missing_users=set(), payments_created=3)
 
     result = bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"]).result
 
-    assert result == {"success": True, "users_paid": 2, "missing_users_message": None}
+    assert result == {"success": True, "payments_processed": 3, "missing_users_message": None}
     mock_storage.delete.assert_called_once_with("some/path")
 
 
@@ -616,12 +617,14 @@ def test_bulk_update_payments_task_success(mock_dataset, mock_bulk, mock_storage
 @mock.patch("commcare_connect.opportunity.visit_import.get_imported_dataset")
 def test_bulk_update_payments_task_with_missing_users(mock_dataset, mock_bulk, mock_storage, mock_cache, opportunity):
     mock_dataset.return_value = Dataset(headers=["username"])
-    mock_bulk.return_value = PaymentImportStatus(seen_users={"u1"}, missing_users={"missing1", "missing2"})
+    mock_bulk.return_value = PaymentImportStatus(
+        seen_users={"u1"}, missing_users={"missing1", "missing2"}, payments_created=1
+    )
 
     result = bulk_update_payments_task.apply(args=[opportunity.pk, "some/path", "csv"]).result
 
     assert result["success"] is True
-    assert result["users_paid"] == 1
+    assert result["payments_processed"] == 1
     assert "not found" in result["missing_users_message"]
 
 

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2934,12 +2934,12 @@ def test_payment_import_modal_success_shows_missing_users():
             "result_data": {
                 "success": True,
                 "payments_processed": 1,
-                "missing_users_message": "2 usernames were not found",
+                "missing_users_message": "The following usernames were not found:<br>ghost1, ghost2",
             },
         },
     )
     assert "You have successfully processed 1 payment!" in html
-    assert "2 usernames were not found" in html
+    assert "The following usernames were not found:" in html
 
 
 def test_payment_import_modal_failure_text():

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2020,7 +2020,7 @@ def test_payment_import_status_polling(client, organization, opportunity, org_us
     response = client.get(url, {"task_id": str(uuid4())})
 
     assert response.status_code == 200
-    assert "Uploading your file" in response.content.decode()
+    assert "Processing your payments" in response.content.decode()
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2881,7 +2881,10 @@ class TestDeleteTasks:
 def test_payment_import_modal_success_text():
     html = render_to_string(
         "opportunity/payment_import_status_modal.html",
-        {"result_ready": True, "result_data": {"success": True, "payments_processed": 2, "missing_users_message": None}},
+        {
+            "result_ready": True,
+            "result_data": {"success": True, "payments_processed": 2, "missing_users_message": None},
+        },
     )
     assert "You have successfully processed 2 payments!" in html
 
@@ -2889,7 +2892,10 @@ def test_payment_import_modal_success_text():
 def test_payment_import_modal_success_text_singular():
     html = render_to_string(
         "opportunity/payment_import_status_modal.html",
-        {"result_ready": True, "result_data": {"success": True, "payments_processed": 1, "missing_users_message": None}},
+        {
+            "result_ready": True,
+            "result_data": {"success": True, "payments_processed": 1, "missing_users_message": None},
+        },
     )
     assert "You have successfully processed 1 payment!" in html
     assert "1 payments" not in html
@@ -2939,7 +2945,15 @@ def test_payment_import_modal_success_shows_missing_users():
 def test_payment_import_modal_failure_text():
     html = render_to_string(
         "opportunity/payment_import_status_modal.html",
-        {"result_ready": True, "result_data": {"success": False, "error_detail": "3 rows have errors"}},
+        {
+            "result_ready": True,
+            "result_data": {
+                "success": False,
+                "error_detail": ["amount must be a number: alice, NOT_A_NUMBER, 2026-06-09, bank, op_b"],
+            },
+        },
     )
     assert "There was an issue with your upload. Please try again." in html
-    assert "3 rows have errors" in html
+    assert "amount must be a number: alice, NOT_A_NUMBER, 2026-06-09, bank, op_b" in html
+    # the raw Python-tuple format must no longer appear
+    assert "(['" not in html

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -8,6 +8,7 @@ import pytest
 from django.contrib.messages import get_messages
 from django.core.files.storage.handler import StorageHandler
 from django.template import Context
+from django.template.loader import render_to_string
 from django.test import Client
 from django.urls import get_resolver, reverse
 from django.utils.timezone import now
@@ -2874,3 +2875,32 @@ class TestDeleteTasks:
         assert AssignedTask.objects.filter(pk=task.pk).exists()
         msgs = list(get_messages(response.wsgi_request))
         assert any("could not update CommCare HQ" in str(m) for m in msgs)
+
+
+def test_payment_import_modal_success_text():
+    html = render_to_string(
+        "opportunity/payment_import_status_modal.html",
+        {"result_ready": True, "result_data": {"success": True, "users_paid": 2, "missing_users_message": None}},
+    )
+    assert "You have successfully uploaded 2 payments!" in html
+
+
+def test_payment_import_modal_success_shows_missing_users():
+    html = render_to_string(
+        "opportunity/payment_import_status_modal.html",
+        {
+            "result_ready": True,
+            "result_data": {"success": True, "users_paid": 1, "missing_users_message": "2 usernames were not found"},
+        },
+    )
+    assert "You have successfully uploaded 1 payments!" in html
+    assert "2 usernames were not found" in html
+
+
+def test_payment_import_modal_failure_text():
+    html = render_to_string(
+        "opportunity/payment_import_status_modal.html",
+        {"result_ready": True, "result_data": {"success": False, "error_detail": "3 rows have errors"}},
+    )
+    assert "There was an issue with your upload. Please try again." in html
+    assert "3 rows have errors" in html

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from django.contrib.messages import get_messages
 from django.core.files.storage.handler import StorageHandler
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template import Context
 from django.template.loader import render_to_string
 from django.test import Client
@@ -2883,6 +2884,31 @@ def test_payment_import_modal_success_text():
         {"result_ready": True, "result_data": {"success": True, "users_paid": 2, "missing_users_message": None}},
     )
     assert "You have successfully uploaded 2 payments!" in html
+
+
+@mock.patch("commcare_connect.opportunity.views.bulk_update_payments_task.delay")
+def test_payment_import_redirects_with_popup_param(mock_delay, client, organization, opportunity, org_user_member):
+    mock_delay.return_value.id = "task-123"
+    client.force_login(org_user_member)
+    url = reverse("opportunity:payment_import", args=(organization.slug, opportunity.id))
+    csv_bytes = b"username,payment amount,payment date (yyyy-mm-dd),payment method,payment operator\n"
+    upload = SimpleUploadedFile("payments.csv", csv_bytes, content_type="text/csv")
+
+    response = client.post(url, {"payments": upload})
+
+    assert response.status_code == 302
+    assert "payment_import_task_id=task-123" in response.url
+    assert "export_task_id=" not in response.url
+
+
+def test_worker_payments_page_renders_modal_when_task_present(client, organization, opportunity, org_user_member):
+    client.force_login(org_user_member)
+    url = reverse("opportunity:worker_payments", args=(organization.slug, opportunity.id))
+
+    response = client.get(url, {"payment_import_task_id": str(uuid4())})
+
+    assert response.status_code == 200
+    assert "payment-import-parent" in response.content.decode()
 
 
 def test_payment_import_modal_success_shows_missing_users():

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2011,6 +2011,16 @@ def test_payment_delete_view(client: Client, opportunity: Opportunity, org_user_
     assert response.status_code == 404
 
 
+def test_payment_import_status_polling(client, organization, opportunity, org_user_member):
+    client.force_login(org_user_member)
+    url = reverse("opportunity:payment_import_status", args=(organization.slug, opportunity.id))
+
+    response = client.get(url, {"task_id": str(uuid4())})
+
+    assert response.status_code == 200
+    assert "Uploading your file" in response.content.decode()
+
+
 @pytest.mark.django_db
 class TestSuspendUser:
     def url(self, org_slug, opp_id, pk):

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2881,9 +2881,18 @@ class TestDeleteTasks:
 def test_payment_import_modal_success_text():
     html = render_to_string(
         "opportunity/payment_import_status_modal.html",
-        {"result_ready": True, "result_data": {"success": True, "users_paid": 2, "missing_users_message": None}},
+        {"result_ready": True, "result_data": {"success": True, "payments_processed": 2, "missing_users_message": None}},
     )
-    assert "You have successfully uploaded 2 payments!" in html
+    assert "You have successfully processed 2 payments!" in html
+
+
+def test_payment_import_modal_success_text_singular():
+    html = render_to_string(
+        "opportunity/payment_import_status_modal.html",
+        {"result_ready": True, "result_data": {"success": True, "payments_processed": 1, "missing_users_message": None}},
+    )
+    assert "You have successfully processed 1 payment!" in html
+    assert "1 payments" not in html
 
 
 @mock.patch("commcare_connect.opportunity.views.bulk_update_payments_task.delay")
@@ -2916,10 +2925,14 @@ def test_payment_import_modal_success_shows_missing_users():
         "opportunity/payment_import_status_modal.html",
         {
             "result_ready": True,
-            "result_data": {"success": True, "users_paid": 1, "missing_users_message": "2 usernames were not found"},
+            "result_data": {
+                "success": True,
+                "payments_processed": 1,
+                "missing_users_message": "2 usernames were not found",
+            },
         },
     )
-    assert "You have successfully uploaded 1 payments!" in html
+    assert "You have successfully processed 1 payment!" in html
     assert "2 usernames were not found" in html
 
 

--- a/commcare_connect/opportunity/tests/test_visit_import.py
+++ b/commcare_connect/opportunity/tests/test_visit_import.py
@@ -39,6 +39,7 @@ from commcare_connect.opportunity.visit_import import (
     REVIEW_STATUS_COL,
     VISIT_ID_COL,
     ImportException,
+    PaymentImportStatus,
     ReviewVisitRowData,
     VisitData,
     _bulk_update_catchments,
@@ -418,6 +419,17 @@ def test_bulk_update_payments_duplicate_check(opportunity: Opportunity):
     assert mobile_user.username in error_details[0]
     assert not error_details[0].startswith("(")
     assert Payment.objects.count() == 1
+
+
+@pytest.mark.parametrize("missing_users", [{"ghost"}, {"ghost1", "ghost2"}])
+def test_payment_import_missing_message(missing_users):
+    status = PaymentImportStatus(seen_users={"alice"}, missing_users=missing_users)
+
+    message = status.get_missing_message()
+
+    assert "The following usernames were not found:" in message
+    for user in missing_users:
+        assert user in message
 
 
 @pytest.fixture

--- a/commcare_connect/opportunity/tests/test_visit_import.py
+++ b/commcare_connect/opportunity/tests/test_visit_import.py
@@ -410,10 +410,13 @@ def test_bulk_update_payments_duplicate_check(opportunity: Opportunity):
         bulk_update_payments(opportunity.pk, dataset_headers, duplicate_dataset_rows)
 
     assert "1 rows have errors" in str(excinfo.value.message)
-
+    # error rows are human-readable strings ("<message>: <cells>"), not raw Python tuples
     error_details = excinfo.value.rows
+    assert isinstance(error_details, list)
     expected_error_substring = "A payment for this user with the same amount and date already exists."
-    assert expected_error_substring in error_details
+    assert expected_error_substring in error_details[0]
+    assert mobile_user.username in error_details[0]
+    assert not error_details[0].startswith("(")
     assert Payment.objects.count() == 1
 
 

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -42,6 +42,7 @@ from commcare_connect.opportunity.views import (
     opportunity_user_invite,
     payment_delete,
     payment_import,
+    payment_import_status,
     payment_report,
     reject_visits,
     resend_user_invites,
@@ -77,6 +78,7 @@ urlpatterns = [
     path("<slug:opp_id>/add_budget_new_users", view=add_budget_new_users, name="add_budget_new_users"),
     path("<slug:opp_id>/payment_export/", view=export_users_for_payment, name="payment_export"),
     path("<slug:opp_id>/payment_import/", view=payment_import, name="payment_import"),
+    path("<slug:opp_id>/payment_import_status/", view=payment_import_status, name="payment_import_status"),
     path("<slug:opp_id>/payment_unit/create", view=add_payment_unit, name="add_payment_unit"),
     path("<slug:opp_id>/payment_units/create", view=add_payment_units, name="add_payment_units"),
     path(

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -800,7 +800,7 @@ def payment_import(request, org_slug=None, opp_id=None):
     saved_path = default_storage.save(file_path, file)
 
     result = bulk_update_payments_task.delay(request.opportunity.pk, saved_path, file_format)
-    return redirect(f"{redirect_url}?export_task_id={result.id}")
+    return redirect(f"{redirect_url}?payment_import_task_id={result.id}")
 
 
 @org_member_required
@@ -2667,6 +2667,7 @@ class BaseWorkerListView(OrganizationUserMixin, OpportunityObjectMixin, View):
             "active_tab": self.active_tab,
             "tabs": self.get_tabs(org_slug, opportunity),
             "export_task_id": self.request.GET.get("export_task_id"),
+            "payment_import_task_id": self.request.GET.get("payment_import_task_id"),
         }
         if self.request.htmx:
             context["table"] = self.get_table(opportunity, org_slug)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -805,6 +805,26 @@ def payment_import(request, org_slug=None, opp_id=None):
 
 @org_member_required
 @opportunity_required
+def payment_import_status(request, org_slug=None, opp_id=None):
+    task_id = request.GET.get("task_id")
+    result_ready = False
+    result_data = None
+    if task_id:
+        result = AsyncResult(task_id)
+        result_ready = result.ready()
+        if result_ready:
+            result_data = result.result if result.successful() else {"success": False, "error_detail": None}
+    context = {
+        "result_ready": result_ready,
+        "result_data": result_data,
+        "task_id": task_id,
+        "opportunity": request.opportunity,
+    }
+    return render(request, "opportunity/payment_import_status_modal.html", context)
+
+
+@org_member_required
+@opportunity_required
 def add_payment_units(request, org_slug=None, opp_id=None):
     if request.POST:
         return add_payment_unit(request, org_slug=org_slug, opp_id=opp_id)

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -330,13 +330,13 @@ def bulk_update_payments(opportunity_id: int, headers: list[str], rows: list[lis
             continue
 
         if not username:
-            invalid_rows.append(([escape(r) for r in row], "username required"))
+            invalid_rows.append((row, "username required"))
             continue
 
         try:
             amount = Decimal(amount_raw)
         except InvalidOperation:
-            invalid_rows.append(([escape(r) for r in row], "amount must be a number"))
+            invalid_rows.append((row, "amount must be a number"))
             continue
 
         try:
@@ -348,7 +348,7 @@ def bulk_update_payments(opportunity_id: int, headers: list[str], rows: list[lis
             else:
                 payment_date = None
         except ValueError:
-            invalid_rows.append(([escape(r) for r in row], "Payment Date must be in YYYY-MM-DD format"))
+            invalid_rows.append((row, "Payment Date must be in YYYY-MM-DD format"))
             continue
 
         payment_row = {
@@ -373,14 +373,15 @@ def bulk_update_payments(opportunity_id: int, headers: list[str], rows: list[lis
         ):
             invalid_rows.append(
                 (
-                    [escape(r) for r in row],
+                    row,
                     "A payment for this user with the same amount and date already exists.",
                 )
             )
         payments_by_user[username].append(payment_row)
 
     if invalid_rows:
-        raise ImportException(f"{len(invalid_rows)} rows have errors", "<br>".join([str(r) for r in invalid_rows]))
+        error_details = [f"{message}: {', '.join(str(cell) for cell in cells)}" for cells, message in invalid_rows]
+        raise ImportException(f"{len(invalid_rows)} rows have errors", error_details)
 
     seen_users = set()
     payment_ids = []

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -105,6 +105,7 @@ class VisitImportStatus:
 class PaymentImportStatus:
     seen_users: set[str]
     missing_users: set[str]
+    payments_created: int = 0
 
     def __len__(self):
         return len(self.seen_users)
@@ -417,7 +418,7 @@ def bulk_update_payments(opportunity_id: int, headers: list[str], rows: list[lis
     missing_users = set(usernames) - seen_users
     send_payment_notification.delay(opportunity.id, payment_ids)
 
-    return PaymentImportStatus(seen_users, missing_users)
+    return PaymentImportStatus(seen_users, missing_users, len(payment_ids))
 
 
 def get_exchange_rate(currency_code, date=None):

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -114,8 +114,7 @@ class PaymentImportStatus:
         joined = ", ".join(self.missing_users)
         missing = textwrap.wrap(joined, width=115, break_long_words=False, break_on_hyphens=False)
         return format_html(
-            "<br>{} usernames were not found:<br>{}",
-            len(self.missing_users),
+            "<br>The following usernames were not found:<br>{}",
             format_html_join(
                 "<br>",
                 "{}",

--- a/commcare_connect/templates/opportunity/opportunity_worker.html
+++ b/commcare_connect/templates/opportunity/opportunity_worker.html
@@ -53,6 +53,9 @@
     <!-- Tab Content Container -->
     <div id="table" class="w-full"></div>
   </div>
+  {% if payment_import_task_id %}
+    {% include "opportunity/payment_import_status_modal.html" with task_id=payment_import_task_id result_ready=False result_data=None %}
+  {% endif %}
 {% endblock content %}
 {% block inline_javascript %}
   {% if filter_usage_data %}

--- a/commcare_connect/templates/opportunity/payment_import_status_modal.html
+++ b/commcare_connect/templates/opportunity/payment_import_status_modal.html
@@ -21,7 +21,7 @@
         {% if result_data.success %}
           <div class="mt-4 border-t border-gray-100 pt-4 text-green-600 text-center">
             <i class="fa-solid fa-circle-check"></i>
-            {% blocktranslate with count=result_data.users_paid %}You have successfully uploaded {{ count }} payments!{% endblocktranslate %}
+            {% blocktranslate count counter=result_data.payments_processed %}You have successfully processed {{ counter }} payment!{% plural %}You have successfully processed {{ counter }} payments!{% endblocktranslate %}
           </div>
           {% if result_data.missing_users_message %}
             <div class="mt-3 text-sm text-gray-600 text-center">{{ result_data.missing_users_message|safe }}</div>

--- a/commcare_connect/templates/opportunity/payment_import_status_modal.html
+++ b/commcare_connect/templates/opportunity/payment_import_status_modal.html
@@ -1,10 +1,45 @@
 {% load i18n %}
-<div id="payment-import-parent" x-data="{ open: true }" x-show="open" x-cloak class="modal-backdrop">
+<div id="payment-import-parent"
+     x-data="{ open: true }"
+     x-show="open"
+     x-cloak
+     class="modal-backdrop">
   <div class="modal">
+    <div class="header text-lg font-semibold text-brand-deep-purple flex justify-between items-center">
+      <h1>{% translate "Import Payment Records" %}</h1>
+    </div>
     <div id="payment-import-result"
          {% if task_id and not result_ready %} hx-get="{% url 'opportunity:payment_import_status' request.org.slug opportunity.opportunity_id %}?task_id={{ task_id }}" hx-trigger="every 2s" hx-target="#payment-import-parent" hx-swap="outerHTML" {% endif %}>
       {% if task_id and not result_ready %}
-        <p>{% translate "Uploading your file… This may take a moment." %}</p>
+        <div class="flex flex-col items-center justify-center mt-4">
+          <i class="fa-solid fa-spinner animate-spin text-amber-500 text-5xl"></i>
+          <p class="text-sm text-gray-600 font-medium animate-pulse mt-4">
+            {% translate "Uploading your file… This may take a moment." %}
+          </p>
+        </div>
+      {% elif result_ready %}
+        {% if result_data.success %}
+          <div class="mt-4 border-t border-gray-100 pt-4 text-green-600 text-center">
+            <i class="fa-solid fa-circle-check"></i>
+            {% blocktranslate with count=result_data.users_paid %}You have successfully uploaded {{ count }} payments!{% endblocktranslate %}
+          </div>
+          {% if result_data.missing_users_message %}
+            <div class="mt-3 text-sm text-gray-600 text-center">{{ result_data.missing_users_message|safe }}</div>
+          {% endif %}
+        {% else %}
+          <div class="mt-4 border-t border-gray-100 pt-4 text-red-600 text-center">
+            <i class="fa-solid fa-circle-exclamation"></i>
+            {% translate "There was an issue with your upload. Please try again." %}
+          </div>
+          {% if result_data.error_detail %}
+            <div class="mt-3 max-h-64 overflow-y-auto custom-scrollbar border border-gray-200 rounded-md p-3 text-sm text-gray-700">
+              {{ result_data.error_detail|safe }}
+            </div>
+          {% endif %}
+        {% endif %}
+        <div class="footer flex justify-end gap-2 p-4">
+          <button type="button" @click="open = false" class="button button-md outline-style">{% translate "Close" %}</button>
+        </div>
       {% endif %}
     </div>
   </div>

--- a/commcare_connect/templates/opportunity/payment_import_status_modal.html
+++ b/commcare_connect/templates/opportunity/payment_import_status_modal.html
@@ -32,13 +32,15 @@
             {% translate "There was an issue with your upload. Please try again." %}
           </div>
           {% if result_data.error_detail %}
-            <div class="mt-3 max-h-64 overflow-y-auto custom-scrollbar border border-gray-200 rounded-md p-3 text-sm text-gray-700">
-              {{ result_data.error_detail|safe }}
-            </div>
+            <ul class="mt-3 max-h-64 overflow-y-auto custom-scrollbar border border-gray-200 rounded-md p-3 text-sm text-gray-700 text-left list-disc list-inside space-y-1">
+              {% for error in result_data.error_detail %}<li>{{ error }}</li>{% endfor %}
+            </ul>
           {% endif %}
         {% endif %}
         <div class="footer flex justify-end gap-2 p-4">
-          <button type="button" @click="open = false" class="button button-md outline-style">{% translate "Close" %}</button>
+          <button type="button"
+                  @click="open = false"
+                  class="button button-md outline-style">{% translate "Close" %}</button>
         </div>
       {% endif %}
     </div>

--- a/commcare_connect/templates/opportunity/payment_import_status_modal.html
+++ b/commcare_connect/templates/opportunity/payment_import_status_modal.html
@@ -14,7 +14,7 @@
         <div class="flex flex-col items-center justify-center mt-4">
           <i class="fa-solid fa-spinner animate-spin text-amber-500 text-5xl"></i>
           <p class="text-sm text-gray-600 font-medium animate-pulse mt-4">
-            {% translate "Uploading your file… This may take a moment." %}
+            {% translate "Processing your payments… Please keep this page open to see the result." %}
           </p>
         </div>
       {% elif result_ready %}

--- a/commcare_connect/templates/opportunity/payment_import_status_modal.html
+++ b/commcare_connect/templates/opportunity/payment_import_status_modal.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<div id="payment-import-parent" x-data="{ open: true }" x-show="open" x-cloak class="modal-backdrop">
+  <div class="modal">
+    <div id="payment-import-result"
+         {% if task_id and not result_ready %} hx-get="{% url 'opportunity:payment_import_status' request.org.slug opportunity.opportunity_id %}?task_id={{ task_id }}" hx-trigger="every 2s" hx-target="#payment-import-parent" hx-swap="outerHTML" {% endif %}>
+      {% if task_id and not result_ready %}
+        <p>{% translate "Uploading your file… This may take a moment." %}</p>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/docs/superpowers/specs/2026-06-16-payment-upload-confirmation-popup-design.md
+++ b/docs/superpowers/specs/2026-06-16-payment-upload-confirmation-popup-design.md
@@ -1,0 +1,149 @@
+# Payment Upload Confirmation Popup — Design
+
+**Date:** 2026-06-16
+**Status:** Implemented
+
+> This document reflects the design as built. Where the wording or a decision
+> changed during implementation, the final behavior is described here.
+
+## Problem
+
+When a user uploads an Excel/CSV sheet to update payments on Connect, the result was
+surfaced through the shared export progress bar (`upload_progress_bar.html`): a thin
+inline bar that, on completion, offered an "All done! View status." link opening a modal.
+
+We want the payment upload to show the same kind of confirmation popup the **work area
+upload** uses — a modal that polls for the task result and then shows a clear success or
+failure message.
+
+- **Success text:** `You have successfully processed N payment!` / `… N payments!`
+  (singular/plural based on the count).
+- **Failure text:** `There was an issue with your upload. Please try again.`
+- **While the task runs:** `Processing your payments… Please keep this page open to see the result.`
+  (no time estimate, since a large import may take a while; the file is already uploaded
+  by this point, so the spinner describes processing, not uploading).
+
+## Decisions
+
+- **N = number of payment records created** — the count of `Payment` rows the import
+  creates (`PaymentImportStatus.payments_created` == `len(payment_ids)`). A file with
+  multiple rows for one worker counts each payment, so the noun "payment(s)" is literally
+  accurate. (This started as "users paid" but was changed during implementation so the
+  number matches the word "payments".)
+- **Keep existing detail alongside the popup** — on success, still list any usernames that
+  were not found; on failure, still show the per-row error detail beneath the generic
+  failure headline.
+- **Failure detail is human-readable** — each bad row is shown as `"<reason>: <cell, cell, …>"`
+  (e.g. `amount must be a number: alice, NOT_A_NUMBER, 2026-06-09, bank, op_b`), rendered as
+  a bulleted list. Not a raw Python tuple.
+- **Replace the progress bar with a work-area-style modal for payment import only** — the
+  shared `export_status` / `upload_progress_bar.html` flow is left untouched because it is
+  used by many genuine exports.
+
+## Current State (pre-change reference)
+
+- View: `payment_import` (`opportunity/views.py`) saves the file, calls
+  `bulk_update_payments_task.delay(...)`, and redirected to `worker_payments` with
+  `?export_task_id={id}`.
+- Task: `bulk_update_payments_task` (`opportunity/tasks.py`) funneled success and caught
+  `ImportException` both through `set_task_progress(..., is_complete=True)` as one
+  `<br>`-joined message — so Celery state was `SUCCESS` in both cases and they were not
+  distinguishable from the task result.
+- `bulk_update_payments` (`opportunity/visit_import.py`) returned
+  `PaymentImportStatus(seen_users, missing_users)`; raised `ImportException(message, rows)`
+  on validation errors, where `rows` was a `<br>`-joined string of `str(tuple)`.
+- Page shell `opportunity_worker.html` shows a polling spinner whenever `export_task_id`
+  is present, polling `export_status` → `render_export_status` → `upload_progress_bar.html`.
+- `bulk_update_payments_task` is used **only** by `payment_import`, so its result format
+  can change freely.
+
+The work-area pattern we mirrored:
+- `import_work_areas_task` returns `{"created": N}` or `{"errors": {...}}`.
+- `import_status` (`microplanning/views.py`) reads `AsyncResult`, sets `result_ready` /
+  `result_data`, renders `import_work_area_modal.html`.
+- The modal shows a spinner while polling (`hx-trigger="every 2s"`), then the
+  success/failure content.
+
+## Design
+
+### 1. Task returns structured data
+
+`bulk_update_payments_task` **returns** a structured dict instead of setting a final
+progress message (mirrors `import_work_areas_task`). The cache lock stays.
+
+- Success → `{"success": True, "payments_processed": status.payments_created, "missing_users_message": status.get_missing_message() or None}`
+- Caught `ImportException` → `{"success": False, "error_detail": e.rows or [e.message]}`
+  (`error_detail` is always a **list of strings** — row errors come from `e.rows`; a
+  structural error with no rows is wrapped as a one-item list with its message).
+- Any uncaught exception → task fails (state `FAILURE`); the status view builds the generic
+  failure `result_data`.
+
+Supporting changes in `bulk_update_payments` (`visit_import.py`):
+- `PaymentImportStatus` gains a `payments_created: int` field, set to `len(payment_ids)`.
+- Invalid rows are raised as `ImportException(message, error_details)` where `error_details`
+  is a list of readable strings (`"<reason>: <raw cells joined by ', '>"`). Cells are no
+  longer pre-`escape()`d — the template auto-escapes instead.
+
+The intermediate "in progress" state no longer needs `set_task_progress`, because the
+modal renders its own spinner while `AsyncResult` is not ready.
+
+### 2. Status endpoint + modal
+
+Mirror `import_status` + `import_work_area_modal.html`.
+
+- New view `payment_import_status(request, org_slug, opp_id)` in `opportunity/views.py`:
+  reads `task_id` from query params, checks `AsyncResult.ready()` / `.successful()`, builds
+  `result_ready` and `result_data` (passing `opportunity=request.opportunity`), and renders
+  the partial. On an unsuccessful task it builds `{"success": False, "error_detail": None}`.
+- New URL → name `opportunity:payment_import_status`.
+- New template `opportunity/payment_import_status_modal.html` (root id `payment-import-parent`,
+  Alpine `x-data="{ open: true }"`):
+  - **polling** → spinner with "Processing your payments… Please keep this page open to see the result."
+  - **success** → green check + `You have successfully processed N payment(s)!`
+    (`{% blocktranslate count %}` / `{% plural %}`), and the missing-users message below it
+    when present (rendered with `|safe`, as it is built with `format_html`).
+  - **failure** → red icon + `There was an issue with your upload. Please try again.`, and a
+    bulleted `<ul>` of the readable error strings when present (auto-escaped, no `|safe`).
+  - A Close button (`@click="open = false"`), consistent with the work-area modal.
+
+### 3. Wire-up
+
+- `payment_import` redirects with `?payment_import_task_id={id}` instead of
+  `?export_task_id={id}`, so the upload no longer triggers the shared export progress bar.
+- The base worker list view adds `payment_import_task_id` to its context (alongside the
+  existing `export_task_id`).
+- `opportunity_worker.html` shell: when `payment_import_task_id` is present, render the
+  payment-import modal, which polls `payment_import_status` every 2s and swaps itself with
+  the result. `upload_progress_bar.html` and `export_status` are not modified.
+
+### 4. Testing
+
+- **Task** (`opportunity/tests/test_tasks.py`): `bulk_update_payments_task` returns the
+  expected dict for (a) success (count = payment records, distinct from users), (b) success
+  with missing users, (c) caught `ImportException` with a readable error list, (d) a
+  structural `ImportException` with no rows (message wrapped into a one-item list), and
+  (e) an unexpected error that propagates (task FAILURE, file still deleted).
+- **Template** (`opportunity/tests/test_views.py`, via `render_to_string`): success text +
+  count (plural), singular form ("1 payment", not "1 payments"), success-with-missing-users,
+  and failure text + readable error list (asserting the old raw-tuple form is gone).
+- **View / wiring** (`opportunity/tests/test_views.py`): the polling endpoint renders the
+  spinner; `payment_import` redirects with `payment_import_task_id` (and not
+  `export_task_id`); the worker payments shell renders the modal when the param is present.
+- **Import logic** (`opportunity/tests/test_visit_import.py`): `bulk_update_payments`
+  duplicate-check asserts the error rows are readable strings, not tuples.
+
+## Out of Scope
+
+- The shared `export_status` / `upload_progress_bar.html` flow and all other exports.
+- Payment validation rules in `bulk_update_payments` (only the error *formatting* and an
+  added `payments_created` count were changed; the validation logic is unchanged).
+- Any change to the import upload form/modal (`import_modal.html`).
+
+## Notes / known limitations
+
+- **Local dev must run a real Celery worker (non-eager) to see the popup resolve.** Default
+  `config/settings/local.py` sets `CELERY_TASK_ALWAYS_EAGER = True` and does not set
+  `CELERY_TASK_STORE_EAGER_RESULT`, so an eager task's result is never written to the result
+  backend and the modal's `AsyncResult(...).ready()` polling would spin forever. Production
+  runs non-eager with a worker (verified working). The existing work-area upload shares this
+  pattern, so this is not specific to this feature.


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->

Adds a confirmation popup after a payment Excel/CSV upload on **Connect Workers → Payments**, mirroring the existing work-area upload modal. Previously the result was surfaced through the shared export progress bar (a thin inline bar + "View status" link); now it appears in a clear modal.


  - **Success:** "You have successfully processed N payment(s)!" — count is the number of payment records created (correct singular/plural), plus a list of any usernames that were not found.

<img width="1791" height="683" alt="Screenshot from 2026-06-16 21-34-44" src="https://github.com/user-attachments/assets/f18f910b-ab82-4b24-93df-fc151c817dd3" />

  - **Failure:** "There was an issue with your upload. Please try again." — with human-readable per-row error details (e.g. `amount must be a number: alice, NOT_A_NUMBER, 2026-06-09, bank,
  op_b`).

<img width="1791" height="683" alt="Screenshot from 2026-06-16 21-31-33" src="https://github.com/user-attachments/assets/b5555b39-7789-4ad3-ad1b-7fc15f6aca6f" />

  - **While processing:** a spinner — "Processing your payments… Please keep this page open to see the result."

<img width="1791" height="683" alt="Screenshot from 2026-06-16 21-19-04" src="https://github.com/user-attachments/assets/612a0a8a-a4e3-4e57-9fc4-e35f90e0d2b6" />

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/CCCT-2193)

Design spec included in PR for reference.
Best to review by commit.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Apart from tests, Tested locally and also by Claude by running the workflows (without browser access).

**Low blast radius**: the only behavioral change to existing flows is that **payment import** no longer triggers the shared export progress bar (it uses a new `payment_import_task_id` param + dedicated modal). The shared export code for other workflows stands unchanged.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests added for all behavior changes

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
