### PR TITLE
Lint and Format files by Ruff

### DIFF
--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -543,8 +543,7 @@ class MUACDistributionPatternIndex(AuditCalculation):
 
         if out_of_range:
             logger.warning(
-                "MUAC out-of-range values for opportunity_access=%s period=%s–%s: "
-                "%d value(s) outside 9.5–21.5 cm: %s",
+                "MUAC out-of-range values for opportunity_access=%s period=%s–%s: %d value(s) outside 9.5–21.5 cm: %s",
                 opportunity_access.id,
                 period_start,
                 period_end,

--- a/commcare_connect/data_export/tests/test_app_structure_export.py
+++ b/commcare_connect/data_export/tests/test_app_structure_export.py
@@ -43,7 +43,7 @@ def _add_export_credentials(api_client, user):
 
 
 def _hq_app_url(opportunity, app):
-    return f"{opportunity.api_key.hq_server.url}/a/{app.cc_domain}" f"/api/v0.5/application/{app.cc_app_id}/"
+    return f"{opportunity.api_key.hq_server.url}/a/{app.cc_domain}/api/v0.5/application/{app.cc_app_id}/"
 
 
 @pytest.mark.django_db

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -131,7 +131,7 @@ class BaseDataExportListView(BaseDataExportView):
 
     @extend_schema(
         description=(
-            "v1.0: Returns CSV text StreamingHttpResponse. " "v2.0: Returns paginated JSON with 'next' and 'results'."
+            "v1.0: Returns CSV text StreamingHttpResponse. v2.0: Returns paginated JSON with 'next' and 'results'."
         )
     )
     def get(self, *args, **kwargs):

--- a/commcare_connect/form_receiver/tests/test_process_xform.py
+++ b/commcare_connect/form_receiver/tests/test_process_xform.py
@@ -35,11 +35,10 @@ DELIVER_PROCESSOR_PATCHES = [
 
 
 def test_process_learn_form_no_matching_blocks():
-    with mock.patch(
-        "commcare_connect.form_receiver.processor.process_learn_modules"
-    ) as process_learn_modules, mock.patch(
-        "commcare_connect.form_receiver.processor.process_assessments"
-    ) as process_assessments:
+    with (
+        mock.patch("commcare_connect.form_receiver.processor.process_learn_modules") as process_learn_modules,
+        mock.patch("commcare_connect.form_receiver.processor.process_assessments") as process_assessments,
+    ):
         process_learn_form(None, get_form_model(), None, None)
     assert process_learn_modules.call_count == 0
     assert process_assessments.call_count == 0

--- a/commcare_connect/form_receiver/tests/test_receiver_endpoint.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_endpoint.py
@@ -36,7 +36,9 @@ def test_process_xform_error(user: User, api_client: APIClient):
     hq_server = HQServerFactory()
     oauth_application = hq_server.oauth_application
     add_credentials(api_client, user, oauth_application=oauth_application)
-    with (mock.patch("commcare_connect.form_receiver.views.process_xform") as process_xform,):
+    with (
+        mock.patch("commcare_connect.form_receiver.views.process_xform") as process_xform,
+    ):
         process_xform.side_effect = ProcessingError("oops, something went wrong")
         response = api_client.post("/api/receiver/", data=get_form_json(), format="json")
     assert response.status_code == 400, response.data

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -1677,9 +1677,10 @@ class TestCoverageProgressView(BaseMicroplanningFlagTest):
         cause.pgcode = "57014"  # QueryCanceled — what statement_timeout raises
         timeout_error = OperationalError("canceling statement due to statement timeout")
         timeout_error.__cause__ = cause
-        with patch("commcare_connect.microplanning.views.CoverageProgressReport") as report_cls, patch(
-            "commcare_connect.microplanning.views.transaction.set_rollback"
-        ) as set_rollback:
+        with (
+            patch("commcare_connect.microplanning.views.CoverageProgressReport") as report_cls,
+            patch("commcare_connect.microplanning.views.transaction.set_rollback") as set_rollback,
+        ):
             report_cls.return_value.header.side_effect = timeout_error
             resp = client.get(self.url(opportunity.organization.slug, str(opportunity.opportunity_id)))
         assert resp.status_code == 503

--- a/commcare_connect/multidb/management/commands/logical_replication_status.py
+++ b/commcare_connect/multidb/management/commands/logical_replication_status.py
@@ -16,9 +16,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         secondary_db_alias = settings.SECONDARY_DB_ALIAS
         if not secondary_db_alias:
-            raise CommandError(
-                "'secondary' database needs to be configured and " "logical replication needs to be setup"
-            )
+            raise CommandError("'secondary' database needs to be configured and logical replication needs to be setup")
 
         self.stdout.write(self.style.WARNING("This will run some queries to get logical replication status"))
         confirm = input("Proceed? (yes/no): ").strip().lower()

--- a/commcare_connect/opportunity/decorators.py
+++ b/commcare_connect/opportunity/decorators.py
@@ -15,9 +15,9 @@ def require_manual_visit_verification(view_func):
 
     @wraps(view_func)
     def _inner(request, *args, **kwargs):
-        assert (
-            getattr(request, "opportunity", None) is not None
-        ), "require_manual_visit_verification must be applied after @opportunity_required"
+        assert getattr(request, "opportunity", None) is not None, (
+            "require_manual_visit_verification must be applied after @opportunity_required"
+        )
         if request.opportunity.automatic_visit_verification:
             response = HttpResponseForbidden()
             response["HX-Trigger"] = "reload_table"

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -203,10 +203,12 @@ class OpportunityChangeForm(OpportunityUserInviteForm, forms.ModelForm):
                     <div class='col-span-2'>
                         <h6 class='title-sm'>{_("Date")}</h6>
                         <span class='hint'>
-                            {_(
-                                "Optional: If not specified, the opportunity start & "
-                                "end dates will apply to the form submissions."
-                            )}
+                            {
+                        _(
+                            "Optional: If not specified, the opportunity start & "
+                            "end dates will apply to the form submissions."
+                        )
+                    }
                         </span>
                     </div>
                 """
@@ -1288,7 +1290,7 @@ class PaymentUnitForm(forms.ModelForm):
                         HTML(
                             f"""
                     <button type="button" class="button button-md outline-style" id="sync-button"
-                    hx-post="{reverse('opportunity:sync_deliver_units', args=(org_slug, self.opportunity.pk))}"
+                    hx-post="{reverse("opportunity:sync_deliver_units", args=(org_slug, self.opportunity.pk))}"
                     hx-trigger="click" hx-swap="none" hx-on::after-request="alert(event?.detail?.xhr?.response);
                     event.detail.successful && location.reload();
                     this.removeAttribute('disabled'); this.innerHTML='Sync Deliver Units';""

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -520,8 +520,7 @@ class AssignedTask(XFormBaseModel):
                     to_reset.setdefault(access, {"properties": {}})["properties"][prop] = ""
                 if len(to_reset) > HQ_CASE_BULK_CHUNK_SIZE:
                     raise ListTooLongError(
-                        f"Too many HQ case property resets ({len(to_reset)}); "
-                        "split the delete into smaller batches."
+                        f"Too many HQ case property resets ({len(to_reset)}); split the delete into smaller batches."
                     )
                 if to_reset:
                     bulk_update_usercases(to_reset)

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -468,7 +468,7 @@ class PaymentInvoiceTable(OpportunityContextTable):
         review_button = (
             f'<a href="{invoice_review_url}" '
             f'class="button button-md outline-style !inline-flex justify-center">'
-            f'{_("Review")}</a>'
+            f"{_('Review')}</a>"
         )
         pay_button = ""
         if self.is_pm:
@@ -597,7 +597,7 @@ class BaseOpportunityList(OrgContextTable):
         return date.strftime("%d-%b-%Y") if date else "--"
 
     def _render_div(self, value, extra_classes=""):
-        base_classes = "flex text-sm font-normal truncate text-brand-deep-purple " "overflow-clip overflow-ellipsis"
+        base_classes = "flex text-sm font-normal truncate text-brand-deep-purple overflow-clip overflow-ellipsis"
         all_classes = f"{base_classes} {extra_classes}".strip()
         return format_html('<div class="{}">{}</div>', all_classes, value)
 
@@ -1053,24 +1053,24 @@ class StatusIndicatorColumn(tables.Column):
     def render(self, record):
         if self._is_suspended(record):
             return format_html(
-                '<span x-data x-tooltip.raw="{}">' '<i class="fa-solid fa-minus-square text-black-600"></i>' "</span>",
+                '<span x-data x-tooltip.raw="{}"><i class="fa-solid fa-minus-square text-black-600"></i></span>',
                 _("User suspended"),
             )
 
         if record.status == UserInviteStatus.accepted:
             return format_html(
-                '<span x-data x-tooltip.raw="{}">' '<i class="fa-solid fa-circle-check text-green-600"></i>' "</span>",
+                '<span x-data x-tooltip.raw="{}"><i class="fa-solid fa-circle-check text-green-600"></i></span>',
                 _("Invite accepted"),
             )
         elif record.status in [UserInviteStatus.invited, UserInviteStatus.sms_delivered]:
             return format_html(
-                '<span x-data x-tooltip.raw="{}">' '<i class="fa-regular fa-clock text-orange-600"></i>' "</span>",
+                '<span x-data x-tooltip.raw="{}"><i class="fa-regular fa-clock text-orange-600"></i></span>',
                 _("Invite pending"),
             )
 
         if record.status in [UserInviteStatus.not_found, UserInviteStatus.sms_not_delivered]:
             return format_html(
-                '<span x-data x-tooltip.raw="{}">' '<i class="fa-solid fa-circle-xmark text-red-600"></i>' "</span>",
+                '<span x-data x-tooltip.raw="{}"><i class="fa-solid fa-circle-xmark text-red-600"></i></span>',
                 _("User not found") if record.status == UserInviteStatus.not_found else _("Invite failed"),
             )
 
@@ -1847,8 +1847,7 @@ class AssignedTaskListTable(OpportunityContextTable):
     def render_assigned_task_id(self, value):
         # TODO: CCCT-2184 - Link to Connect Worker page filtered to task view
         return format_html(
-            '<a href="#" class="text-brand-indigo hover:underline">'
-            '<span class="text-sm font-medium">#{}</span></a>',
+            '<a href="#" class="text-brand-indigo hover:underline"><span class="text-sm font-medium">#{}</span></a>',
             value,
         )
 

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -212,7 +212,7 @@ def generate_review_visit_export(opportunity_id: int, from_date, to_date, status
     opportunity = Opportunity.objects.get(id=opportunity_id)
     logger.info(
         f"""Export review visit for {opportunity.name} with date
-        from {from_date} to {to_date} and status {','.join(status)}"""
+        from {from_date} to {to_date} and status {",".join(status)}"""
     )
     dataset = export_user_visit_review_data(opportunity, from_date, to_date, [VisitReviewStatus(s) for s in status])
     export_tmp_name = f"{now().isoformat()}_{slugify(opportunity.name)}_review_visit_export.{export_format}"

--- a/commcare_connect/opportunity/tests/factories.py
+++ b/commcare_connect/opportunity/tests/factories.py
@@ -283,7 +283,7 @@ class AssignedTaskFactory(DjangoModelFactory):
     completed_at = Faker("date_time", tzinfo=timezone.utc)
     duration = LazyFunction(lambda: timedelta(hours=1))
     status = AssignedTaskStatus.ASSIGNED
-    due_date = LazyFunction(lambda: (date.today() + timedelta(days=7)))
+    due_date = LazyFunction(lambda: date.today() + timedelta(days=7))
     assigned_by = SubFactory(UserFactory)
 
     class Meta:

--- a/commcare_connect/opportunity/tests/test_export.py
+++ b/commcare_connect/opportunity/tests/test_export.py
@@ -318,9 +318,9 @@ def test_export_catchment_area_table_data(opportunity: Opportunity):
 
     data_set = export_catchment_area_table(opportunity)
 
-    assert set(expected_headers).issubset(
-        set(data_set.headers)
-    ), f"Expected headers {expected_headers} not found in dataset headers {data_set.headers}"
+    assert set(expected_headers).issubset(set(data_set.headers)), (
+        f"Expected headers {expected_headers} not found in dataset headers {data_set.headers}"
+    )
 
     assert len(data_set) == len(catchments), f"Expected {len(catchments)} catchments, but got {len(data_set)}"
 

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -5,15 +5,15 @@ from unittest import mock
 import pytest
 
 from commcare_connect.opportunity.exceptions import TaskAlreadyAssignedError
-from commcare_connect.opportunity.models import OpportunityActiveEvent  # added via pghistory
-from commcare_connect.opportunity.models import PaymentInvoiceStatusEvent  # added via pghistory
 from commcare_connect.opportunity.models import (
     AssignedTask,
     AssignedTaskStatus,
     InvoiceStatus,
     Opportunity,
+    OpportunityActiveEvent,  # added via pghistory
     OpportunityClaimLimit,
     PaymentInvoice,
+    PaymentInvoiceStatusEvent,  # added via pghistory
 )
 from commcare_connect.opportunity.tests.factories import (
     AssignedTaskFactory,

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -193,9 +193,10 @@ def test_download_attachments(mobile_user: User, opportunity: Opportunity):
         opportunity=opportunity,
         form_json={"attachments": {"myimage.jpg": {"content_type": "image/jpeg", "length": 20}}},
     )
-    with mock.patch("commcare_connect.opportunity.tasks.httpx.get") as get_response, mock.patch(
-        "commcare_connect.opportunity.tasks.default_storage.save"
-    ) as save_blob:
+    with (
+        mock.patch("commcare_connect.opportunity.tasks.httpx.get") as get_response,
+        mock.patch("commcare_connect.opportunity.tasks.default_storage.save") as save_blob,
+    ):
         get_response.return_value.content = b"asdas"
         download_user_visit_attachments.run(user_visit.id)
         blob_meta = BlobMeta.objects.first()
@@ -221,9 +222,10 @@ def test_download_inaccessibility_request_attachments_creates_blobs(opportunity)
         "photo.jpg": {"content_type": "image/jpeg", "length": 20},
     }
 
-    with mock.patch("commcare_connect.opportunity.tasks.httpx.get") as get_response, mock.patch(
-        "commcare_connect.opportunity.tasks.default_storage.save"
-    ) as save_blob:
+    with (
+        mock.patch("commcare_connect.opportunity.tasks.httpx.get") as get_response,
+        mock.patch("commcare_connect.opportunity.tasks.default_storage.save") as save_blob,
+    ):
         get_response.return_value.content = b"imgdata"
         download_inaccessibility_request_attachments.run(xform_id, attachments)
 
@@ -252,9 +254,10 @@ def test_download_inaccessibility_request_attachments_skips_existing_blobs(oppor
     )
     attachments = {"photo.jpg": {"content_type": "image/jpeg", "length": 20}}
 
-    with mock.patch("commcare_connect.opportunity.tasks.httpx.get") as get_response, mock.patch(
-        "commcare_connect.opportunity.tasks.default_storage.save"
-    ) as save_blob:
+    with (
+        mock.patch("commcare_connect.opportunity.tasks.httpx.get") as get_response,
+        mock.patch("commcare_connect.opportunity.tasks.default_storage.save") as save_blob,
+    ):
         download_inaccessibility_request_attachments.run(xform_id, attachments)
 
     get_response.assert_not_called()

--- a/commcare_connect/opportunity/tests/test_visit_import.py
+++ b/commcare_connect/opportunity/tests/test_visit_import.py
@@ -488,25 +488,25 @@ def test_bulk_update_catchments(opportunity, dataset, new_catchments, old_catchm
 
     import_status = _bulk_update_catchments(opportunity, dataset)
 
-    assert import_status.seen_catchments == {
-        str(catchment.id) for catchment in old_catchments
-    }, "Mismatch in updated catchments"
+    assert import_status.seen_catchments == {str(catchment.id) for catchment in old_catchments}, (
+        "Mismatch in updated catchments"
+    )
     assert import_status.new_catchments == len(new_catchments), "Incorrect number of new catchments"
 
     for catchment in old_catchments:
         updated_catchment = CatchmentArea.objects.get(site_code=catchment.site_code)
-        assert (
-            updated_catchment.name == f"{name_change} {catchment.name}"
-        ), f"Name not updated correctly for catchment {catchment.id}"
-        assert (
-            updated_catchment.radius == catchment.radius + radius_change
-        ), f"Radius not updated correctly for catchment {catchment.id}"
-        assert (
-            updated_catchment.latitude == catchment.latitude + latitude_change
-        ), f"Latitude not updated correctly for catchment {catchment.id}"
-        assert (
-            updated_catchment.longitude == catchment.longitude + longitude_change
-        ), f"Longitude not updated correctly for catchment {catchment.id}"
+        assert updated_catchment.name == f"{name_change} {catchment.name}", (
+            f"Name not updated correctly for catchment {catchment.id}"
+        )
+        assert updated_catchment.radius == catchment.radius + radius_change, (
+            f"Radius not updated correctly for catchment {catchment.id}"
+        )
+        assert updated_catchment.latitude == catchment.latitude + latitude_change, (
+            f"Latitude not updated correctly for catchment {catchment.id}"
+        )
+        assert updated_catchment.longitude == catchment.longitude + longitude_change, (
+            f"Longitude not updated correctly for catchment {catchment.id}"
+        )
         assert updated_catchment.active, f"Active status not updated correctly for catchment {catchment.id}"
 
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -761,7 +761,7 @@ def add_budget_new_users(request, org_slug=None, opp_id=None):
     csrf_token = get_token(request)
     form_html = f"""
         <form id="form-content"
-              hx-post="{reverse('opportunity:add_budget_new_users', args=[org_slug, opp_id])}"
+              hx-post="{reverse("opportunity:add_budget_new_users", args=[org_slug, opp_id])}"
               hx-trigger="submit"
               hx-headers='{{"X-CSRFToken": "{csrf_token}"}}'>
             <input type="hidden" name="csrfmiddlewaretoken" value="{csrf_token}">
@@ -2183,16 +2183,16 @@ class UserTasksView(WorkerPageView, FilterMixin):
             create_url = reverse(
                 "opportunity:create_task", args=(self.request.org.slug, self.opportunity.opportunity_id)
             )
-            context[
-                "create_task_url"
-            ] = f"{create_url}?{urlencode({'next': 'worker_tasks', 'user': self.opportunity_access.user.user_id})}"
+            context["create_task_url"] = (
+                f"{create_url}?{urlencode({'next': 'worker_tasks', 'user': self.opportunity_access.user.user_id})}"
+            )
 
             delete_url = reverse(
                 "opportunity:delete_tasks", args=(self.request.org.slug, self.opportunity.opportunity_id)
             )
-            context[
-                "delete_tasks_url"
-            ] = f"{delete_url}?{urlencode({'next': 'worker_tasks', 'user': self.opportunity_access.user.user_id})}"
+            context["delete_tasks_url"] = (
+                f"{delete_url}?{urlencode({'next': 'worker_tasks', 'user': self.opportunity_access.user.user_id})}"
+            )
         return context
 
 

--- a/commcare_connect/program/forms.py
+++ b/commcare_connect/program/forms.py
@@ -114,7 +114,8 @@ class BaseManagedOpportunityInitForm:
         self.set_organization_initial()
         opportunity_details_row = self.helper.layout[0]
         organization_field_layout = Column(
-            Field("organization"), css_class="col-span-2"  # This makes the field take the full width of the grid row
+            Field("organization"),
+            css_class="col-span-2",  # This makes the field take the full width of the grid row
         )
         opportunity_details_row.fields.insert(1, organization_field_layout)
 

--- a/commcare_connect/program/views.py
+++ b/commcare_connect/program/views.py
@@ -235,13 +235,11 @@ def apply_or_decline_application(request, application_id, action, org_slug=None,
     action_map = {
         "apply": {
             "status": ProgramApplicationStatus.APPLIED,
-            "message": f"Application for the program '{application.program.name}' has been "
-            f"successfully submitted.",
+            "message": f"Application for the program '{application.program.name}' has been successfully submitted.",
         },
         "decline": {
             "status": ProgramApplicationStatus.DECLINED,
-            "message": f"The application for the program '{application.program.name}' has been marked "
-            f"as 'Declined'.",
+            "message": f"The application for the program '{application.program.name}' has been marked as 'Declined'.",
         },
     }
 

--- a/commcare_connect/reports/tests/test_reports.py
+++ b/commcare_connect/reports/tests/test_reports.py
@@ -489,12 +489,12 @@ def test_export_invoice_report_task_creates_export_file():
     mock_table = mock.MagicMock()
 
     storages_mock = mock.MagicMock(ExportS3Boto3Storage=mock_storage)
-    with mock.patch("commcare_connect.reports.views.InvoiceReportView", mock_view), mock.patch(
-        "commcare_connect.reports.views.InvoiceReportFilter", mock_filter
-    ), mock.patch("commcare_connect.reports.views.InvoiceReportTable", mock_table), mock.patch(
-        "commcare_connect.reports.tasks.TableExport"
-    ) as mock_table_export, mock.patch.dict(
-        "sys.modules", {"commcare_connect.utils.storages": storages_mock}
+    with (
+        mock.patch("commcare_connect.reports.views.InvoiceReportView", mock_view),
+        mock.patch("commcare_connect.reports.views.InvoiceReportFilter", mock_filter),
+        mock.patch("commcare_connect.reports.views.InvoiceReportTable", mock_table),
+        mock.patch("commcare_connect.reports.tasks.TableExport") as mock_table_export,
+        mock.patch.dict("sys.modules", {"commcare_connect.utils.storages": storages_mock}),
     ):
         mock_table_export.return_value.export.return_value = "col1,col2\nval1,val2"
         result = export_invoice_report_task({}, user_id=UserFactory().id)

--- a/commcare_connect/users/tests/test_forms.py
+++ b/commcare_connect/users/tests/test_forms.py
@@ -1,6 +1,7 @@
 """
 Module for all Form Tests.
 """
+
 from django.utils.translation import gettext_lazy as _
 
 from commcare_connect.users.forms import ManualUserOTPForm, UserAdminCreationForm

--- a/commcare_connect/users/user_credentials.py
+++ b/commcare_connect/users/user_credentials.py
@@ -116,19 +116,22 @@ class UserCredentialIssuer:
             """
             for i in range(0, len(users_credential["usernames"]), cls.USERNAME_CHUNK_SIZE):
                 i_chunk = i + cls.USERNAME_CHUNK_SIZE
-                yield {
-                    "usernames": users_credential["usernames"][i:i_chunk],
-                    "title": UserCredential.get_title(
-                        credential_type=users_credential["credential_type"],
-                        level=users_credential["level"],
-                        delivery_type_name=users_credential["delivery_type__name"]
-                        or users_credential["opportunity__name"],
-                    ),
-                    "type": users_credential["credential_type"],
-                    "level": users_credential["level"],
-                    "slug": users_credential["opportunity__id"],
-                    "opportunity_id": users_credential["opportunity__id"],
-                }, users_credential["credential_ids"][i:i_chunk]
+                yield (
+                    {
+                        "usernames": users_credential["usernames"][i:i_chunk],
+                        "title": UserCredential.get_title(
+                            credential_type=users_credential["credential_type"],
+                            level=users_credential["level"],
+                            delivery_type_name=users_credential["delivery_type__name"]
+                            or users_credential["opportunity__name"],
+                        ),
+                        "type": users_credential["credential_type"],
+                        "level": users_credential["level"],
+                        "slug": users_credential["opportunity__id"],
+                        "opportunity_id": users_credential["opportunity__id"],
+                    },
+                    users_credential["credential_ids"][i:i_chunk],
+                )
 
         unissued_credentials_qs = cls._get_unissued_user_credentials_queryset()
         index_in_chunk = 0

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,6 +1,7 @@
 """
 Base settings to build other settings files upon.
 """
+
 from pathlib import Path
 
 import environ

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -13,6 +13,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+
 import os
 import sys
 from pathlib import Path

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,7 @@
 """Useful tasks for use when developing CommCare Connect.
 
 This uses the `Invoke` library."""
+
 from pathlib import Path
 
 from invoke import Context, Exit, call, task


### PR DESCRIPTION
## Product Description
Files linted by running `prek run -a`.

Much of the changes here originate from the differences between how ruff and black format quotes in formatted strings.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2386)

## Safety Assurance
### Safety story
- Formatting changes only.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
