### PR TITLE
Fix a time-related bug in audit report

### DIFF
--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -265,25 +265,25 @@ class WACoverageToVisitRatio(AuditCalculation):
         _eligible = ~Q(status__in=[WorkAreaStatus.EXCLUDED])
         wa_stats = WorkArea.objects.filter(opportunity_access=opportunity_access).aggregate(
             total_eligible=Count("id", filter=_eligible),
-            visited_count=Count(
-                "id", filter=Q(status__in=[WorkAreaStatus.VISITED, WorkAreaStatus.EXPECTED_VISIT_REACHED])
-            ),
             expected_visits=Sum("expected_visit_count", filter=_eligible),
         )
 
         total_eligible = wa_stats["total_eligible"] or 0
         expected_visits = wa_stats["expected_visits"] or 0
-        actual_visits = UserVisit.objects.filter(
+
+        visits_qs = UserVisit.objects.filter(
             opportunity_access=opportunity_access,
             visit_date__date__lte=period_end,
             work_area__isnull=False,
             deliver_unit__slug=SERVICE_DELIVERY_SLUG,
-        ).count()
+        )
+        actual_visits = visits_qs.count()
+        visited_count = visits_qs.values("work_area").distinct().count()
 
         if not (total_eligible and expected_visits and actual_visits):
             return None, 0
 
-        coverage_ratio = wa_stats["visited_count"] / total_eligible
+        coverage_ratio = visited_count / total_eligible
         visit_ratio = actual_visits / expected_visits
         return coverage_ratio / visit_ratio, total_eligible
 

--- a/commcare_connect/audit/tests/test_chc_indicators.py
+++ b/commcare_connect/audit/tests/test_chc_indicators.py
@@ -479,6 +479,29 @@ class TestWACoverageToVisitRatio(BaseIndicatorTest):
         make_visit(access)
         self.assert_insufficient_data(access)
 
+    def test_wa_visited_after_period_end_not_counted_as_visited(self):
+        """A WA whose only visits fall after period_end must not be counted as visited,
+        even if its current status is VISITED."""
+        access, wag = make_access_and_wag()
+        wa_in_period = WorkAreaFactory(
+            opportunity=wag.opportunity,
+            work_area_group=wag,
+            opportunity_access=access,
+            status=WorkAreaStatus.VISITED,
+            expected_visit_count=10,
+        )
+        wa_after_period = WorkAreaFactory(
+            opportunity=wag.opportunity,
+            work_area_group=wag,
+            opportunity_access=access,
+            status=WorkAreaStatus.VISITED,
+            expected_visit_count=10,
+        )
+        make_visits(10, access, work_area=wa_in_period, visit_date=IN_PERIOD)
+        make_visits(10, access, work_area=wa_after_period, visit_date=AFTER_PERIOD)
+        # Only wa_in_period counts as visited at period_end → (1/2) / (10/20) = 1.0
+        self.assert_compute_result(access, sample=2, value=1.0, in_range=True)
+
 
 @pytest.mark.django_db
 class TestInaccessibleWARateEarlyWarning(BaseIndicatorTest):


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CI-728

This is not directly a fix to the above ticket, but as I debugged it, I found that the weekly performance report is not idempotent i.e. if it’s re-generated with same date-filters today, it should generate the same data, which it doesn’t. This is because the report doesn’t apply date-filters on all components of the calculation.

This fix calculates visit records filtered to the report's end date, so neither number can change when report is re-generated.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
All tests pass.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New test added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
