### PR TITLE
fix query fan-out in get_annotated_opportunity_access

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -165,29 +165,23 @@ def get_annotated_opportunity_access(opportunity: Opportunity):
         .select_related("opportunity_access", "opportunity_access__opportunityclaim", "opportunity_access__user")
         .annotate(
             last_visit_date_d=Max(
-                "opportunity_access__user__uservisit__visit_date",
-                filter=Q(opportunity_access__user__uservisit__opportunity=opportunity)
-                & ~Q(opportunity_access__user__uservisit__status=VisitValidationStatus.trial),
+                "opportunity_access__uservisit__visit_date",
+                filter=~Q(opportunity_access__uservisit__status=VisitValidationStatus.trial),
             ),
             date_deliver_started=Min(
-                "opportunity_access__user__uservisit__visit_date",
-                filter=Q(opportunity_access__user__uservisit__opportunity=opportunity),
+                "opportunity_access__uservisit__visit_date",
             ),
             passed_assessment=Sum(
                 Case(
                     When(
-                        Q(
-                            opportunity_access__user__assessments__opportunity=opportunity,
-                            opportunity_access__user__assessments__passed=True,
-                        ),
+                        Q(opportunity_access__assessment__passed=True),
                         then=1,
                     ),
                     default=0,
                 )
             ),
             completed_modules_count=Count(
-                "opportunity_access__user__completed_modules__module",
-                filter=Q(opportunity_access__user__completed_modules__opportunity=opportunity),
+                "opportunity_access__completedmodule__module",
                 distinct=True,
             ),
             job_claimed=Case(
@@ -202,8 +196,7 @@ def get_annotated_opportunity_access(opportunity: Opportunity):
                 When(
                     Q(completed_modules_count=learn_modules_count),
                     then=Max(
-                        "opportunity_access__user__completed_modules__date",
-                        filter=Q(opportunity_access__user__completed_modules__opportunity=opportunity),
+                        "opportunity_access__completedmodule__date",
                     ),
                 )
             )

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -171,14 +171,10 @@ def get_annotated_opportunity_access(opportunity: Opportunity):
             date_deliver_started=Min(
                 "opportunity_access__uservisit__visit_date",
             ),
-            passed_assessment=Sum(
-                Case(
-                    When(
-                        Q(opportunity_access__assessment__passed=True),
-                        then=1,
-                    ),
-                    default=0,
-                )
+            passed_assessment=Count(
+                "opportunity_access__assessment",
+                filter=Q(opportunity_access__assessment__passed=True),
+                distinct=True,
             ),
             completed_modules_count=Count(
                 "opportunity_access__completedmodule__module",


### PR DESCRIPTION
## Product Description

No user-facing change.

## Technical Summary
https://dimagi.atlassian.net/browse/QA-8561
- The query reached `uservisit`, `assessment`, and `completedmodule` through `opportunity_access → user`, which joins all records for those users globally before filtering by opportunity. On an opportunity with 3 users who collectively have 26,000+ visits across other opportunities, the intermediate join consumed too much space.
- Switching the traversal to go directly through `opportunity_access` (already scoped to one user+opportunity pair) cuts the fan-out entirely. No schema changes, no subqueries.
## Safety Assurance

### Safety story

Read-only query change. `opportunity_access` is a direct FK on all three models and already scopes to the correct user+opportunity pair, so the results are equivalent. Verified on staging against real data before and after.

### Automated test coverage

No new tests added; existing helper tests cover this function and pass.

### QA Plan

QA ticket: https://dimagi.atlassian.net/browse/QA-8561

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change