### PR TITLE
Coverage Tracker Progress Page Metrics update

### DIFF
--- a/commcare_connect/microplanning/coverage_progress.py
+++ b/commcare_connect/microplanning/coverage_progress.py
@@ -8,7 +8,7 @@ from django.db.models.functions import Coalesce
 from django.utils import timezone
 from django.utils.timezone import localdate
 
-from commcare_connect.microplanning.helpers import pct
+from commcare_connect.microplanning.helpers import pct, ratio
 from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup, WorkAreaStatus
 from commcare_connect.opportunity.models import UserVisit, VisitValidationStatus
 
@@ -361,7 +361,7 @@ def build_ward_rows(target_aggregates, filtered_status, filtered_visits, last_we
             "last_week": pct(lw_visits.get("visits_approved", 0), target["expected_visit_total"]),
         }
         for out_key, pct_key, denom in _WARD_PCT_RATIOS:
-            row[out_key] = pct(row[pct_key], ratio_denominator[denom])
+            row[out_key] = ratio(row[pct_key], ratio_denominator[denom])
 
         rows.append(row)
     return rows
@@ -404,10 +404,10 @@ def build_wag_rows(display, target_aggregates, filtered_status, filtered_visits,
         row["pct_WAs_evc_reached"] = pct(status.get("WAs_evc_reached", 0), target["num_work_areas"])
         row["pct_WAs_evc_reached_last_week"] = pct(lw_status.get("WAs_evc_reached", 0), target["num_work_areas"])
         # pct_WAs_visited is not a bottom-table column; compute inline as the ratio numerator
-        row["pct_WA_visited_to_pct_visits"] = pct(
+        row["pct_WA_visited_to_pct_visits"] = ratio(
             pct(status.get("WAs_visited", 0), target["num_work_areas"]), row["pct_visits_approved"]
         )
-        row["pct_WA_visited_to_pct_visits_last_week"] = pct(
+        row["pct_WA_visited_to_pct_visits_last_week"] = ratio(
             pct(lw_status.get("WAs_visited", 0), target["num_work_areas"]), row["pct_visits_approved_last_week"]
         )
         rows.append(row)

--- a/commcare_connect/microplanning/coverage_progress.py
+++ b/commcare_connect/microplanning/coverage_progress.py
@@ -337,7 +337,7 @@ def build_ward_rows(target_aggregates, filtered_status, filtered_visits, last_we
         # raw counts/sums (default 0 when this ward is absent from an aggregate)
         row = {
             "ward": ward,
-            "target_population": target["target_population"],
+            "expected_visit_total": target["expected_visit_total"],
             "building_count": target["building_count"],
             "num_work_areas": target["num_work_areas"],
             "visits_approved": visits.get("visits_approved", 0),
@@ -397,7 +397,7 @@ def build_wag_rows(display, target_aggregates, filtered_status, filtered_visits,
             "work_area_group_id": wag_id,
             "work_area_group": meta["work_area_group"],
             "ward": meta["ward"],
-            "target_population": target["target_population"],
+            "expected_visit_total": target["expected_visit_total"],
         }
         row["pct_visits_approved"] = pct(visits.get("visits_approved", 0), target["expected_visit_total"])
         row["pct_visits_approved_last_week"] = pct(lw_visits.get("visits_approved", 0), target["expected_visit_total"])

--- a/commcare_connect/microplanning/helpers.py
+++ b/commcare_connect/microplanning/helpers.py
@@ -23,6 +23,16 @@ def pct(numerator, denominator, ndigits=2):
     return round(numerator / denominator * 100, ndigits)
 
 
+def ratio(numerator, denominator, ndigits=2):
+    """Plain ratio of ``numerator`` over ``denominator`` (no ×100), rounded to ``ndigits``.
+
+    Returns None for a zero/falsy denominator or a None numerator.
+    """
+    if not denominator or numerator is None:
+        return None
+    return round(numerator / denominator, ndigits)
+
+
 def exclude_work_areas_for_opportunity(opportunity, work_area_ids, user, exclusion_reason):
     """Exclude work areas and unassign their HQ cases.
     HQ calls are batched by HQ_BULK_CHUNK_SIZE; a batch failure skips DB exclusion

--- a/commcare_connect/microplanning/tables.py
+++ b/commcare_connect/microplanning/tables.py
@@ -8,7 +8,7 @@ from django_tables2 import columns, tables
 WARD_LABEL_COLUMNS = (("ward", _("Ward")),)
 
 WARD_METRIC_COLUMNS = (
-    ("target_population", _("Ward Population Target")),
+    ("expected_visit_total", _("Expected Visit Count")),
     ("building_count", _("Building Count")),
     ("num_work_areas", _("Work Areas")),
     ("visits_approved", _("Approved Visits")),
@@ -48,7 +48,7 @@ WAG_LABEL_COLUMNS = (
 )
 
 WAG_METRIC_COLUMNS = (
-    ("target_population", _("Population Target")),
+    ("expected_visit_total", _("Expected Visit Count")),
     ("pct_visits_approved", _("% Visits Completed")),
     ("pct_visits_approved_last_week", _("% Visits Completed (Last Week)")),
     ("pct_WAs_evc_reached", _("% WAs EVC Reached")),

--- a/commcare_connect/microplanning/tests/test_coverage_progress.py
+++ b/commcare_connect/microplanning/tests/test_coverage_progress.py
@@ -335,7 +335,7 @@ def test_build_wag_rows_reduced_columns(opportunity):
 
     assert row["work_area_group"] == "G1"
     assert row["ward"] == "w1"
-    assert row["target_population"] == 300
+    assert row["expected_visit_total"] == 50
     assert row["pct_visits_approved"] == 50.0  # 25 / 50
     assert row["pct_WAs_evc_reached"] == 25.0  # 3 / 12
     assert row["pct_WA_visited_to_pct_visits"] == 100.0  # (6/12=50) / (25/50=50) * 100

--- a/commcare_connect/microplanning/tests/test_coverage_progress.py
+++ b/commcare_connect/microplanning/tests/test_coverage_progress.py
@@ -268,13 +268,13 @@ def test_build_ward_rows_merges_and_derives():
     assert row["pct_WAs_visited"] == 40.0  # 4 / 10
     assert row["pct_WAs_evc_reached"] == 20.0  # 2 / 10
     assert row["pct_Buildings_covered_in_WAs_visited"] == 40.0  # 20 / 50
-    assert row["pct_WA_visited_to_pct_visits"] == 80.0  # 40 / 50 * 100
-    assert row["pct_WA_evc_reached_to_pct_visit"] == 40.0  # 20 / 50 * 100
+    assert row["pct_WA_visited_to_pct_visits"] == 0.8  # 40 / 50
+    assert row["pct_WA_evc_reached_to_pct_visit"] == 0.4  # 20 / 50
     assert row["WAs_visited_last_week"] == 1
     assert row["pct_WAs_visited_last_week"] == 10.0  # 1 / 10
-    # last-week ratio = pct_WAs_visited_last_week / pct_visits_approved_last_week * 100
-    #                 = 10.0 / (5/40*100 = 12.5) * 100 = 80.0
-    assert row["pct_WA_visited_to_pct_visits_last_week"] == 80.0
+    # last-week ratio = pct_WAs_visited_last_week / pct_visits_approved_last_week
+    #                 = 10.0 / (5/40*100 = 12.5) = 0.8
+    assert row["pct_WA_visited_to_pct_visits_last_week"] == 0.8
 
 
 def test_build_ward_rows_zero_denominator_yields_none():
@@ -338,7 +338,7 @@ def test_build_wag_rows_reduced_columns(opportunity):
     assert row["expected_visit_total"] == 50
     assert row["pct_visits_approved"] == 50.0  # 25 / 50
     assert row["pct_WAs_evc_reached"] == 25.0  # 3 / 12
-    assert row["pct_WA_visited_to_pct_visits"] == 100.0  # (6/12=50) / (25/50=50) * 100
+    assert row["pct_WA_visited_to_pct_visits"] == 1.0  # (6/12=50) / (25/50=50)
     # reduced set: building-coverage columns are NOT present
     assert "pct_Buildings_covered_in_WAs_visited" not in row
 

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -1690,7 +1690,7 @@ class TestCoverageProgressView(BaseMicroplanningFlagTest):
         assert resp["Content-Type"].startswith("text/csv")
         assert "attachment" in resp["Content-Disposition"]
         body = resp.getvalue().decode()
-        assert "Ward Population Target" in body
+        assert "Expected Visit Count" in body
         assert "w1" in body
 
     def test_export_returns_xlsx_of_wag_table(self, client, org_user_admin, opportunity):

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -1551,18 +1551,18 @@ class TestGetMetricsForMicroplanningWorkAreas:
         UserVisitFactory(opportunity=opp, work_area=None, status=VisitValidationStatus.pending)
 
         metrics = get_metrics_for_microplanning(opp)
-        m = self._get_metric(metrics, "% WA visited to % total visits")
+        m = self._get_metric(metrics, "WA Visited : Visits Ratio")
         assert m["value"] == 1000.0
         assert "percentage" not in m
-        assert m["unit"] == "%"
+        assert "unit" not in m
 
     def test_pct_visited_to_pct_visits_zero_denominator(self, opp):
         """No visits and no expected visits → show '--'."""
 
         metrics = get_metrics_for_microplanning(opp)
-        m = self._get_metric(metrics, "% WA visited to % total visits")
+        m = self._get_metric(metrics, "WA Visited : Visits Ratio")
         assert m["value"] == "--"
-        assert m["unit"] == "%"
+        assert "unit" not in m
 
     def test_pct_visited_ignores_visits_without_work_area(self, opp):
         """Approved visits with no work_area must not inflate the ratio's total_approved denominator."""
@@ -1577,7 +1577,7 @@ class TestGetMetricsForMicroplanningWorkAreas:
             UserVisitFactory(opportunity=opp, work_area=None, status=VisitValidationStatus.approved)
 
         metrics = get_metrics_for_microplanning(opp)
-        m = self._get_metric(metrics, "% WA visited to % total visits")
+        m = self._get_metric(metrics, "WA Visited : Visits Ratio")
         # total_approved (WA-attached) = 1 → pct_visits = 1/20 = 0.05
         # pct_wa_visited = 1/2 = 0.5 → ratio = 0.5 / 0.05 = 10.0
         assert m["value"] == 1000.0

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -1552,7 +1552,7 @@ class TestGetMetricsForMicroplanningWorkAreas:
 
         metrics = get_metrics_for_microplanning(opp)
         m = self._get_metric(metrics, "WA Visited : Visits Ratio")
-        assert m["value"] == 1000.0
+        assert m["value"] == 10.0
         assert "percentage" not in m
         assert "unit" not in m
 
@@ -1580,7 +1580,7 @@ class TestGetMetricsForMicroplanningWorkAreas:
         m = self._get_metric(metrics, "WA Visited : Visits Ratio")
         # total_approved (WA-attached) = 1 → pct_visits = 1/20 = 0.05
         # pct_wa_visited = 1/2 = 0.5 → ratio = 0.5 / 0.05 = 10.0
-        assert m["value"] == 1000.0
+        assert m["value"] == 10.0
 
     def test_zero_non_excluded_work_areas(self, opp):
         """All WAs excluded → percentage metrics show None; visited count is 0."""

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -263,7 +263,7 @@ def get_metrics_for_microplanning(opportunity):
             "value": agg["excluded"],
             "percentage": pct(agg["excluded"], total, ndigits=None),
         },
-        {"name": _("% WA visited to % total visits"), "value": visited_to_visits, "unit": "%"},
+        {"name": _("WA Visited : Visits Ratio"), "value": visited_to_visits},
     ]
 
 

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -230,7 +230,7 @@ def get_metrics_for_microplanning(opportunity):
         total_approved_visits = agg["total_approved_visits"] or 0
         pct_wa_visited = (agg["visited"] or 0) / non_excluded_count
         pct_visits = total_approved_visits / total_expected
-        visited_to_visits = round((pct_wa_visited * 100) / pct_visits, 2) if pct_visits else "--"
+        visited_to_visits = round(pct_wa_visited / pct_visits, 2) if pct_visits else "--"
     else:
         visited_to_visits = "--"
 


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CI-735

This replaces `Ward Population Target` with `Expected Visits` in Coverage tracker page, and changes a percentage number to ratio.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
NA

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will be tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Modified

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will be tested on staging
### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
