### PR TITLE
CCCT-2109: Fix daily limit race condition in deliver form processing

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -45,7 +45,6 @@ from commcare_connect.opportunity.tasks import (
 )
 from commcare_connect.opportunity.visit_import import update_payment_accrued_for_user
 from commcare_connect.users.models import User
-from commcare_connect.utils.lock import try_redis_lock
 
 logger = logging.getLogger(__name__)
 
@@ -434,7 +433,8 @@ def clean_form_submission(access: OpportunityAccess, user_visit: UserVisit, xfor
 def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Opportunity, deliver_unit_block: dict):
     """Process a delivery form submission into a UserVisit and update CompletedWork.
 
-    Acquires a Redis lock per entity to handle concurrent submissions, then:
+    Locks the claim limit row (select_for_update) to serialize concurrent
+    submissions for the same user + payment unit, then:
     1. Creates a UserVisit with initial status based on daily/total/claim limits
     2. Runs verification flag checks via clean_form_submission()
     3. Auto-rejects flagged visits if automatic_visit_verification is enabled
@@ -455,15 +455,18 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
         )
 
     claim = OpportunityClaim.objects.get(opportunity_access=access)
-    claim_limit = OpportunityClaimLimit.objects.get(opportunity_claim=claim, payment_unit=payment_unit)
     entity_id = deliver_unit_block.get("entity_id")
     entity_name = deliver_unit_block.get("entity_name")
 
-    # handle concurrent form submissions for same entity id
-    lock_key = f"visit_processor:{access.id}:{deliver_unit.id}:{entity_id}"
-    with try_redis_lock(lock_key, timeout=30, blocking_timeout=5) as acquired, transaction.atomic():
-        if not acquired:
-            raise ProcessingError("Error processing form, please retry again.")
+    with transaction.atomic():
+        # Lock the claim limit row to serialize concurrent submissions for the same
+        # user + payment unit. Without it, simultaneous submissions read the same
+        # daily/total counts before either commits and both pass the limit check,
+        # letting visits slip past the daily limit. The lock also serializes the
+        # duplicate-entity check below.
+        claim_limit = OpportunityClaimLimit.objects.select_for_update().get(
+            opportunity_claim=claim, payment_unit=payment_unit
+        )
         counts = (
             UserVisit.objects.filter(opportunity_access=access, deliver_unit=deliver_unit)
             .exclude(status__in=[VisitValidationStatus.over_limit, VisitValidationStatus.trial])

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils.timezone import now
 from rest_framework.test import APIClient
 
@@ -1404,3 +1406,29 @@ def test_work_area_update_invalid_photo_evidence(
         oauth_application=oauth_application,
     )
     assert WorkAreaInaccessibilityRequest.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_deliver_form_locks_claim_limit_row(
+    user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
+):
+    """Regression guard for the daily-limit race condition fix."""
+    oauth_application = opportunity.hq_server.oauth_application
+    form_json = _create_opp_and_form_json(opportunity, user=user_with_connectid_link)
+
+    with CaptureQueriesContext(connection) as ctx:
+        make_request(api_client, form_json, user_with_connectid_link, oauth_application=oauth_application)
+
+    locking_queries = [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "for update" in q["sql"].lower() and "opportunityclaimlimit" in q["sql"].lower()
+    ]
+    assert locking_queries, (
+        "Expected a 'SELECT ... FOR UPDATE' on the OpportunityClaimLimit row to serialize "
+        "concurrent submissions, but none was issued. The daily-limit race condition guard "
+        "may have been removed from process_deliver_unit."
+    )
+
+    # Sanity check the form was actually processed (the lock guards a real save path).
+    assert UserVisit.objects.filter(user=user_with_connectid_link).count() == 1


### PR DESCRIPTION
## Product Description

Fixes a bug where visits could slip past the daily limit. For example, with a daily limit of 5, the 6th visit was sometimes **not** flagged as `over_limit` while later visits (7th, 8th) were.

This happened when two forms were submitted at nearly the same time: both checked the daily count before either was saved, so both saw a count below the limit and were accepted. Under production concurrency (gevent workers) this let an extra visit through.

## Technical Summary

Ticket: [CCCT-2109](https://dimagi.atlassian.net/browse/CCCT-2109)

The limit check counted existing visits and then saved the new one in a transaction. Two concurrent submissions for **different entities** read the same (stale) count before either committed, both passed the check, and both were saved as `pending`.

The previous guard was a Redis lock keyed on `entity_id`, so submissions for *different* entities took *different* locks and ran concurrently — never serialized.

**Fix:** take a `select_for_update` lock on the per-`(user, payment_unit)` `OpportunityClaimLimit` row inside the transaction, so all submissions sharing a payment unit are serialized and the limit check always sees committed counts.

**Why `select_for_update` instead of changing the Redis key:**
- **Right granularity** — the limit is per `(user, payment_unit)`, which is exactly the `OpportunityClaimLimit` row's key.
- **Correctness lives with the data** — the invariant is a DB count, serialized in the same transaction that reads it.
- **No mid-transaction expiry** — the Redis lock's 30s timeout can release while the transaction is still running (the critical section includes an O(visits) location loop), reopening the race. A row lock lasts exactly as long as the transaction.
- **Consistency** — `select_for_update` is already the pattern in this module (task and work-area processing), including in this same function.

The entity-scoped Redis lock is removed; the payment-unit row lock is broader and covers everything it did, including the duplicate-entity check. Errors propagate (500) like the other processing paths.

> Note: I am open to consider using the redis approach if there are concerns with the existing one.

## Safety Assurance

### Safety story

The change is small and localized to `process_deliver_unit`, and reuses a locking pattern already established in this module. Contention is scoped to the same user + payment unit (different users/payment units never block each other). The lock is held only for the transaction, so there is no risk of a stale/expired lock. No data migration; existing visits are unaffected.

### Automated test coverage

Full `form_receiver` suite passes.

### QA Plan
https://dimagi.atlassian.net/browse/QA-8562

- With a daily limit of N, submit several forms in quick succession and confirm the (N+1)th visit is flagged `over_limit`.
- Confirm normal single submissions and duplicate-entity handling still behave as before.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2109]: https://dimagi.atlassian.net/browse/CCCT-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ