### PR TITLE
CCCT-2470: Split Org Pay vs FLW Pay on invoices

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1729,31 +1729,33 @@ class PaymentUnitTable(OrgContextTable):
 
 
 class InvoiceLineItemsTable(tables.Table):
-    month = tables.Column()
-    payment_unit_name = tables.Column(verbose_name="Payment Unit")
-    number_approved = tables.Column()
-    flw_amount_local = tables.Column(verbose_name="FLW Pay (local)")
-    org_amount_local = tables.Column(verbose_name="Org Pay (local)")
-    total_amount_local = tables.Column(verbose_name="Total Pay (local)")
-    exchange_rate = tables.Column()
-    total_amount_usd = tables.Column(verbose_name="Total Pay (USD)")
+    month = tables.Column(verbose_name=gettext_lazy("Month"))
+    payment_unit_name = tables.Column(verbose_name=gettext_lazy("Payment Unit"))
+    number_approved = tables.Column(verbose_name=gettext_lazy("Number Approved"))
+    flw_amount_local = tables.Column(verbose_name=gettext_lazy("FLW Pay (local)"))
+    org_amount_local = tables.Column(verbose_name=gettext_lazy("Org Pay (local)"))
+    total_amount_local = tables.Column(verbose_name=gettext_lazy("Total Pay (local)"))
+    exchange_rate = tables.Column(verbose_name=gettext_lazy("Exchange Rate"))
+    total_amount_usd = tables.Column(verbose_name=gettext_lazy("Total Pay (USD)"))
 
     def __init__(self, currency, *args, show_org=False, **kwargs):
         super().__init__(*args, **kwargs)
         if currency:
-            self.columns["flw_amount_local"].column.verbose_name = f"FLW Pay ({currency})"
-            self.columns["org_amount_local"].column.verbose_name = f"Org Pay ({currency})"
-            self.columns["total_amount_local"].column.verbose_name = f"Total Pay ({currency})"
+            self.columns["flw_amount_local"].column.verbose_name = _("FLW Pay (%(currency)s)") % {"currency": currency}
+            self.columns["org_amount_local"].column.verbose_name = _("Org Pay (%(currency)s)") % {"currency": currency}
+            self.columns["total_amount_local"].column.verbose_name = _("Total Pay (%(currency)s)") % {
+                "currency": currency
+            }
         if show_org:
-            usd_tooltip = (
+            usd_tooltip = _(
                 "Sum of FLW pay and org pay (USD), each converted at the exchange rate "
                 "at the delivery's approval time."
             )
         else:
             self.columns["flw_amount_local"].column.visible = False
             self.columns["org_amount_local"].column.visible = False
-            usd_tooltip = "FLW pay (USD), converted at the exchange rate at the delivery's approval time."
-        self.columns["total_amount_usd"].column.verbose_name = header_with_tooltip("Total Pay (USD)", usd_tooltip)
+            usd_tooltip = _("FLW pay (USD), converted at the exchange rate at the delivery's approval time.")
+        self.columns["total_amount_usd"].column.verbose_name = header_with_tooltip(_("Total Pay (USD)"), usd_tooltip)
 
     class Meta:
         orderable = False
@@ -1766,25 +1768,29 @@ class InvoiceLineItemsTable(tables.Table):
 
 
 class InvoiceDeliveriesTable(tables.Table):
-    date_approved = DMYTColumn(verbose_name=_("Date Approved"), accessor="status_modified_date")
-    opportunity = tables.Column(verbose_name=_("Opportunity"), accessor="payment_unit__opportunity__name")
-    approved_count = tables.Column(verbose_name=_("Approved Deliveries"), accessor="saved_approved_count")
-    flw_amount_local = tables.Column(verbose_name=_("FLW Pay"), accessor="saved_payment_accrued")
-    org_amount_local = tables.Column(verbose_name=_("Org Pay"), accessor="saved_org_payment_accrued")
-    total_amount_local = tables.Column(verbose_name=_("Total Pay"), accessor="saved_payment_accrued", empty_values=())
-    total_amount_usd = tables.Column(
-        verbose_name=_("Total Pay (USD)"), accessor="saved_payment_accrued_usd", empty_values=()
+    date_approved = DMYTColumn(verbose_name=gettext_lazy("Date Approved"), accessor="status_modified_date")
+    opportunity = tables.Column(verbose_name=gettext_lazy("Opportunity"), accessor="payment_unit__opportunity__name")
+    approved_count = tables.Column(verbose_name=gettext_lazy("Approved Deliveries"), accessor="saved_approved_count")
+    flw_amount_local = tables.Column(verbose_name=gettext_lazy("FLW Pay"), accessor="saved_payment_accrued")
+    org_amount_local = tables.Column(verbose_name=gettext_lazy("Org Pay"), accessor="saved_org_payment_accrued")
+    total_amount_local = tables.Column(
+        verbose_name=gettext_lazy("Total Pay"), accessor="saved_payment_accrued", empty_values=()
     )
-    entity_name = tables.Column(verbose_name=_("Beneficiary"), accessor="entity_name")
-    date_created = DMYTColumn(verbose_name=_("Date of Delivery"), accessor="date_created")
-    username = tables.Column(verbose_name=_("Worker"), accessor="opportunity_access__user__name")
+    total_amount_usd = tables.Column(
+        verbose_name=gettext_lazy("Total Pay (USD)"), accessor="saved_payment_accrued_usd", empty_values=()
+    )
+    entity_name = tables.Column(verbose_name=gettext_lazy("Beneficiary"), accessor="entity_name")
+    date_created = DMYTColumn(verbose_name=gettext_lazy("Date of Delivery"), accessor="date_created")
+    username = tables.Column(verbose_name=gettext_lazy("Worker"), accessor="opportunity_access__user__name")
 
     def __init__(self, currency, *args, show_org=False, **kwargs):
         super().__init__(*args, **kwargs)
         if currency:
-            self.columns["flw_amount_local"].column.verbose_name = f"FLW Pay ({currency})"
-            self.columns["org_amount_local"].column.verbose_name = f"Org Pay ({currency})"
-            self.columns["total_amount_local"].column.verbose_name = f"Total Pay ({currency})"
+            self.columns["flw_amount_local"].column.verbose_name = _("FLW Pay (%(currency)s)") % {"currency": currency}
+            self.columns["org_amount_local"].column.verbose_name = _("Org Pay (%(currency)s)") % {"currency": currency}
+            self.columns["total_amount_local"].column.verbose_name = _("Total Pay (%(currency)s)") % {
+                "currency": currency
+            }
         if not show_org:
             self.columns["flw_amount_local"].column.exclude_from_export = True
             self.columns["org_amount_local"].column.exclude_from_export = True

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1769,15 +1769,25 @@ class InvoiceDeliveriesTable(tables.Table):
     date_approved = DMYTColumn(verbose_name=_("Date Approved"), accessor="status_modified_date")
     opportunity = tables.Column(verbose_name=_("Opportunity"), accessor="payment_unit__opportunity__name")
     approved_count = tables.Column(verbose_name=_("Approved Deliveries"), accessor="saved_approved_count")
-    payment_accrued = tables.Column(verbose_name=_("Payment Accrued"), accessor="saved_payment_accrued")
-    payment_accrued_usd = tables.Column(verbose_name=_("Payment Accrued (USD)"), accessor="saved_payment_accrued_usd")
+    flw_amount_local = tables.Column(verbose_name=_("FLW Pay"), accessor="saved_payment_accrued")
+    org_amount_local = tables.Column(verbose_name=_("Org Pay"), accessor="saved_org_payment_accrued")
+    total_amount_local = tables.Column(verbose_name=_("Total Pay"), accessor="saved_payment_accrued", empty_values=())
+    total_amount_usd = tables.Column(
+        verbose_name=_("Total Pay (USD)"), accessor="saved_payment_accrued_usd", empty_values=()
+    )
     entity_name = tables.Column(verbose_name=_("Beneficiary"), accessor="entity_name")
     date_created = DMYTColumn(verbose_name=_("Date of Delivery"), accessor="date_created")
     username = tables.Column(verbose_name=_("Worker"), accessor="opportunity_access__user__name")
 
-    def __init__(self, currency, *args, **kwargs):
+    def __init__(self, currency, *args, show_org=False, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns["payment_accrued"].column.verbose_name = f"Payment Accrued ({currency})"
+        if currency:
+            self.columns["flw_amount_local"].column.verbose_name = f"FLW Pay ({currency})"
+            self.columns["org_amount_local"].column.verbose_name = f"Org Pay ({currency})"
+            self.columns["total_amount_local"].column.verbose_name = f"Total Pay ({currency})"
+        if not show_org:
+            self.columns["flw_amount_local"].column.exclude_from_export = True
+            self.columns["org_amount_local"].column.exclude_from_export = True
 
     class Meta:
         model = CompletedWork
@@ -1790,9 +1800,17 @@ class InvoiceDeliveriesTable(tables.Table):
             "date_created",
             "date_approved",
             "approved_count",
-            "payment_accrued",
-            "payment_accrued_usd",
+            "flw_amount_local",
+            "org_amount_local",
+            "total_amount_local",
+            "total_amount_usd",
         )
+
+    def value_total_amount_local(self, record):
+        return (record.saved_payment_accrued or 0) + (record.saved_org_payment_accrued or 0)
+
+    def value_total_amount_usd(self, record):
+        return (record.saved_payment_accrued_usd or 0) + (record.saved_org_payment_accrued_usd or 0)
 
 
 _task_select_td_extra = {

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1732,26 +1732,28 @@ class InvoiceLineItemsTable(tables.Table):
     month = tables.Column()
     payment_unit_name = tables.Column(verbose_name="Payment Unit")
     number_approved = tables.Column()
-    amount_per_unit = tables.Column(
-        verbose_name="Payment Unit Amount (local)",
-    )
-    total_amount_local = tables.Column(
-        verbose_name="Total Amount (local)",
-    )
+    flw_amount_local = tables.Column(verbose_name="FLW Pay (local)")
+    org_amount_local = tables.Column(verbose_name="Org Pay (local)")
+    total_amount_local = tables.Column(verbose_name="Total Pay (local)")
     exchange_rate = tables.Column()
-    total_amount_usd = tables.Column(
-        verbose_name=header_with_tooltip(
-            "Total Amount (USD)",
-            "Approved count × (payment unit amount ÷ exchange rate at time of approval) "
-            "rounded to 2 decimals for each delivery",
-        ),
-    )
+    total_amount_usd = tables.Column(verbose_name="Total Pay (USD)")
 
-    def __init__(self, currency, *args, **kwargs):
+    def __init__(self, currency, *args, show_org=False, **kwargs):
         super().__init__(*args, **kwargs)
         if currency:
-            self.columns["amount_per_unit"].column.verbose_name = f"Payment Unit Amount ({currency})"
-            self.columns["total_amount_local"].column.verbose_name = f"Total Amount ({currency})"
+            self.columns["flw_amount_local"].column.verbose_name = f"FLW Pay ({currency})"
+            self.columns["org_amount_local"].column.verbose_name = f"Org Pay ({currency})"
+            self.columns["total_amount_local"].column.verbose_name = f"Total Pay ({currency})"
+        if show_org:
+            usd_tooltip = (
+                "Sum of FLW pay and org pay (USD), each converted at the exchange rate "
+                "at the delivery's approval time."
+            )
+        else:
+            self.columns["flw_amount_local"].column.visible = False
+            self.columns["org_amount_local"].column.visible = False
+            usd_tooltip = "FLW pay (USD), converted at the exchange rate at the delivery's approval time."
+        self.columns["total_amount_usd"].column.verbose_name = header_with_tooltip("Total Pay (USD)", usd_tooltip)
 
     class Meta:
         orderable = False

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1749,12 +1749,15 @@ class InvoiceLineItemsTable(tables.Table):
         if show_org:
             usd_tooltip = _(
                 "Sum of FLW pay and org pay (USD), each converted at the exchange rate "
-                "at the delivery's approval time."
+                "at the delivery's approval time and rounded to 2 decimals per delivery."
             )
         else:
             self.columns["flw_amount_local"].column.visible = False
             self.columns["org_amount_local"].column.visible = False
-            usd_tooltip = _("FLW pay (USD), converted at the exchange rate at the delivery's approval time.")
+            usd_tooltip = _(
+                "FLW pay (USD), converted at the exchange rate at the delivery's approval time "
+                "and rounded to 2 decimals per delivery."
+            )
         self.columns["total_amount_usd"].column.verbose_name = header_with_tooltip(_("Total Pay (USD)"), usd_tooltip)
 
     class Meta:

--- a/commcare_connect/opportunity/tests/test_completed_work.py
+++ b/commcare_connect/opportunity/tests/test_completed_work.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -20,7 +20,11 @@ from commcare_connect.opportunity.tests.factories import (
     PaymentUnitFactory,
     UserVisitFactory,
 )
-from commcare_connect.opportunity.utils.completed_work import get_uninvoiced_visit_items, update_status
+from commcare_connect.opportunity.utils.completed_work import (
+    get_invoice_items,
+    get_uninvoiced_visit_items,
+    update_status,
+)
 
 
 @pytest.mark.django_db
@@ -42,7 +46,6 @@ class TestUninvoicedVisitItems:
         invoice_item = items[0]
         assert invoice_item["payment_unit_name"] == completed_work.payment_unit.name
         assert invoice_item["number_approved"] == 1
-        assert invoice_item["amount_per_unit"] == completed_work.payment_unit.amount
         assert invoice_item["total_amount_local"] == completed_work.payment_unit.amount
 
     def test_items_with_prior_invoice(self):
@@ -70,7 +73,6 @@ class TestUninvoicedVisitItems:
         invoice_item = items[0]
         assert invoice_item["payment_unit_name"] == completed_work.payment_unit.name
         assert invoice_item["number_approved"] == 1
-        assert invoice_item["amount_per_unit"] == completed_work.payment_unit.amount
         assert invoice_item["total_amount_local"] == completed_work.payment_unit.amount
 
     @patch("commcare_connect.opportunity.visit_import.get_exchange_rate")
@@ -122,7 +124,6 @@ class TestUninvoicedVisitItems:
 
             total_local_amount = expected_number_approved * expected_payment_unit.amount
             assert item["number_approved"] == expected_number_approved
-            assert item["amount_per_unit"] == expected_payment_unit.amount
             assert item["total_amount_local"] == total_local_amount
             assert item["exchange_rate"] == expected_exchange_rate
             assert float(item["total_amount_usd"]) == round(total_local_amount / expected_exchange_rate, 2)
@@ -204,7 +205,6 @@ class TestUninvoicedVisitItems:
 
             total_local_amount = expected_number_approved * expected_payment_unit.amount
             assert item["number_approved"] == expected_number_approved
-            assert item["amount_per_unit"] == expected_payment_unit.amount
             assert item["total_amount_local"] == total_local_amount
             assert item["exchange_rate"] == expected_exchange_rate
             assert float(item["total_amount_usd"]) == round(total_local_amount / expected_exchange_rate, 2)
@@ -716,3 +716,32 @@ class TestUpdateStatus:
         self._run_update_status(completed_work)
 
         assert completed_work.status == CompletedWorkStatus.approved
+
+
+@pytest.mark.django_db
+def test_get_invoice_items_total_includes_org_pay():
+    payment_unit = PaymentUnitFactory(amount=10, org_amount=4)
+    cw = CompletedWorkFactory(
+        payment_unit=payment_unit,
+        status=CompletedWorkStatus.approved,
+        saved_approved_count=2,
+        saved_payment_accrued=20,
+        saved_org_payment_accrued=8,
+        saved_payment_accrued_usd=2,
+        saved_org_payment_accrued_usd=1,
+    )
+    cw.status_modified_date = datetime(2025, 10, 5, tzinfo=timezone.utc)
+    cw.save()
+
+    items = get_invoice_items(CompletedWork.objects.filter(id=cw.id))
+
+    assert len(items) == 1
+    item = items[0]
+    # Raw FLW/Org breakdowns are surfaced separately.
+    assert item["flw_amount_local"] == 20
+    assert item["org_amount_local"] == 8
+    assert item["flw_amount_usd"] == 2
+    assert item["org_amount_usd"] == 1
+    # Totals always fold in org pay (FLW + Org).
+    assert item["total_amount_local"] == 28
+    assert float(item["total_amount_usd"]) == 3.0

--- a/commcare_connect/opportunity/tests/test_tables.py
+++ b/commcare_connect/opportunity/tests/test_tables.py
@@ -18,39 +18,25 @@ from commcare_connect.opportunity.tests.factories import (
 )
 
 
-def test_invoice_line_items_table_hides_org_columns_when_not_show_org():
-    table = InvoiceLineItemsTable("KES", [], show_org=False)
+@pytest.mark.parametrize("show_org", [False, True])
+def test_invoice_line_items_table_org_column_visibility(show_org):
+    table = InvoiceLineItemsTable("KES", [], show_org=show_org)
     visible = [column.name for column in table.columns]
-    assert "flw_amount_local" not in visible
-    assert "org_amount_local" not in visible
+    assert ("flw_amount_local" in visible) is show_org
+    assert ("org_amount_local" in visible) is show_org
     assert "total_amount_local" in visible
     assert table.columns["total_amount_local"].column.verbose_name == "Total Pay (KES)"
+    if show_org:
+        assert table.columns["flw_amount_local"].column.verbose_name == "FLW Pay (KES)"
+        assert table.columns["org_amount_local"].column.verbose_name == "Org Pay (KES)"
 
 
-def test_invoice_line_items_table_shows_org_columns_when_show_org():
-    table = InvoiceLineItemsTable("KES", [], show_org=True)
-    visible = [column.name for column in table.columns]
-    assert "flw_amount_local" in visible
-    assert "org_amount_local" in visible
-    assert table.columns["flw_amount_local"].column.verbose_name == "FLW Pay (KES)"
-    assert table.columns["org_amount_local"].column.verbose_name == "Org Pay (KES)"
-    assert table.columns["total_amount_local"].column.verbose_name == "Total Pay (KES)"
-
-
-def test_invoice_deliveries_table_hides_org_columns_when_not_show_org():
-    table = InvoiceDeliveriesTable("KES", [], show_org=False)
+@pytest.mark.parametrize("show_org", [False, True])
+def test_invoice_deliveries_table_org_column_visibility(show_org):
+    table = InvoiceDeliveriesTable("KES", [], show_org=show_org)
     headers = next(table.as_values())
-    assert "FLW Pay (KES)" not in headers
-    assert "Org Pay (KES)" not in headers
-    assert "Total Pay (KES)" in headers
-    assert "Total Pay (USD)" in headers
-
-
-def test_invoice_deliveries_table_shows_org_columns_when_show_org():
-    table = InvoiceDeliveriesTable("KES", [], show_org=True)
-    headers = next(table.as_values())
-    assert "FLW Pay (KES)" in headers
-    assert "Org Pay (KES)" in headers
+    assert ("FLW Pay (KES)" in headers) is show_org
+    assert ("Org Pay (KES)" in headers) is show_org
     assert "Total Pay (KES)" in headers
     assert "Total Pay (USD)" in headers
 

--- a/commcare_connect/opportunity/tests/test_tables.py
+++ b/commcare_connect/opportunity/tests/test_tables.py
@@ -4,13 +4,32 @@ from django_tables2 import RequestConfig
 
 from commcare_connect.opportunity.helpers import get_worker_tasks_base_queryset
 from commcare_connect.opportunity.models import AssignedTaskStatus
-from commcare_connect.opportunity.tables import WorkerTasksTable
+from commcare_connect.opportunity.tables import InvoiceLineItemsTable, WorkerTasksTable
 from commcare_connect.opportunity.tests.factories import (
     AssignedTaskFactory,
     OpportunityAccessFactory,
     TaskTypeFactory,
     UserInviteFactory,
 )
+
+
+def test_invoice_line_items_table_hides_org_columns_when_not_show_org():
+    table = InvoiceLineItemsTable("KES", [], show_org=False)
+    visible = [column.name for column in table.columns]
+    assert "flw_amount_local" not in visible
+    assert "org_amount_local" not in visible
+    assert "total_amount_local" in visible
+    assert table.columns["total_amount_local"].column.verbose_name == "Total Pay (KES)"
+
+
+def test_invoice_line_items_table_shows_org_columns_when_show_org():
+    table = InvoiceLineItemsTable("KES", [], show_org=True)
+    visible = [column.name for column in table.columns]
+    assert "flw_amount_local" in visible
+    assert "org_amount_local" in visible
+    assert table.columns["flw_amount_local"].column.verbose_name == "FLW Pay (KES)"
+    assert table.columns["org_amount_local"].column.verbose_name == "Org Pay (KES)"
+    assert table.columns["total_amount_local"].column.verbose_name == "Total Pay (KES)"
 
 
 def _make_table(opportunity, per_page=25):

--- a/commcare_connect/opportunity/tests/test_tables.py
+++ b/commcare_connect/opportunity/tests/test_tables.py
@@ -4,9 +4,14 @@ from django_tables2 import RequestConfig
 
 from commcare_connect.opportunity.helpers import get_worker_tasks_base_queryset
 from commcare_connect.opportunity.models import AssignedTaskStatus
-from commcare_connect.opportunity.tables import InvoiceLineItemsTable, WorkerTasksTable
+from commcare_connect.opportunity.tables import (
+    InvoiceDeliveriesTable,
+    InvoiceLineItemsTable,
+    WorkerTasksTable,
+)
 from commcare_connect.opportunity.tests.factories import (
     AssignedTaskFactory,
+    CompletedWorkFactory,
     OpportunityAccessFactory,
     TaskTypeFactory,
     UserInviteFactory,
@@ -30,6 +35,45 @@ def test_invoice_line_items_table_shows_org_columns_when_show_org():
     assert table.columns["flw_amount_local"].column.verbose_name == "FLW Pay (KES)"
     assert table.columns["org_amount_local"].column.verbose_name == "Org Pay (KES)"
     assert table.columns["total_amount_local"].column.verbose_name == "Total Pay (KES)"
+
+
+def test_invoice_deliveries_table_hides_org_columns_when_not_show_org():
+    table = InvoiceDeliveriesTable("KES", [], show_org=False)
+    headers = next(table.as_values())
+    assert "FLW Pay (KES)" not in headers
+    assert "Org Pay (KES)" not in headers
+    assert "Total Pay (KES)" in headers
+    assert "Total Pay (USD)" in headers
+
+
+def test_invoice_deliveries_table_shows_org_columns_when_show_org():
+    table = InvoiceDeliveriesTable("KES", [], show_org=True)
+    headers = next(table.as_values())
+    assert "FLW Pay (KES)" in headers
+    assert "Org Pay (KES)" in headers
+    assert "Total Pay (KES)" in headers
+    assert "Total Pay (USD)" in headers
+
+
+@pytest.mark.django_db
+def test_invoice_deliveries_table_total_folds_in_org_pay():
+    completed_work = CompletedWorkFactory(
+        saved_payment_accrued=40,
+        saved_org_payment_accrued=10,
+        saved_payment_accrued_usd=4,
+        saved_org_payment_accrued_usd=1,
+    )
+    table = InvoiceDeliveriesTable("KES", [completed_work], show_org=True)
+
+    rows = list(table.as_values())
+    headers, values = rows[0], rows[1]
+    row = dict(zip(headers, values))
+
+    # as_values keeps numeric cells numeric (force_str strings_only=True).
+    assert row["FLW Pay (KES)"] == 40
+    assert row["Org Pay (KES)"] == 10
+    assert row["Total Pay (KES)"] == 50  # 40 + 10
+    assert row["Total Pay (USD)"] == 5  # 4 + 1
 
 
 def _make_table(opportunity, per_page=25):

--- a/commcare_connect/opportunity/utils/completed_work.py
+++ b/commcare_connect/opportunity/utils/completed_work.py
@@ -327,11 +327,12 @@ def get_invoice_items(completed_works_qs):
         .values("payment_unit", "month_approved")
         .annotate(
             payment_unit_name=F("payment_unit__name"),
-            payment_unit_amount=F("payment_unit__amount"),
             record_count=Sum("saved_approved_count"),
             currency=F("opportunity_access__opportunity__currency__code"),
-            total_amount_usd=Sum("saved_payment_accrued_usd"),
-            total_amount_local=Sum("saved_payment_accrued"),
+            flw_amount_local=Sum("saved_payment_accrued"),
+            org_amount_local=Sum("saved_org_payment_accrued"),
+            flw_amount_usd=Sum("saved_payment_accrued_usd"),
+            org_amount_usd=Sum("saved_org_payment_accrued_usd"),
         )
         .order_by("month_approved")
     )
@@ -344,18 +345,25 @@ def get_invoice_items(completed_works_qs):
         exchange_rate_cache_key = (currency, month)
 
         if exchange_rate_cache_key not in exchange_rates_by_month:
-            exchange_rate = get_exchange_rate(currency, month)
-            exchange_rates_by_month[exchange_rate_cache_key] = exchange_rate
-
+            exchange_rates_by_month[exchange_rate_cache_key] = get_exchange_rate(currency, month)
         exchange_rate = exchange_rates_by_month[exchange_rate_cache_key]
+
+        flw_local = record["flw_amount_local"] or 0
+        org_local = record["org_amount_local"] or 0
+        flw_usd = record["flw_amount_usd"] or 0
+        org_usd = record["org_amount_usd"] or 0
+
         invoice_items.append(
             {
-                "month": record["month_approved"],
+                "month": month,
                 "payment_unit_name": record["payment_unit_name"],
                 "number_approved": record["record_count"],
-                "amount_per_unit": record["payment_unit_amount"],
-                "total_amount_local": record["total_amount_local"],
-                "total_amount_usd": record["total_amount_usd"],
+                "flw_amount_local": flw_local,
+                "org_amount_local": org_local,
+                "total_amount_local": flw_local + org_local,
+                "flw_amount_usd": flw_usd,
+                "org_amount_usd": org_usd,
+                "total_amount_usd": flw_usd + org_usd,
                 "exchange_rate": exchange_rate,
                 "currency": currency,
             }

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1721,7 +1721,8 @@ class InvoiceReviewView(OrganizationUserMixin, OpportunityObjectMixin, DetailVie
         line_items_table = None
         if invoice.service_delivery:
             completed_works = get_invoiced_visit_items(invoice)
-            line_items_table = InvoiceLineItemsTable(opportunity.currency_code, completed_works)
+            show_org = any(item["org_amount_local"] for item in completed_works)
+            line_items_table = InvoiceLineItemsTable(opportunity.currency_code, completed_works, show_org=show_org)
         return AutomatedPaymentInvoiceForm(
             instance=invoice,
             opportunity=opportunity,
@@ -3246,10 +3247,11 @@ def invoice_items(request, *args, **kwargs):
     line_items = get_uninvoiced_visit_items(request.opportunity, start_date, end_date)
     total_local_amount = sum(item["total_amount_local"] for item in line_items)
     total_usd_amount = sum(item["total_amount_usd"] for item in line_items)
+    show_org = any(item["org_amount_local"] for item in line_items)
 
     html = render_to_string(
         "opportunity/partials/invoice_line_items.html",
-        {"table": InvoiceLineItemsTable(request.opportunity.currency_code, line_items)},
+        {"table": InvoiceLineItemsTable(request.opportunity.currency_code, line_items, show_org=show_org)},
         request=request,
     )
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3285,7 +3285,8 @@ def download_invoice_line_items(request, org_slug, opp_id):
     else:
         deliveries = get_uninvoiced_completed_works_qs(request.opportunity, start_date, end_date)
 
-    table = InvoiceDeliveriesTable(request.opportunity.currency_code, deliveries)
+    show_org = deliveries.filter(saved_org_payment_accrued__gt=0).exists()
+    table = InvoiceDeliveriesTable(request.opportunity.currency_code, deliveries, show_org=show_org)
     export_format = "csv"
     exporter = TableExport(export_format, table)
     filename = f"invoice_line_items_{start_date}_{end_date}.csv"


### PR DESCRIPTION
## Product Description

Service-delivery invoices now break payment into **FLW Pay**, **Org Pay**, and **Total Pay**, and the invoice's payable amount is the total (FLW + Org) rather than FLW pay alone.

On the invoice **Review** screen and the **create-invoice** line-items table, managed opportunities (those with a non-zero org amount) show three columns — FLW Pay, Org Pay, Total Pay — each localized to the opportunity's currency. Non-managed opportunities (no org pay) show a single column, now labelled **Total Pay**. The **line-items CSV download** carries the same breakdown.

### Line-items table on a managed opportunity showing FLW Pay / Org Pay / Total Pay
<img width="1557" height="501" alt="image" src="https://github.com/user-attachments/assets/e186ff6e-d8f8-443f-a7cd-88f879c68fa2" />


### Line-items of the same table if no org pay is specified for opportunity
<img width="1557" height="501" alt="image" src="https://github.com/user-attachments/assets/611dbe7e-4dbf-4956-8b21-75bf62eecc50" />


## Technical Summary

[Link to ticket](https://dimagi.atlassian.net/browse/CCCT-2470)

Org pay was already cached per `CompletedWork` (`saved_org_payment_accrued` / `_usd`) but dropped at invoicing. This change surfaces it through the line-item pipeline and folds it into the invoice amount.

- **Line-item data:** `get_invoice_items` now returns separate `flw_/org_/total_` components for both local currency and USD, with `total = flw + org`. The obsolete `amount_per_unit` key was removed.
- **Table:** `InvoiceLineItemsTable(currency, data, show_org=False)` conditionally renders the FLW/Org columns (Total Pay always shown) with currency-localized headers. The Review view and the create-page `invoice_items` endpoint set `show_org` when any line item has a non-zero org amount.
- **CSV export:** `InvoiceDeliveriesTable` (the line-items download) now mirrors the on-screen table — FLW Pay / Org Pay / Total Pay in local currency plus Total Pay (USD), replacing the single Payment Accrued columns. As this table is export-only, the FLW/Org columns are dropped via `exclude_from_export` (not `visible`) when the export contains no org pay; the download view sets `show_org` from the deliveries being exported.

### Note
This change of including org payment in the invoice amount applies to **newly created** service-delivery invoices. This was not done previously (although it should have been). I've raised this with the necessary people already and identified the invoices on production that are incorrect. We will not attempt to rectify older invoices at this point.

One other thing to note - for these incorrectly calculated invoices, reviewing the invoice will show the org payment in the table but it won't add up to the invoice amount since the invoice amount is fixed at invoice creation while the line items table is calculated on the fly. All affected invoices have been identified and the necessary communication will be made to the stakeholders involved.

## Safety Assurance

### Safety story

The change is scoped to the service-delivery invoice line-items table, its CSV export, and the service-delivery invoice amount.

Existing invoices are not modified, so already-created invoices (pending, frozen, or paid) keep their original amounts as a historical record.

### Automated test coverage

- `test_completed_work.py::test_get_invoice_items_total_includes_org_pay` — total folds in org pay for both local and USD; raw FLW/Org components are surfaced separately.
- `test_tables.py` — `InvoiceLineItemsTable` hides FLW/Org columns when `show_org=False` and shows them with currency-localized headers when `show_org=True`.
- `test_tables.py` — `InvoiceDeliveriesTable` (CSV export) hides FLW/Org columns when `show_org=False`, shows them when `show_org=True`, and its Total columns fold in org pay through the export path.

### QA Plan

No QA planned, as this change is mostly rendering.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
