### PR TITLE
Audit Report Table Improvements

### DIFF
--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -150,7 +150,6 @@ class AuditReportEntryTable(OrgContextTable):
         model = AuditReportEntry
         fields = ("user",)
         empty_text = _l("No workers.")
-        order_by = ("user",)
 
     def __init__(self, data, *, opportunity, report, columns_spec, **kw):
         self.opportunity = opportunity

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -79,6 +79,7 @@ class CalcColumn(columns.Column):
     def __init__(self, calc_name, tooltip="", **kw):
         self.calc_name = calc_name
         self.calc_tooltip = tooltip
+        kw.setdefault("attrs", {"th": {"class": "whitespace-normal align-bottom w-28"}})
         super().__init__(empty_values=(), orderable=False, **kw)
 
     @property
@@ -144,6 +145,7 @@ class AuditReportEntryTable(OrgContextTable):
     user = columns.Column(
         accessor="opportunity_access__user__name",
         verbose_name=_l("Connect Worker"),
+        attrs={"th": {"class": "whitespace-normal align-bottom w-40"}},
     )
 
     class Meta:

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -80,7 +80,7 @@ class CalcColumn(columns.Column):
         self.calc_name = calc_name
         self.calc_tooltip = tooltip
         kw.setdefault("attrs", {"th": {"class": "whitespace-normal align-bottom w-28"}})
-        super().__init__(empty_values=(), orderable=False, **kw)
+        super().__init__(empty_values=(), order_by=(f"results__{calc_name}__value",), **kw)
 
     @property
     def header(self):

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -105,7 +105,7 @@ def _detail_url(audit_opp, report):
 
 
 @pytest.mark.django_db
-def test_detail_splits_flagged_and_unflagged(client, program_manager_org_user_admin, audit_opp):
+def test_detail_lists_all_workers_in_one_table(client, program_manager_org_user_admin, audit_opp):
     client.force_login(program_manager_org_user_admin)
     report = AuditReportFactory(opportunity=audit_opp)
 
@@ -115,9 +115,12 @@ def test_detail_splits_flagged_and_unflagged(client, program_manager_org_user_ad
     response = client.get(_detail_url(audit_opp, report))
     assert response.status_code == 200
     html = response.content.decode()
-    # Both user names appear.
-    assert flagged_entry.opportunity_access.user.name in html
-    assert unflagged_entry.opportunity_access.user.name in html
+    # Both flagged and no-action workers appear in the single merged table.
+    rendered_rows = [e.opportunity_access.user.name for e in response.context["table"].page.object_list.data]
+    assert flagged_entry.opportunity_access.user.name in rendered_rows
+    assert unflagged_entry.opportunity_access.user.name in rendered_rows
+    # The flagged worker (still needing review) is ordered ahead of the no-action one.
+    assert rendered_rows[0] == flagged_entry.opportunity_access.user.name
     # Progress indicator "0 of 1 workers reviewed" — only flagged rows are counted.
     assert "0 of 1" in html
 

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -126,7 +126,7 @@ def test_detail_lists_all_workers_in_one_table(client, program_manager_org_user_
 
 
 @pytest.mark.django_db
-def test_detail_filter_limits_tables_server_side(client, program_manager_org_user_admin, audit_opp):
+def test_detail_filter_limits_table_server_side(client, program_manager_org_user_admin, audit_opp):
     client.force_login(program_manager_org_user_admin)
     report = AuditReportFactory(opportunity=audit_opp)
 
@@ -145,16 +145,19 @@ def test_detail_filter_limits_tables_server_side(client, program_manager_org_use
             results={"fake": {"value": 0.5, "has_sufficient_data": True, "in_range": False, "label": "Fake"}},
         )
 
-    # htmx-style partial request with a filter.
+    # htmx-style partial request filtered to a single selected worker.
     response = client.get(
         _detail_url(audit_opp, report),
-        {"filter": "alice"},
+        {"worker": str(alice_access.pk)},
         HTTP_HX_REQUEST="true",
     )
     assert response.status_code == 200
-    html = response.content.decode()
-    assert "Alice Smith" in html
-    assert "Bob Jones" not in html
+    rendered_rows = [e.opportunity_access.user.name for e in response.context["table"].page.object_list.data]
+    assert rendered_rows == ["Alice Smith"]
+    # Both workers remain available as filter options.
+    option_names = [name for _, name in response.context["worker_filter_choices"]]
+    assert "Alice Smith" in option_names
+    assert "Bob Jones" in option_names
 
 
 @pytest.mark.django_db

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -126,6 +126,36 @@ def test_detail_lists_all_workers_in_one_table(client, program_manager_org_user_
 
 
 @pytest.mark.django_db
+def test_detail_sorts_by_calculation_column(client, program_manager_org_user_admin, audit_opp):
+    client.force_login(program_manager_org_user_admin)
+    report = AuditReportFactory(opportunity=audit_opp)
+
+    def _scored_entry(name, value):
+        access = OpportunityAccessFactory(opportunity=audit_opp, accepted=True)
+        access.user.name = name
+        access.user.save(update_fields=["name"])
+        return AuditReportEntryFactory(
+            audit_report=report,
+            opportunity_access=access,
+            flagged=False,
+            results={"fake": {"value": value, "has_sufficient_data": True, "in_range": True, "label": "Fake"}},
+        )
+
+    _scored_entry("High", 0.9)
+    _scored_entry("Low", 0.1)
+    _scored_entry("Mid", 0.5)
+
+    response = client.get(_detail_url(audit_opp, report), {"sort": "fake"})
+    assert response.status_code == 200
+    rendered_rows = [e.opportunity_access.user.name for e in response.context["table"].page.object_list.data]
+    assert rendered_rows == ["Low", "Mid", "High"]
+
+    response = client.get(_detail_url(audit_opp, report), {"sort": "-fake"})
+    rendered_rows = [e.opportunity_access.user.name for e in response.context["table"].page.object_list.data]
+    assert rendered_rows == ["High", "Mid", "Low"]
+
+
+@pytest.mark.django_db
 def test_detail_filter_limits_table_server_side(client, program_manager_org_user_admin, audit_opp):
     client.force_login(program_manager_org_user_admin)
     report = AuditReportFactory(opportunity=audit_opp)

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -88,14 +88,18 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
     _require_feature_flag(opportunity)
     report = get_object_or_404(AuditReport, audit_report_id=audit_report_id, opportunity=opportunity)
 
-    name_filter = request.GET.get("filter", "").strip()
-    qs = report.entries.select_related("opportunity_access__user")
-    if name_filter:
-        qs = qs.filter(opportunity_access__user__name__icontains=name_filter)
-    entries = list(qs.order_by("opportunity_access__user__name"))
-
-    all_entries = list(report.entries.all())
+    all_entries = list(
+        report.entries.select_related("opportunity_access__user").order_by("opportunity_access__user__name")
+    )
     columns_spec = _column_specs(all_entries)
+
+    worker_filter_choices = [(str(e.opportunity_access_id), e.opportunity_access.user.name) for e in all_entries]
+
+    selected_workers = request.GET.getlist("worker")
+    if selected_workers:
+        entries = [e for e in all_entries if str(e.opportunity_access_id) in selected_workers]
+    else:
+        entries = list(all_entries)
 
     # If no sorting given, apply default to float workers that need review to the top of the table
     if not request.GET.get("sort"):
@@ -133,10 +137,11 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
         "opportunity": opportunity,
         "report": report,
         "table": table,
+        "worker_filter_choices": worker_filter_choices,
+        "selected_workers": selected_workers,
         "reviewed_count": reviewed_count,
         "total_flagged": total_flagged,
         "can_complete": total_flagged == reviewed_count and report.status == AuditReport.Status.PENDING,
-        "name_filter": name_filter,
         "path": path,
         "org_slug": org_slug,
     }

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -97,30 +97,21 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
     all_entries = list(report.entries.all())
     columns_spec = _column_specs(all_entries)
 
-    to_review = [e for e in entries if e.flagged and not e.reviewed]
-    no_action = [e for e in entries if not e.flagged or e.reviewed]
+    # If no sorting given, apply default to float workers that need review to the top of the table
+    if not request.GET.get("sort"):
+        entries.sort(key=lambda e: (not (e.flagged and not e.reviewed), e.opportunity_access.user.name.lower()))
 
     total_flagged = sum(1 for e in all_entries if e.flagged)
     reviewed_count = sum(1 for e in all_entries if e.flagged and e.reviewed)
 
-    review_table = AuditReportEntryTable(
-        to_review,
+    table = AuditReportEntryTable(
+        entries,
         opportunity=opportunity,
         report=report,
         columns_spec=columns_spec,
-        prefix="review-",
         org_slug=org_slug,
     )
-    no_action_table = AuditReportEntryTable(
-        no_action,
-        opportunity=opportunity,
-        report=report,
-        columns_spec=columns_spec,
-        prefix="noaction-",
-        org_slug=org_slug,
-    )
-    RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(review_table)
-    RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(no_action_table)
+    RequestConfig(request, paginate={"per_page": DEFAULT_PAGE_SIZE}).configure(table)
 
     path = [
         {"title": _("Opportunities"), "url": reverse("opportunity:list", args=(org_slug,))},
@@ -141,8 +132,7 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
     context = {
         "opportunity": opportunity,
         "report": report,
-        "review_table": review_table,
-        "no_action_table": no_action_table,
+        "table": table,
         "reviewed_count": reviewed_count,
         "total_flagged": total_flagged,
         "can_complete": total_flagged == reviewed_count and report.status == AuditReport.Status.PENDING,

--- a/commcare_connect/templates/audit/audit_report_body.html
+++ b/commcare_connect/templates/audit/audit_report_body.html
@@ -42,7 +42,6 @@
               class="button button-md primary-dark"
               {% if not can_complete %}disabled{% endif %}
               hx-post="{% url 'opportunity:audit:audit_report_complete' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
-              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               hx-swap="none"
               hx-on::after-request="if (event.detail.successful) window.location.reload()">
         {% trans "Complete Audit" %}

--- a/commcare_connect/templates/audit/audit_report_body.html
+++ b/commcare_connect/templates/audit/audit_report_body.html
@@ -3,6 +3,7 @@
 <div id="detail-body"
      hx-get="{% url 'opportunity:audit:audit_report_detail' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
      hx-trigger="refreshDetail from:body"
+     hx-include="#worker-filter"
      hx-swap="outerHTML"
      class="flex flex-col gap-4">
   <div class="metric-container flex items-center justify-between">
@@ -15,28 +16,38 @@
       <span class="text-xs text-white mt-1">{% trans "Workers reviewed" %}</span>
     </div>
   </div>
-  <div>
-    <input type="text"
-           name="filter"
-           value="{{ name_filter }}"
-           placeholder="{% trans 'Filter by worker name' %}"
-           class="base-input w-64"
-           hx-get="{% url 'opportunity:audit:audit_report_detail' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
-           hx-trigger="input changed delay:200ms, search"
-           hx-target="#detail-body"
-           hx-swap="outerHTML"
-           hx-vals='{"page": "1"}' />
+  <div class="w-64">
+    <select id="worker-filter"
+            name="worker"
+            multiple
+            data-tomselect
+            aria-label="{% trans 'Filter by worker name' %}"
+            placeholder="{% trans 'Filter by worker name' %}"
+            hx-get="{% url 'opportunity:audit:audit_report_detail' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
+            hx-trigger="change delay:300ms"
+            hx-target="#audit-table-region"
+            hx-select="#audit-table-region"
+            hx-swap="outerHTML"
+            hx-push-url="true">
+      {% for value, name in worker_filter_choices %}
+        <option value="{{ value }}"
+                {% if value in selected_workers %}selected{% endif %}>{{ name }}</option>
+      {% endfor %}
+    </select>
   </div>
-  {% render_table table %}
-  <div class="flex justify-end mt-6">
-    <button type="button"
-            class="button button-md primary-dark"
-            {% if not can_complete %}disabled{% endif %}
-            hx-post="{% url 'opportunity:audit:audit_report_complete' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
-            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-            hx-swap="none"
-            hx-on::after-request="if (event.detail.successful) window.location.reload()">
-      {% trans "Complete Audit" %}
-    </button>
+  <div id="audit-table-region" class="flex flex-col gap-4">
+    {% render_table table %}
+    <div class="flex justify-end mt-6">
+      <button type="button"
+              class="button button-md primary-dark"
+              {% if not can_complete %}disabled{% endif %}
+              hx-post="{% url 'opportunity:audit:audit_report_complete' org_slug=org_slug opp_id=opportunity.opportunity_id audit_report_id=report.audit_report_id %}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-swap="none"
+              hx-on::after-request="if (event.detail.successful) window.location.reload()">
+        {% trans "Complete Audit" %}
+      </button>
+    </div>
   </div>
+  {% include "components/tomselect_init.html" %}
 </div>

--- a/commcare_connect/templates/audit/audit_report_body.html
+++ b/commcare_connect/templates/audit/audit_report_body.html
@@ -25,12 +25,9 @@
            hx-trigger="input changed delay:200ms, search"
            hx-target="#detail-body"
            hx-swap="outerHTML"
-           hx-vals='{"review-page": "1", "noaction-page": "1"}' />
+           hx-vals='{"page": "1"}' />
   </div>
-  <h2 class="text-xl font-semibold">{% trans "Workers to Review" %}</h2>
-  {% render_table review_table %}
-  <h2 class="text-xl font-semibold mt-4">{% trans "No Action" %}</h2>
-  {% render_table no_action_table %}
+  {% render_table table %}
   <div class="flex justify-end mt-6">
     <button type="button"
             class="button button-md primary-dark"

--- a/commcare_connect/templates/audit/audit_report_detail.html
+++ b/commcare_connect/templates/audit/audit_report_detail.html
@@ -1,8 +1,16 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n static %}
 {% block title %}
   {% blocktrans with start=report.period_start %}Weekly Performance Report — {{ start }}{% endblocktrans %}
 {% endblock %}
+{% block css %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'bundles/css/tomselect.css' %}">
+{% endblock css %}
+{% block javascript %}
+  {{ block.super }}
+  <script src="{% static 'bundles/js/tomselect-bundle.js' %}"></script>
+{% endblock javascript %}
 {% block content %}
   <div class="container md:max-w-screen-2xl mx-auto flex flex-col gap-4">
     {% include 'components/breadcrumbs.html' with path=path %}


### PR DESCRIPTION
## Product Description

The weekly performance audit report's detail view has been reworked so reviewers can scan and triage all FLWs from a single, sortable table.

The previous two separate tables ("Workers to Review" and "No Action") are now one merged table listing every FLW, with workers still needing review floated to the top:
<img width="1617" height="738" alt="Screenshot_20260622_121356" src="https://github.com/user-attachments/assets/a467531d-8d7f-4152-a882-681a471bebc1" />

The worker search box in the upper-left has been replaced with a multi-select dropdown, so reviewers can filter the table to one or several specific FLWs at once:
<img width="429" height="328" alt="Screenshot_20260622_121412" src="https://github.com/user-attachments/assets/89ac832f-8de8-4a4d-9f45-efd56463a733" />

Every column is now sortable (previously only the worker-name column was), and the metric column headers wrap onto multiple lines to keep the columns narrow instead of stretching wide.


## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2482)

This is a release path 3 feature — Experiments & early stage iterations of product area.

The detail view assembles all entries into a single Python list (it must materialize the full set anyway to build the filter dropdown options and the reviewed/flagged counts), so filtering and the default "review-needed first" ordering are done in memory rather than via additional queries. The worker filter is a TomSelect multi-select that live-updates only the results table via htmx, leaving the dropdown intact while selecting.

## Safety Assurance

### Safety story

This change is low-risk: it is read-only (presentation and filtering of existing audit data only — no writes or data migrations), scoped entirely to the weekly performance report detail view, and the report itself remains gated behind the existing `WEEKLY_PERFORMANCE_REPORT` feature flag. It is fully reversible by revert.

### Automated test coverage

Tests cover the merged single table (all FLWs present, review-needed ordered first), server-side filtering by selected worker with the full worker list still offered as filter options, and ascending/descending sorting by a calculation column. Existing detail, task-modal, and complete-audit tests remain green.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
