### PR TITLE
fix(prelogin): update KMC per-newborn cost from $36 to $60

### DIFF
--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -792,8 +792,8 @@
           <span class="src-name">Connect individual-giving blog</span>
         </div>
         <div class="body">
-          <h3>$36 delivers one newborn through the Kangaroo Mother Care program.</h3>
-          <p>That covers partner engagement, the Kangaroo wraps, scales, thermometers, pulse oximeters, training, payment per verified case, and supervision. We picked it for our first individual-giving experiment because $36 is the smallest unit at which one donor can fund a complete intervention with verified delivery.</p>
+          <h3>$60 delivers one newborn through the Kangaroo Mother Care program.</h3>
+          <p>That covers partner engagement, the Kangaroo wraps, scales, thermometers, pulse oximeters, training, payment per verified case, and supervision. We picked it for our first individual-giving experiment because $60 is the smallest unit at which one donor can fund a complete intervention with verified delivery.</p>
         </div>
       </article>
       <article class="insight-row" data-programs="ecd" data-ldvp="learn">
@@ -929,7 +929,7 @@
             <h3>Kangaroo Mother Care</h3>
             <p>Home visits for small and vulnerable newborns after hospital discharge. Closes the follow-up gap with 4 to 5 visits in the first 60 days.</p>
             <div class="stat-strip">
-              <div class="ps"><div class="n">$36</div><div class="l">Per newborn</div></div>
+              <div class="ps"><div class="n">$60</div><div class="l">Per newborn</div></div>
               <div class="ps"><div class="n">5k+</div><div class="l">Cases tracked</div></div>
             </div>
             <div class="meta"><span class="more">Learn more →</span></div>
@@ -1442,7 +1442,7 @@
         <div class="hero-stats-row">
           <span class="hero-stats-tag">Program Stats</span>
           <div class="hero-stats-items">
-            <div><div class="num">$36</div><div class="label">Per newborn</div></div>
+            <div><div class="num">$60</div><div class="label">Per newborn</div></div>
             <div><div class="num">5k+</div><div class="label">Cases tracked</div></div>
             <div><div class="num">50K</div><div class="label">Uganda 2-yr case target</div></div>
           </div>
@@ -1537,8 +1537,8 @@
           <span class="src-name">Connect individual-giving blog</span>
         </div>
         <div class="body">
-          <h3>$36 delivers one newborn through the Kangaroo Mother Care program.</h3>
-          <p>That covers partner engagement, the Kangaroo wraps, scales, thermometers, pulse oximeters, training, payment per verified case, and supervision. We picked it for our first individual-giving experiment because $36 is the smallest unit at which one donor can fund a complete intervention with verified delivery.</p>
+          <h3>$60 delivers one newborn through the Kangaroo Mother Care program.</h3>
+          <p>That covers partner engagement, the Kangaroo wraps, scales, thermometers, pulse oximeters, training, payment per verified case, and supervision. We picked it for our first individual-giving experiment because $60 is the smallest unit at which one donor can fund a complete intervention with verified delivery.</p>
         </div>
       </article>
       </div>
@@ -1551,10 +1551,10 @@
   <div class="closing-cta">
     <div class="closing-inner">
       <span class="eyebrow on-dark">SUPPORT KANGAROO CARE</span>
-      <h2>$36 funds one newborn. <em>Verified delivery.</em></h2>
-      <p class="lead">$36 covers the full Connect KMC cycle for one small and vulnerable newborn: Kangaroo wraps, scales, thermometers, pulse oximeters, Frontline Worker training, payment for visits, and supervision. Every dollar is tied to a verified outcome. Individual donors, foundations, and program funders all welcome.</p>
+      <h2>$60 funds one newborn. <em>Verified delivery.</em></h2>
+      <p class="lead">$60 covers the full Connect KMC cycle for one small and vulnerable newborn: Kangaroo wraps, scales, thermometers, pulse oximeters, Frontline Worker training, payment for visits, and supervision. Every dollar is tied to a verified outcome. Individual donors, foundations, and program funders all welcome.</p>
       <div class="cta-actions">
-        <a href="https://sites.dimagi.com/support-kmc" class="btn btn-primary" target="_blank" rel="noopener">Donate $36 · Fund a Baby</a>
+        <a href="https://sites.dimagi.com/support-kmc" class="btn btn-primary" target="_blank" rel="noopener">Donate $60 · Fund a Baby</a>
         <a href="mailto:connect-kmc@dimagi.com" class="btn btn-ghost-on-dark">Design a Program</a>
       </div>
     </div>

--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -103,6 +103,7 @@
         <a href="https://connect.dimagi.com/accounts/signup/" class="btn btn-primary" target="_blank" rel="noopener">Sign Up</a>
       </div>
     </nav>
+
     <button class="nav-toggle" id="nav-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-nav">
       <span class="nav-toggle-bar"></span>
       <span class="nav-toggle-bar"></span>


### PR DESCRIPTION
## Product Description

The KMC (Kangaroo Mother Care) per-newborn cost on the marketing site has been updated from **$36 to $60** — all 9 occurrences across the homepage and portfolio detail page: stat pills, insight cards, the closing CTA, and the donate button label.

## Technical Summary

Promoted from labs ([jjackson/connect-labs#732](https://github.com/jjackson/connect-labs/pull/732)), verified at `labs.connect.dimagi.com/portfolio/kangaroo-mother-care`. Single-file change: `commcare_connect/templates/prelogin/home.html`.

## Safety Assurance

### Safety story

Staged and visually verified on labs before promotion. Pure copy change — no logic, routing, or structural modifications.

### Automated test coverage

N/A — no template unit tests for this copy change.

### QA Plan

Verify on `connect.dimagi.com/portfolio/kangaroo-mother-care` after deploy: stat pill, insight cards, CTA section, and donate button all show $60.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change