### PR TITLE
Auto-archive test opportunities 30 days after end date

### DIFF
--- a/commcare_connect/opportunity/api/views/mobile.py
+++ b/commcare_connect/opportunity/api/views/mobile.py
@@ -40,7 +40,7 @@ class OpportunityViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        return Opportunity.objects.filter(opportunityaccess__user=self.request.user)
+        return Opportunity.objects.filter(opportunityaccess__user=self.request.user, archived=False)
 
 
 class UserLearnProgressView(RetrieveAPIView):

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -433,9 +433,9 @@ class OpportunityData:
     @staticmethod
     def get_base_qs(organization, filters, program_manager=False):
         today = now().date()
-        base_filter = Q(organization=organization)
+        base_filter = Q(organization=organization, archived=False)
         if program_manager:
-            base_filter |= Q(program__organization=organization)
+            base_filter |= Q(program__organization=organization, archived=False)
         is_test = filters.get("is_test", None)
         if is_test not in ["", None]:
             base_filter &= Q(is_test=is_test)

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -433,9 +433,10 @@ class OpportunityData:
     @staticmethod
     def get_base_qs(organization, filters, program_manager=False):
         today = now().date()
-        base_filter = Q(organization=organization, archived=False)
+        base_filter = Q(organization=organization)
         if program_manager:
-            base_filter |= Q(program__organization=organization, archived=False)
+            base_filter |= Q(program__organization=organization)
+        base_filter &= Q(archived=False)
         is_test = filters.get("is_test", None)
         if is_test not in ["", None]:
             base_filter &= Q(is_test=is_test)

--- a/commcare_connect/opportunity/migrations/0135_opportunity_archived.py
+++ b/commcare_connect/opportunity/migrations/0135_opportunity_archived.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+from django_celery_beat.models import CrontabSchedule, PeriodicTask
+
+
+def create_auto_archive_test_opps_periodic_task(apps, schema_editor):
+    schedule, _ = CrontabSchedule.objects.get_or_create(
+        minute="0",
+        hour="0",
+        day_of_week="*",
+        day_of_month="*",
+        month_of_year="*",
+    )
+    PeriodicTask.objects.update_or_create(
+        name="auto_archive_test_opportunities",
+        defaults={
+            "crontab": schedule,
+            "task": "commcare_connect.opportunity.tasks.auto_archive_test_opportunities",
+        },
+    )
+
+
+def delete_auto_archive_test_opps_periodic_task(apps, schema_editor):
+    PeriodicTask.objects.filter(name="auto_archive_test_opportunities").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("opportunity", "0134_add_program_fk_to_opportunity"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="opportunity",
+            name="archived",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(
+            create_auto_archive_test_opps_periodic_task,
+            delete_auto_archive_test_opps_periodic_task,
+            hints={"run_on_secondary": False},
+        ),
+    ]

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -113,6 +113,7 @@ class Opportunity(BaseModel):
     auto_approve_payments = models.BooleanField(default=True)
     automatic_visit_verification = models.BooleanField(default=False)
     is_test = models.BooleanField(default=True)
+    archived = models.BooleanField(default=False)
     delivery_type = models.ForeignKey(DeliveryType, null=True, blank=True, on_delete=models.DO_NOTHING)
     managed = models.BooleanField(default=False)
     program = models.ForeignKey("program.Program", on_delete=models.DO_NOTHING, null=True)
@@ -220,7 +221,7 @@ class Opportunity(BaseModel):
 
     @property
     def is_active(self):
-        return bool(self.active and self.end_date and self.end_date >= now().date())
+        return bool(not self.archived and self.active and self.end_date and self.end_date >= now().date())
 
     @property
     def has_ended(self):

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -276,6 +276,12 @@ def auto_deactivate_ended_opportunities():
         opportunities.update(active=False)
 
 
+@celery_app.task()
+def auto_archive_test_opportunities():
+    cutoff = datetime.date.today() - datetime.timedelta(days=OPPORTUNITY_AUTO_DEACTIVATION_DAYS)
+    Opportunity.objects.filter(is_test=True, archived=False, end_date__lte=cutoff).update(archived=True)
+
+
 def _get_inactive_message(access: OpportunityAccess):
     has_claimed_opportunity = OpportunityClaim.objects.filter(opportunity_access=access).exists()
     if has_claimed_opportunity:

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -73,6 +73,7 @@ from config import celery_app
 logger = logging.getLogger(__name__)
 
 OPPORTUNITY_AUTO_DEACTIVATION_DAYS = 30
+OPPORTUNITY_AUTO_ARCHIVE_DAYS = 30
 SYSTEM = "system"
 
 
@@ -278,7 +279,7 @@ def auto_deactivate_ended_opportunities():
 
 @celery_app.task()
 def auto_archive_test_opportunities():
-    cutoff = datetime.date.today() - datetime.timedelta(days=OPPORTUNITY_AUTO_DEACTIVATION_DAYS)
+    cutoff = datetime.date.today() - datetime.timedelta(days=OPPORTUNITY_AUTO_ARCHIVE_DAYS)
     Opportunity.objects.filter(is_test=True, archived=False, end_date__lte=cutoff).update(archived=True)
 
 

--- a/commcare_connect/opportunity/tests/test_api_views.py
+++ b/commcare_connect/opportunity/tests/test_api_views.py
@@ -224,6 +224,20 @@ def test_opportunity_list_endpoint(
     assert all(all(field in unit for field in payment_unit_fields) for unit in payment_units)
 
 
+@pytest.mark.django_db
+def test_opportunity_list_endpoint_excludes_archived(
+    mobile_user_with_connect_link: User,
+    api_client: APIClient,
+    opportunity: Opportunity,
+):
+    opportunity.archived = True
+    opportunity.save()
+    api_client.force_authenticate(mobile_user_with_connect_link)
+    response = api_client.get("/api/opportunity/")
+    assert response.status_code == 200
+    assert len(response.data) == 0
+
+
 def test_delivery_progress_endpoint(
     mobile_user_with_connect_link: User, api_client: APIClient, opportunity: Opportunity
 ):

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -23,6 +23,7 @@ from commcare_connect.opportunity.models import (
 from commcare_connect.opportunity.tasks import (
     _get_inactive_message,
     add_connect_users,
+    auto_archive_test_opportunities,
     auto_deactivate_ended_opportunities,
     download_inaccessibility_request_attachments,
     download_user_visit_attachments,
@@ -427,6 +428,42 @@ class TestAutoDeactivateEndedOpportunities:
             deactivation_event.pgh_context.metadata["action"]
             == "commcare_connect.opportunity.tasks.auto_deactivate_ended_opportunities"
         )
+
+
+@pytest.mark.django_db
+class TestAutoArchiveTestOpportunities:
+    def test_archives_test_opps_30_days_after_end(self):
+        cutoff = datetime.date.today() - datetime.timedelta(days=30)
+        opp_to_archive = OpportunityFactory(is_test=True, archived=False, end_date=cutoff)
+        opp_not_yet_ended = OpportunityFactory(is_test=True, archived=False, end_date=datetime.date.today())
+        opp_already_archived = OpportunityFactory(is_test=True, archived=True, end_date=cutoff)
+        opp_not_test = OpportunityFactory(is_test=False, archived=False, end_date=cutoff)
+
+        auto_archive_test_opportunities()
+
+        opp_to_archive.refresh_from_db()
+        opp_not_yet_ended.refresh_from_db()
+        opp_already_archived.refresh_from_db()
+        opp_not_test.refresh_from_db()
+
+        assert opp_to_archive.archived is True
+        assert opp_not_yet_ended.archived is False
+        assert opp_already_archived.archived is True  # unchanged
+        assert opp_not_test.archived is False
+
+    @pytest.mark.parametrize(
+        "is_test,end_date,expected_archived",
+        [
+            (True, datetime.date.today() - datetime.timedelta(days=30), True),
+            (True, datetime.date.today() - datetime.timedelta(days=29), False),
+            (False, datetime.date.today() - datetime.timedelta(days=30), False),
+        ],
+    )
+    def test_archive_boundary_conditions(self, is_test, end_date, expected_archived):
+        opp = OpportunityFactory(is_test=is_test, archived=False, end_date=end_date)
+        auto_archive_test_opportunities()
+        opp.refresh_from_db()
+        assert opp.archived is expected_archived
 
 
 @mock.patch("commcare_connect.opportunity.tasks.send_message")

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -21,6 +21,7 @@ from commcare_connect.opportunity.models import (
     UserInvite,
 )
 from commcare_connect.opportunity.tasks import (
+    OPPORTUNITY_AUTO_ARCHIVE_DAYS,
     _get_inactive_message,
     add_connect_users,
     auto_archive_test_opportunities,
@@ -432,34 +433,16 @@ class TestAutoDeactivateEndedOpportunities:
 
 @pytest.mark.django_db
 class TestAutoArchiveTestOpportunities:
-    def test_archives_test_opps_30_days_after_end(self):
-        cutoff = datetime.date.today() - datetime.timedelta(days=30)
-        opp_to_archive = OpportunityFactory(is_test=True, archived=False, end_date=cutoff)
-        opp_not_yet_ended = OpportunityFactory(is_test=True, archived=False, end_date=datetime.date.today())
-        opp_already_archived = OpportunityFactory(is_test=True, archived=True, end_date=cutoff)
-        opp_not_test = OpportunityFactory(is_test=False, archived=False, end_date=cutoff)
-
-        auto_archive_test_opportunities()
-
-        opp_to_archive.refresh_from_db()
-        opp_not_yet_ended.refresh_from_db()
-        opp_already_archived.refresh_from_db()
-        opp_not_test.refresh_from_db()
-
-        assert opp_to_archive.archived is True
-        assert opp_not_yet_ended.archived is False
-        assert opp_already_archived.archived is True  # unchanged
-        assert opp_not_test.archived is False
-
     @pytest.mark.parametrize(
-        "is_test,end_date,expected_archived",
+        "is_test,days_ago,expected_archived",
         [
-            (True, datetime.date.today() - datetime.timedelta(days=30), True),
-            (True, datetime.date.today() - datetime.timedelta(days=29), False),
-            (False, datetime.date.today() - datetime.timedelta(days=30), False),
+            (True, OPPORTUNITY_AUTO_ARCHIVE_DAYS, True),
+            (True, OPPORTUNITY_AUTO_ARCHIVE_DAYS - 1, False),
+            (False, OPPORTUNITY_AUTO_ARCHIVE_DAYS, False),
         ],
     )
-    def test_archive_boundary_conditions(self, is_test, end_date, expected_archived):
+    def test_archive_boundary_conditions(self, is_test, days_ago, expected_archived):
+        end_date = datetime.date.today() - datetime.timedelta(days=days_ago)
         opp = OpportunityFactory(is_test=is_test, archived=False, end_date=end_date)
         auto_archive_test_opportunities()
         opp.refresh_from_db()

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -644,6 +644,16 @@ def test_get_opportunity_list_data_all_annotations(organization, filters, expect
 
 
 @pytest.mark.django_db
+def test_opportunity_list_excludes_archived(organization):
+    today = now().date()
+    OpportunityFactory(organization=organization, end_date=today + timedelta(days=1), active=True, archived=False)
+    OpportunityFactory(organization=organization, end_date=today + timedelta(days=1), active=True, archived=True)
+
+    queryset = OpportunityData(organization, False, {}).get_data()
+    assert queryset.count() == 1
+
+
+@pytest.mark.django_db
 def test_tiered_queryset_basic():
     users = [User.objects.create(username=f"user{i}") for i in range(5)]
     user_ids = [u.id for u in users]


### PR DESCRIPTION
## Product Description

Test opportunities are archived automatically 30 days after their end date and hidden from the opportunity list and mobile API.

## Technical Summary

[CCCT-2469](https://dimagi.atlassian.net/browse/CCCT-2469)

- `archived` and `active` are separate flags that coexist. The deactivation job is unchanged; this only touches `is_test=True` rows.
- The migration also registers the periodic task

## Safety Assurance

### Safety story

`archived` defaults to `False`, so no existing data changes on deploy. Only `is_test=True` rows get touched. Confirmed locally.

### Automated test coverage

Tests added for the archive task and both list contexts; all passing.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CCCT-2469]: https://dimagi.atlassian.net/browse/CCCT-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ