### PR TITLE
Apply Correct Auth for Adding Credentials

### DIFF
--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -44,7 +44,8 @@ def send_message_bulk(messages: list[Message]) -> MessagingBulkResponse:
 
 def add_credentials(credentials_items: list[dict]):
     json = {"credentials": credentials_items}
-    response = _make_request(POST, "/users/add_credential", json=json, timeout=30)
+    auth = BasicAuth(settings.CONNECTID_CREDENTIALS_CLIENT_ID, settings.CONNECTID_CREDENTIALS_CLIENT_SECRET)
+    response = _make_request(POST, "/users/add_credential", json=json, timeout=30, auth=auth)
     return response.json()
 
 
@@ -92,11 +93,11 @@ def get_user_otp(phone_number):
         raise
 
 
-def _make_request(method, path, params=None, json=None, timeout=5) -> Response:
+def _make_request(method, path, params=None, json=None, timeout=5, auth=None) -> Response:
     if json and not method == "POST":
         raise ValueError("json can only be used with POST requests")
-
-    auth = BasicAuth(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_CLIENT_SECRET)
+    if not auth:
+        auth = BasicAuth(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_CLIENT_SECRET)
     response = httpx.request(
         method, f"{settings.CONNECTID_URL}{path}", params=params, json=json, auth=auth, timeout=timeout
     )


### PR DESCRIPTION
## Product Description

No user-facing changes. This is a backend-only change to how CommCare Connect authenticates with the PersonalID service when adding user credentials.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-1942)

This is a release path 1 feature — Improvements to existing features & quick wins

The `add_credential` endpoint on ConnectID requires a dedicated set of client credentials rather than the default ConnectID client used by all other requests. To support this, `_make_request` now accepts an optional `auth` argument, falling back to the default `CONNECTID_CLIENT_ID`/`CONNECTID_CLIENT_SECRET` when none is supplied, while `add_credentials` passes a `BasicAuth` built from the new `CONNECTID_CREDENTIALS_CLIENT_ID`/`CONNECTID_CREDENTIALS_CLIENT_SECRET` settings.

Without applying this specific client credentials, the user credentials on PersonalID default to having the issuing auth be staging, which is incorrect for user creds added from Connect prod.

## Safety Assurance

### Safety story

The change is low-risk and narrowly scoped: it only alters which credentials are sent for the single `add_credential` call, and all other PersonalID requests continue to use the default auth via the unchanged fallback path. The new settings default to empty strings, so deployment requires the corresponding environment variables to be configured.

### Automated test coverage

No new automated tests were added; the change relies on the existing `_make_request` behaviour, which is unchanged for all callers that do not pass `auth`.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
