### PR TITLE
[fix] use django URLs for pre-login auth links instead of static URLs

### DIFF
--- a/commcare_connect/prelogin/tests/test_views.py
+++ b/commcare_connect/prelogin/tests/test_views.py
@@ -17,15 +17,6 @@ class TestPreloginHome:
         assert resp.status_code == 200
         assert b"Connect by Dimagi" in resp.content
 
-    def test_login_url_defaults_to_accounts_login(self, client):
-        resp = client.get(reverse("prelogin:home"))
-        assert resp.context["app_login_url"] == "/accounts/login/"
-
-    def test_login_url_respects_setting_override(self, client, settings):
-        settings.PRELOGIN_APP_LOGIN_URL = "/custom/login/"
-        resp = client.get(reverse("prelogin:home"))
-        assert resp.context["app_login_url"] == "/custom/login/"
-
 
 class TestMarketingRoutes:
     """Every clean-URL route renders the SPA template server-side so a direct
@@ -37,7 +28,6 @@ class TestMarketingRoutes:
     def test_marketing_route_renders(self, client, name):
         resp = client.get(reverse(f"prelogin:{name}"))
         assert resp.status_code == 200
-        assert resp.context["app_login_url"] == "/accounts/login/"
 
     def test_portfolio_detail_renders(self, client):
         resp = client.get("/portfolio/kangaroo-mother-care")
@@ -63,7 +53,3 @@ class TestContactPage:
         content = pathlib.Path(path).read_text()
         assert "503070" in content  # portalId
         assert "ca08edba-5d8f-4386-b5e9-d6b026c14599" in content  # formId
-
-    def test_contact_login_url_in_context(self, client):
-        resp = client.get("/contact/")
-        assert resp.context["app_login_url"] == "/accounts/login/"

--- a/commcare_connect/prelogin/urls.py
+++ b/commcare_connect/prelogin/urls.py
@@ -10,9 +10,8 @@ app_name = "prelogin"
 # home.html. Server-side we must still list each route, otherwise a direct
 # load or refresh of e.g. /platform hits Django (not the router) and 404s.
 #
-# All routes go through views.home (HomeView) — not a bare TemplateView — so
-# {{ app_login_url }} is supplied on every page, not just "/". Keep this list
-# in sync with the data-page routes in index.html upstream
+# All routes go through views.home (HomeView) — not a bare TemplateView.
+# Keep this list in sync with the data-page routes in index.html upstream
 # (dimagi-internal/connect-prelogin) and with sitemap.xml.
 #
 # Do NOT use a blanket catch-all: this host also serves the real app

--- a/commcare_connect/prelogin/views.py
+++ b/commcare_connect/prelogin/views.py
@@ -1,14 +1,8 @@
-from django.conf import settings
 from django.views.generic import TemplateView
 
 
 class HomeView(TemplateView):
     template_name = "prelogin/home.html"
-
-    def get_context_data(self, **kwargs):
-        ctx = super().get_context_data(**kwargs)
-        ctx["app_login_url"] = getattr(settings, "PRELOGIN_APP_LOGIN_URL", "/accounts/login/")
-        return ctx
 
 
 class ContactView(HomeView):

--- a/commcare_connect/templates/prelogin/contact.html
+++ b/commcare_connect/templates/prelogin/contact.html
@@ -107,8 +107,8 @@
           <a href="{% url 'prelogin:portfolio' %}">Portfolio</a>
           <a href="{% url 'prelogin:frontline-network' %}">Frontline Network</a>
           <div class="nav-cta">
-            <a href="{{ app_login_url }}" class="btn btn-ghost">Sign In</a>
-            <a href="{% url 'account_signup' %}" class="btn btn-primary">Sign Up</a>
+            <a href="{% url "account_login" %}" class="btn btn-ghost">Sign In</a>
+            <a href="{% url "account_signup" %}" class="btn btn-primary">Sign Up</a>
           </div>
         </nav>
         <button class="nav-toggle"
@@ -126,8 +126,8 @@
         <a href="{% url 'prelogin:platform' %}">Platform</a>
         <a href="{% url 'prelogin:portfolio' %}">Portfolio</a>
         <a href="{% url 'prelogin:frontline-network' %}">Frontline Network</a>
-        <a href="{{ app_login_url }}" class="mobile-nav-cta-secondary">Sign In</a>
-        <a href="{% url 'account_signup' %}" class="mobile-nav-cta">Sign Up</a>
+        <a href="{% url "account_login" %}" class="mobile-nav-cta-secondary">Sign In</a>
+        <a href="{% url "account_signup" %}" class="mobile-nav-cta">Sign Up</a>
       </nav>
     </header>
     <main id="main">
@@ -254,10 +254,10 @@
               <a href="{% url 'prelogin:release-notes' %}">Release Notes</a>
             </li>
             <li>
-              <a href="{% url 'account_signup' %}">Sign Up</a>
+              <a href="{% url "account_signup" %}">Sign Up</a>
             </li>
             <li>
-              <a href="{{ app_login_url }}">Sign In</a>
+              <a href="{% url "account_login" %}">Sign In</a>
             </li>
           </ul>
         </div>

--- a/commcare_connect/templates/prelogin/contact.html
+++ b/commcare_connect/templates/prelogin/contact.html
@@ -107,8 +107,8 @@
           <a href="{% url 'prelogin:portfolio' %}">Portfolio</a>
           <a href="{% url 'prelogin:frontline-network' %}">Frontline Network</a>
           <div class="nav-cta">
-            <a href="{% url "account_login" %}" class="btn btn-ghost">Sign In</a>
-            <a href="{% url "account_signup" %}" class="btn btn-primary">Sign Up</a>
+            <a href="{% url 'account_login' %}" class="btn btn-ghost">Sign In</a>
+            <a href="{% url 'account_signup' %}" class="btn btn-primary">Sign Up</a>
           </div>
         </nav>
         <button class="nav-toggle"
@@ -126,8 +126,8 @@
         <a href="{% url 'prelogin:platform' %}">Platform</a>
         <a href="{% url 'prelogin:portfolio' %}">Portfolio</a>
         <a href="{% url 'prelogin:frontline-network' %}">Frontline Network</a>
-        <a href="{% url "account_login" %}" class="mobile-nav-cta-secondary">Sign In</a>
-        <a href="{% url "account_signup" %}" class="mobile-nav-cta">Sign Up</a>
+        <a href="{% url 'account_login' %}" class="mobile-nav-cta-secondary">Sign In</a>
+        <a href="{% url 'account_signup' %}" class="mobile-nav-cta">Sign Up</a>
       </nav>
     </header>
     <main id="main">
@@ -254,10 +254,10 @@
               <a href="{% url 'prelogin:release-notes' %}">Release Notes</a>
             </li>
             <li>
-              <a href="{% url "account_signup" %}">Sign Up</a>
+              <a href="{% url 'account_signup' %}">Sign Up</a>
             </li>
             <li>
-              <a href="{% url "account_login" %}">Sign In</a>
+              <a href="{% url 'account_login' %}">Sign In</a>
             </li>
           </ul>
         </div>

--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -99,8 +99,8 @@
       <a href="/portfolio" data-route="/portfolio">Portfolio</a>
       <a href="/frontline-network" data-route="/frontline-network">Frontline Network</a>
       <div class="nav-cta">
-        <a href="{% url "account_login" %}" class="btn btn-ghost">Sign In</a>
-        <a href="{% url "account_signup" %}" class="btn btn-primary" target="_blank" rel="noopener">Sign Up</a>
+        <a href="{% url 'account_login' %}" class="btn btn-ghost">Sign In</a>
+        <a href="{% url 'account_signup' %}" class="btn btn-primary" target="_blank" rel="noopener">Sign Up</a>
       </div>
     </nav>
 
@@ -115,8 +115,8 @@
     <a href="/platform" data-route="/platform">Platform</a>
     <a href="/portfolio" data-route="/portfolio">Portfolio</a>
     <a href="/frontline-network" data-route="/frontline-network">Frontline Network</a>
-    <a href="{% url "account_login" %}" class="mobile-nav-cta-secondary">Sign In</a>
-    <a href="{% url "account_signup" %}" class="mobile-nav-cta" target="_blank" rel="noopener">Sign Up</a>
+    <a href="{% url 'account_login' %}" class="mobile-nav-cta-secondary">Sign In</a>
+    <a href="{% url 'account_signup' %}" class="mobile-nav-cta" target="_blank" rel="noopener">Sign Up</a>
   </nav>
 </header>
 <main id="main">
@@ -3515,8 +3515,8 @@
       <ul>
         <li><a href="https://dimagi.atlassian.net/wiki/spaces/connectpublic/overview?homepageId=3145401509" target="_blank" rel="noopener">Help Site ↗</a></li>
         <li><a href="/release-notes">Release Notes</a></li>
-        <li><a href="{% url "account_signup" %}" target="_blank" rel="noopener">Sign Up</a></li>
-        <li><a href="{% url "account_login" %}">Sign In</a></li>
+        <li><a href="{% url 'account_signup' %}" target="_blank" rel="noopener">Sign Up</a></li>
+        <li><a href="{% url 'account_login' %}">Sign In</a></li>
       </ul>
     </div>
     <div class="foot-col">

--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -99,8 +99,8 @@
       <a href="/portfolio" data-route="/portfolio">Portfolio</a>
       <a href="/frontline-network" data-route="/frontline-network">Frontline Network</a>
       <div class="nav-cta">
-        <a href="{{ app_login_url }}" class="btn btn-ghost">Sign In</a>
-        <a href="https://connect.dimagi.com/accounts/signup/" class="btn btn-primary" target="_blank" rel="noopener">Sign Up</a>
+        <a href="{% url "account_login" %}" class="btn btn-ghost">Sign In</a>
+        <a href="{% url "account_signup" %}" class="btn btn-primary" target="_blank" rel="noopener">Sign Up</a>
       </div>
     </nav>
 
@@ -115,8 +115,8 @@
     <a href="/platform" data-route="/platform">Platform</a>
     <a href="/portfolio" data-route="/portfolio">Portfolio</a>
     <a href="/frontline-network" data-route="/frontline-network">Frontline Network</a>
-    <a href="{{ app_login_url }}" class="mobile-nav-cta-secondary">Sign In</a>
-    <a href="https://connect.dimagi.com/accounts/signup/" class="mobile-nav-cta" target="_blank" rel="noopener">Sign Up</a>
+    <a href="{% url "account_login" %}" class="mobile-nav-cta-secondary">Sign In</a>
+    <a href="{% url "account_signup" %}" class="mobile-nav-cta" target="_blank" rel="noopener">Sign Up</a>
   </nav>
 </header>
 <main id="main">
@@ -3515,8 +3515,8 @@
       <ul>
         <li><a href="https://dimagi.atlassian.net/wiki/spaces/connectpublic/overview?homepageId=3145401509" target="_blank" rel="noopener">Help Site ↗</a></li>
         <li><a href="/release-notes">Release Notes</a></li>
-        <li><a href="https://connect.dimagi.com/accounts/signup/" target="_blank" rel="noopener">Sign Up</a></li>
-        <li><a href="{{ app_login_url }}">Sign In</a></li>
+        <li><a href="{% url "account_signup" %}" target="_blank" rel="noopener">Sign Up</a></li>
+        <li><a href="{% url "account_login" %}">Sign In</a></li>
       </ul>
     </div>
     <div class="foot-col">


### PR DESCRIPTION
## Product Description
This fixes the signup URLs on staging which currently point to the production instance.

## Technical Summary
Use Django resolved URLs instead of hard coded URLs. This also removes references to the `PRELOGIN_APP_LOGIN_URL` which seems unused.

## Safety Assurance

### Safety story
Tested locally. The views are also covered by basic tests.

### Automated test coverage
Basic coverage.

### QA Plan
None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
