### PR TITLE
Fix Visit Panel Height

### DIFF
--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -26,12 +26,14 @@
         {% if can_manage_tasks %}
           <button type="button"
                   class="button-icon shadow-sm"
+                  aria-label="{% trans 'Create Task' %}"
                   @click.stop="showCreateTaskModal = true"
                   x-tooltip.raw="{% trans 'Create Task' %}">
             <i class="fa-solid fa-plus text-brand-deep-purple"></i>
           </button>
           <button type="button"
                   class="button-icon hover:bg-red-600 hover:text-white shadow-sm"
+                  aria-label="{% trans 'Delete Task(s)' %}"
                   @click="$store.confirmModal.show({ title: '{% trans "Delete Tasks" %}', message: `{% blocktrans %}Are you sure you want to delete __count__ task(s)? This action can not be undone.{% endblocktrans %}`.replace('__count__', selected.length), confirmBtnText: '{% trans "Delete" %}', confirmBtnRed: true, formRef: $refs.deleteTasksForm })"
                   :disabled="selected.length === 0"
                   x-tooltip.raw="{% trans 'Delete Task(s)' %}">

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -22,7 +22,22 @@
     {% include "components/worker_page/worker_profile_kpi.html" %}
     <div class="relative">
       {% include 'components/worker_page/visit_task_tabs.html' %}
-      <div class="absolute right-4 top-1/2 -translate-y-1/2">
+      <div class="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-2">
+        {% if can_manage_tasks %}
+          <button type="button"
+                  class="button-icon shadow-sm"
+                  @click.stop="showCreateTaskModal = true"
+                  x-tooltip.raw="{% trans 'Create Task' %}">
+            <i class="fa-solid fa-plus text-brand-deep-purple"></i>
+          </button>
+          <button type="button"
+                  class="button-icon hover:bg-red-600 hover:text-white shadow-sm"
+                  @click="$store.confirmModal.show({ title: '{% trans "Delete Tasks" %}', message: `{% blocktrans %}Are you sure you want to delete __count__ task(s)? This action can not be undone.{% endblocktrans %}`.replace('__count__', selected.length), confirmBtnText: '{% trans "Delete" %}', confirmBtnRed: true, formRef: $refs.deleteTasksForm })"
+                  :disabled="selected.length === 0"
+                  x-tooltip.raw="{% trans 'Delete Task(s)' %}">
+            <i class="fa-solid fa-trash"></i>
+          </button>
+        {% endif %}
         <button type="button"
                 @click="showFilterModal = true"
                 class="relative button-icon shadow-sm">
@@ -35,6 +50,17 @@
         </button>
       </div>
     </div>
+    {% if can_manage_tasks %}
+      <form x-ref="deleteTasksForm"
+            hx-post="{{ delete_tasks_url }}"
+            hx-trigger="submit"
+            class="hidden">
+        {% csrf_token %}
+        <template x-for="id in selected">
+          <input type="hidden" name="task_ids" :value="id">
+        </template>
+      </form>
+    {% endif %}
     <div x-show="showFilterModal" x-cloak class="modal-backdrop">
       <div class="modal">
         <div class="header text-lg font-semibold text-brand-deep-purple">
@@ -59,7 +85,7 @@
       </div>
     </div>
     {% include "components/tomselect_init.html" %}
-    <div class="w-full grid grid-cols-10 gap-2">
+    <div class="w-full grid grid-cols-10 gap-2 min-h-[600px]">
       <div class="col-span-6" hx-indicator="#loading-spinner">
         <div class="w-full"
              hx-get="{% url 'opportunity:user_tasks_table' request.org.slug opportunity.opportunity_id %}{% querystring %}"
@@ -118,33 +144,6 @@
             </div>
           </div>
         </div>
-        {% if can_manage_tasks %}
-          <div class="flex gap-4 items-center justify-start mt-4">
-            <form x-ref="deleteTasksForm"
-                  hx-post="{{ delete_tasks_url }}"
-                  hx-trigger="submit"
-                  class="hidden">
-              {% csrf_token %}
-              <template x-for="id in selected">
-                <input type="hidden" name="task_ids" :value="id">
-              </template>
-            </form>
-            <button type="button"
-                    class="button button-md primary-dark"
-                    @click.stop="showCreateTaskModal = true">
-              <i class="fa-solid fa-plus mr-2"></i>
-              {% trans "Create Task" %}
-            </button>
-            <button type="button"
-                    class="button button-md bg-red-600 hover:bg-red-700 text-white"
-                    @click="$store.confirmModal.show({ title: '{% trans "Delete Tasks" %}', message: '{% trans "Are you sure you want to delete these tasks? This action can not be undone." %}', confirmBtnText: '{% trans "Delete" %}', confirmBtnRed: true, formRef: $refs.deleteTasksForm, })"
-                    :disabled="selected.length === 0">
-              <i class="fa-solid fa-trash mr-2"></i>
-              <span x-text="selected.length === 0 ? '{% trans "Delete Tasks" %}' : selected.length === 1 ? '{% trans "Delete 1 Task" %}' : '{% trans "Delete" %} ' + selected.length + ' {% trans "Tasks" %}'">
-              </span>
-            </button>
-          </div>
-        {% endif %}
       </div>
       <div class="col-span-4 relative" hx-indicator="#task-loading-indicator">
         <div class="absolute inset-0">

--- a/commcare_connect/templates/opportunity/user_visit_verification.html
+++ b/commcare_connect/templates/opportunity/user_visit_verification.html
@@ -18,7 +18,7 @@
     {% if show_worker_tasks_tabs %}
       {% include 'components/worker_page/visit_task_tabs.html' %}
     {% endif %}
-    <div class="w-full grid grid-cols-10 gap-2">
+    <div class="w-full grid grid-cols-10 gap-2 min-h-[600px]">
       <div class="col-span-6" hx-indicator="#loading-spinner">
         <div hx-get="{% url 'opportunity:user_visit_verification_table' request.org.slug opportunity.opportunity_id %}{% querystring %}"
              hx-trigger="load"


### PR DESCRIPTION
## Product Description

<video controls width="100%" src="https://github.com/user-attachments/assets/5217e480-328e-4585-b94c-0006a2beb424"></video>

## Technical Summary
https://dimagi.atlassian.net/browse/CI-726

While investigating the issue, I traced it back to PR #1184, where `min-height` was removed to keep the task actions visible. The real issue was the button placement, not the panel height.

This change:

* Restores `min-h-[600px]` on the visit and task detail panels.
* Moves "Create Task" and "Delete Tasks" into the tab bar as icon buttons with tooltips, matching the existing pattern.

## Safety Assurance

### Safety story

Template-only change. No backend logic changed; the buttons still use the same Alpine.js handlers and HTMX endpoints.

### Automated test coverage

No tests added. UI-only change.

### QA Plan

Verified locally that the panel height is consistent, the actions remain visible, and both buttons work as expected.

### Labels & Review

* [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
