### PR TITLE
Audit Review Username Fallback

### DIFF
--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -1,3 +1,5 @@
+from django.db.models import Value
+from django.db.models.functions import Coalesce, NullIf
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
@@ -22,7 +24,6 @@ class AuditReportTable(OrgContextTable):
         accessor="completed_by",
         verbose_name=_l("Reviewer"),
         default="—",
-        order_by=("completed_by__name", "completed_by__username"),
         orderable=True,
     )
     view = columns.Column(
@@ -54,6 +55,11 @@ class AuditReportTable(OrgContextTable):
 
     def render_reviewer(self, value):
         return value.name or value.username
+
+    def order_reviewer(self, queryset, is_descending):
+        reviewer_display = Coalesce(NullIf("completed_by__name", Value("")), "completed_by__username")
+        queryset = queryset.order_by(reviewer_display.desc() if is_descending else reviewer_display.asc())
+        return queryset, True
 
     def render_view(self, record):
         url = reverse(

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -19,9 +19,10 @@ class AuditReportTable(OrgContextTable):
     )
     status = columns.Column(verbose_name=_l("Status"))
     reviewer = columns.Column(
-        accessor="completed_by__name",
+        accessor="completed_by",
         verbose_name=_l("Reviewer"),
         default="—",
+        order_by=("completed_by__name", "completed_by__username"),
         orderable=True,
     )
     view = columns.Column(
@@ -50,6 +51,9 @@ class AuditReportTable(OrgContextTable):
             modifier = "warning-dark"
             label = _("Pending")
         return format_html('<span class="badge badge-md {}">{}</span>', modifier, label)
+
+    def render_reviewer(self, value):
+        return value.name or value.username
 
     def render_view(self, record):
         url = reverse(

--- a/commcare_connect/audit/tests/test_tables.py
+++ b/commcare_connect/audit/tests/test_tables.py
@@ -1,6 +1,8 @@
 import pytest
 
+from commcare_connect.audit.models import AuditReport
 from commcare_connect.audit.tables import AuditReportTable
+from commcare_connect.audit.tests.factories import AuditReportFactory
 from commcare_connect.opportunity.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -20,3 +22,16 @@ def test_render_reviewer_falls_back_to_username(name, username, expected):
 
 def test_reviewer_column_default_for_no_reviewer():
     assert AuditReportTable([]).base_columns["reviewer"].default == "—"
+
+
+@pytest.mark.parametrize("is_descending,expected", [(False, ["amy", "Bob", "zach"]), (True, ["zach", "Bob", "amy"])])
+def test_order_reviewer_uses_username_fallback(is_descending, expected):
+    # name="" sorts by username ("amy"), so blank-name reviewers interleave with named ones.
+    AuditReportFactory(completed_by=UserFactory(name="", username="amy"))
+    AuditReportFactory(completed_by=UserFactory(name="Bob", username="zzz_bob"))
+    AuditReportFactory(completed_by=UserFactory(name="", username="zach"))
+
+    ordered, applied = AuditReportTable([]).order_reviewer(AuditReport.objects.all(), is_descending)
+
+    assert applied is True
+    assert [r.completed_by.name or r.completed_by.username for r in ordered] == expected

--- a/commcare_connect/audit/tests/test_tables.py
+++ b/commcare_connect/audit/tests/test_tables.py
@@ -1,0 +1,22 @@
+import pytest
+
+from commcare_connect.audit.tables import AuditReportTable
+from commcare_connect.opportunity.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    "name,username,expected",
+    [
+        ("Jane Auditor", "jane", "Jane Auditor"),
+        ("", "jane", "jane"),
+    ],
+)
+def test_render_reviewer_falls_back_to_username(name, username, expected):
+    user = UserFactory.build(name=name, username=username)
+    assert AuditReportTable([]).render_reviewer(user) == expected
+
+
+def test_reviewer_column_default_for_no_reviewer():
+    assert AuditReportTable([]).base_columns["reviewer"].default == "—"


### PR DESCRIPTION
## Product Description

The "Reviewer" column on the audit report list now shows the reviewer's username when their name field is blank, instead of displaying a placeholder dash. Previously, audit reports that were marked complete by a user without a populated name appeared to have no reviewer at all.

<img width="1596" height="458" alt="Screenshot_20260630_110937" src="https://github.com/user-attachments/assets/182c6424-8b1d-45d8-a7e5-b2b73fd28192" />

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2593)

This is a release path 3 feature — Experiments & early stage iterations of product area.

Web users that auth via CommCare HQ SSO can have a null `name` field if their associated HQ account has no first/last name. This results in a default "---" being shown on the audit review table, falsely indicating that there was no reviewer for a reviewed audit. Falling back to a user's username allows for still displaying something on the reviewer column in cases where the user's name field is blank.

## Safety Assurance

### Safety story

This is a read-only, display-only change to a single django-tables2 column — it alters no data, models, or migrations and only affects how the reviewer is rendered in the audit report list. A null `completed_by` continues to render the existing "—" placeholder, so behaviour for reports without a reviewer is unchanged.

### Automated test coverage

Tests cover the reviewer column's rendering across the relevant cases: a reviewer with a name (shows the name), a reviewer with a blank name (falls back to username), and the column default rendered when there is no reviewer.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
