### PR TITLE
Fix approved count on deliver page

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -270,13 +270,17 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity, fi
             )
 
         pending_count_sq = completed_work_status_subquery(CompletedWorkStatus.pending)
-        approved_count_sq = completed_work_status_subquery(CompletedWorkStatus.approved, sum_field="saved_approved_count")
+        approved_count_sq = completed_work_status_subquery(
+            CompletedWorkStatus.approved, sum_field="saved_approved_count"
+        )
         rejected_count_sq = completed_work_status_subquery(CompletedWorkStatus.rejected)
         over_limit_count_sq = completed_work_status_subquery(CompletedWorkStatus.over_limit)
         incomplete_count_sq = completed_work_status_subquery(CompletedWorkStatus.incomplete)
 
         total_pending_for_user = completed_work_status_total_subquery(CompletedWorkStatus.pending)
-        total_approved_for_user = completed_work_status_total_subquery(CompletedWorkStatus.approved, sum_field="saved_approved_count")
+        total_approved_for_user = completed_work_status_total_subquery(
+            CompletedWorkStatus.approved, sum_field="saved_approved_count"
+        )
         total_rejected_for_user = completed_work_status_total_subquery(CompletedWorkStatus.rejected)
         total_over_limit_for_user = completed_work_status_total_subquery(CompletedWorkStatus.over_limit)
 

--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -247,34 +247,36 @@ def get_annotated_opportunity_access_deliver_status(opportunity: Opportunity, fi
             output_field=IntegerField(),
         )
 
-        def completed_work_status_subquery(status_value):
+        def completed_work_status_subquery(status_value, sum_field=None):
+            agg = Sum(sum_field) if sum_field else Count("id", distinct=True)
             return Subquery(
                 CompletedWork.objects.filter(
                     opportunity_access_id=OuterRef("pk"), payment_unit=payment_unit, status=status_value
                 )
                 .values("opportunity_access_id")
-                .annotate(status_count=Count("id", distinct=True))
+                .annotate(status_count=agg)
                 .values("status_count")[:1],
                 output_field=IntegerField(),
             )
 
-        def completed_work_status_total_subquery(status_value):
+        def completed_work_status_total_subquery(status_value, sum_field=None):
+            agg = Sum(sum_field) if sum_field else Count("id", distinct=True)
             return Subquery(
                 CompletedWork.objects.filter(opportunity_access_id=OuterRef("pk"), status=status_value)
                 .values("opportunity_access_id")
-                .annotate(status_count=Count("id", distinct=True))
+                .annotate(status_count=agg)
                 .values("status_count")[:1],
                 output_field=IntegerField(),
             )
 
         pending_count_sq = completed_work_status_subquery(CompletedWorkStatus.pending)
-        approved_count_sq = completed_work_status_subquery(CompletedWorkStatus.approved)
+        approved_count_sq = completed_work_status_subquery(CompletedWorkStatus.approved, sum_field="saved_approved_count")
         rejected_count_sq = completed_work_status_subquery(CompletedWorkStatus.rejected)
         over_limit_count_sq = completed_work_status_subquery(CompletedWorkStatus.over_limit)
         incomplete_count_sq = completed_work_status_subquery(CompletedWorkStatus.incomplete)
 
         total_pending_for_user = completed_work_status_total_subquery(CompletedWorkStatus.pending)
-        total_approved_for_user = completed_work_status_total_subquery(CompletedWorkStatus.approved)
+        total_approved_for_user = completed_work_status_total_subquery(CompletedWorkStatus.approved, sum_field="saved_approved_count")
         total_rejected_for_user = completed_work_status_total_subquery(CompletedWorkStatus.rejected)
         total_over_limit_for_user = completed_work_status_total_subquery(CompletedWorkStatus.over_limit)
 


### PR DESCRIPTION
## Product Description

The approved count on the deliver page now shows correctly approved counts.

## Technical Summary

[CI-740](https://dimagi.atlassian.net/browse/CI-740)

Visits are grouped into `CompletedWork` records by `entity_id`, so multiple visits can belong to the same record. Since duplicate visits are no longer exist, a single record can contain multiple approved completions tracked in `saved_approved_count`. The delivery page was incorrectly using `Count("id")`, which counted records instead of approved completions. This fix replaces it with `Sum("saved_approved_count")`, aligning the calculation with invoicing.

## Safety Assurance

### Safety story

Verified on prod data: FLW `82580abca211253bc3c0` had one approved CW record for "Bonus for full 6-visit completion" with `saved_approved_count = 2`. Old query returned 1, fix returns 2. For entity-scoped payment units (MBW visit), counts are unchanged since each record has `saved_approved_count = 1`.

### Automated test coverage

Existing tests in `test_helpers.py` all pass, no new tests needed.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-740]: https://dimagi.atlassian.net/browse/CI-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ