### PR TITLE
Audit Access for Network Manager

### DIFF
--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -6,7 +6,14 @@ from commcare_connect.audit.tests.factories import AuditReportEntryFactory, Audi
 from commcare_connect.flags.flag_names import WEEKLY_PERFORMANCE_REPORT
 from commcare_connect.flags.models import Flag
 from commcare_connect.opportunity.models import AssignedTask
-from commcare_connect.opportunity.tests.factories import OpportunityAccessFactory, OpportunityFactory, TaskTypeFactory
+from commcare_connect.opportunity.tests.factories import (
+    OpportunityAccessFactory,
+    OpportunityFactory,
+    TaskTypeFactory,
+    UserFactory,
+)
+from commcare_connect.organization.models import UserOrganizationMembership
+from commcare_connect.users.tests.factories import OrgWithUsersFactory
 
 
 @pytest.fixture
@@ -15,6 +22,121 @@ def audit_opp(program_manager_org):
     flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
     flag.opportunities.add(opportunity)
     return opportunity
+
+
+@pytest.fixture
+def nm_audit_opp(managed_opportunity):
+    flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
+    flag.opportunities.add(managed_opportunity)
+    return managed_opportunity
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role, expected_status",
+    [
+        (UserOrganizationMembership.Role.ADMIN, 200),
+        (UserOrganizationMembership.Role.MEMBER, 200),
+        (UserOrganizationMembership.Role.VIEWER, 404),
+    ],
+)
+def test_nm_audit_list_access_by_role(client, role, expected_status, nm_audit_opp):
+    """Audit access for the network manager (the opportunity's delivery org) follows
+    @org_member_required: members and admins are allowed, viewers are denied. The same
+    decorator gates all audit views, so the role behaviour is asserted once here."""
+    user = UserFactory()
+    UserOrganizationMembership.objects.create(user=user, organization=nm_audit_opp.organization, role=role)
+    client.force_login(user)
+    AuditReportFactory(opportunity=nm_audit_opp)
+
+    url = reverse(
+        "opportunity:audit:audit_report_list",
+        kwargs={"org_slug": nm_audit_opp.organization.slug, "opp_id": nm_audit_opp.opportunity_id},
+    )
+    assert client.get(url).status_code == expected_status
+
+
+@pytest.mark.django_db
+def test_unrelated_org_admin_cannot_access_audit(client, nm_audit_opp):
+    """An admin of an org unrelated to the opportunity is denied both ways: via the
+    opportunity's slug (not a member of that org) and via their own org's slug (the
+    opportunity doesn't belong to it, so opportunity_required rejects it)."""
+    other_org = OrgWithUsersFactory()
+    other_admin = other_org.memberships.filter(role="admin").first().user
+    client.force_login(other_admin)
+    AuditReportFactory(opportunity=nm_audit_opp)
+
+    via_real_slug = reverse(
+        "opportunity:audit:audit_report_list",
+        kwargs={"org_slug": nm_audit_opp.organization.slug, "opp_id": nm_audit_opp.opportunity_id},
+    )
+    assert client.get(via_real_slug).status_code == 404
+
+    via_own_slug = reverse(
+        "opportunity:audit:audit_report_list",
+        kwargs={"org_slug": other_org.slug, "opp_id": nm_audit_opp.opportunity_id},
+    )
+    assert client.get(via_own_slug).status_code == 404
+
+
+@pytest.mark.django_db
+def test_nm_member_can_complete_review(client, org_user_member, nm_audit_opp):
+    """AC: a network manager — here a non-admin member, the newly-granted case — can
+    complete the FLW review. Business logic of completion is covered by the PM tests."""
+    client.force_login(org_user_member)
+    report = AuditReportFactory(opportunity=nm_audit_opp)
+    access = OpportunityAccessFactory(opportunity=nm_audit_opp, accepted=True)
+    AuditReportEntryFactory(
+        audit_report=report,
+        opportunity_access=access,
+        flagged=True,
+        reviewed=True,
+        results={"fake": {"value": 0.5, "has_sufficient_data": True, "in_range": False, "label": "Fake"}},
+    )
+
+    url = reverse(
+        "opportunity:audit:audit_report_complete",
+        kwargs={
+            "org_slug": nm_audit_opp.organization.slug,
+            "opp_id": nm_audit_opp.opportunity_id,
+            "audit_report_id": report.audit_report_id,
+        },
+    )
+    response = client.post(url)
+    assert response.status_code == 204
+    report.refresh_from_db()
+    assert report.status == AuditReport.Status.COMPLETED
+    assert report.completed_by == org_user_member
+
+
+@pytest.mark.django_db
+def test_nm_member_can_assign_tasks(client, org_user_member, nm_audit_opp):
+    """AC: a network manager — here a non-admin member — can assign audit tasks to an FLW."""
+    client.force_login(org_user_member)
+    report = AuditReportFactory(opportunity=nm_audit_opp)
+    access = OpportunityAccessFactory(opportunity=nm_audit_opp, accepted=True)
+    entry = AuditReportEntryFactory(
+        audit_report=report,
+        opportunity_access=access,
+        flagged=True,
+        results={"fake": {"value": 0.5, "has_sufficient_data": True, "in_range": False, "label": "Fake"}},
+    )
+    task_type = TaskTypeFactory(opportunity=nm_audit_opp, name="Refresher Module A")
+
+    url = reverse(
+        "opportunity:audit:audit_report_task_action",
+        kwargs={
+            "org_slug": nm_audit_opp.organization.slug,
+            "opp_id": nm_audit_opp.opportunity_id,
+            "audit_report_id": report.audit_report_id,
+            "entry_id": entry.audit_report_entry_id,
+        },
+    )
+    response = client.post(url, data={"action": "tasks_assigned", "task_type_ids": [str(task_type.pk)]})
+    assert response.status_code == 200
+    entry.refresh_from_db()
+    assert entry.reviewed is True
+    assert AssignedTask.objects.filter(task_type=task_type).count() == 1
 
 
 @pytest.mark.django_db

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -17,7 +17,7 @@ from commcare_connect.flags.flag_names import WEEKLY_PERFORMANCE_REPORT
 from commcare_connect.flags.models import Flag
 from commcare_connect.opportunity.exceptions import TaskAlreadyAssignedError
 from commcare_connect.opportunity.models import AssignedTask, TaskType
-from commcare_connect.organization.decorators import opportunity_required, org_program_manager_required
+from commcare_connect.organization.decorators import opportunity_required, org_member_required
 
 DEFAULT_PAGE_SIZE = 25
 DEFAULT_TASK_DUE_DAYS = 7
@@ -32,7 +32,7 @@ def _require_feature_flag(opportunity):
         raise Http404("Weekly performance report is not enabled for this opportunity.")
 
 
-@org_program_manager_required
+@org_member_required
 @opportunity_required
 def audit_report_list(request, org_slug, opp_id):
     opportunity = request.opportunity
@@ -70,7 +70,7 @@ def audit_report_list(request, org_slug, opp_id):
 
 
 @opportunity_required
-@org_program_manager_required
+@org_member_required
 def audit_report_detail(request, org_slug, opp_id, audit_report_id):
     opportunity = request.opportunity
     _require_feature_flag(opportunity)
@@ -143,7 +143,7 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
 
 
 @opportunity_required
-@org_program_manager_required
+@org_member_required
 def audit_report_task_modal(request, org_slug, opp_id, audit_report_id, entry_id):
     opportunity = request.opportunity
     _require_feature_flag(opportunity)
@@ -172,7 +172,7 @@ def audit_report_task_modal(request, org_slug, opp_id, audit_report_id, entry_id
 
 
 @opportunity_required
-@org_program_manager_required
+@org_member_required
 @require_POST
 def audit_report_task_action(request, org_slug, opp_id, audit_report_id, entry_id):
     opportunity = request.opportunity
@@ -219,7 +219,7 @@ def audit_report_task_action(request, org_slug, opp_id, audit_report_id, entry_i
 
 
 @opportunity_required
-@org_program_manager_required
+@org_member_required
 @require_POST
 def audit_report_complete(request, org_slug, opp_id, audit_report_id):
     opportunity = request.opportunity
@@ -240,7 +240,7 @@ def audit_report_complete(request, org_slug, opp_id, audit_report_id):
 
 
 @opportunity_required
-@org_program_manager_required
+@org_member_required
 @require_GET
 def export_audit_report(request, org_slug, opp_id, audit_report_id):
     opportunity = request.opportunity

--- a/commcare_connect/flags/models.py
+++ b/commcare_connect/flags/models.py
@@ -63,6 +63,10 @@ class Flag(AbstractUserFlag):
         return cls.objects.filter(filters).distinct()
 
     def is_active_for(self, obj: Organization | Opportunity | Program):
+        # A transient/unsaved Flag (e.g. waffle's default for a missing flag) has no
+        # primary key
+        if self.pk is None:
+            return False
         if isinstance(obj, Organization):
             organization_ids = self._get_ids_for_relation("organizations")
             return obj.pk in organization_ids

--- a/commcare_connect/flags/tests/test_flag_models.py
+++ b/commcare_connect/flags/tests/test_flag_models.py
@@ -42,6 +42,13 @@ class TestFlagModel:
         invalid_obj = {"name": "test"}
         assert flag.is_active_for(invalid_obj) is False
 
+    def test_unsaved_flag_is_not_active_for(self, opportunity):
+        """A transient Flag (no pk) — e.g. waffle's default for a missing flag — must
+        not blow up when its M2M relations are checked during a flag lookup."""
+        transient_flag = Flag(name="open_chat_studio_widget")
+        assert transient_flag.pk is None
+        assert transient_flag.is_active_for(opportunity) is False
+
     def test_active_flags_for_user(self):
         user = UserFactory()
         user_flag = FlagFactory()


### PR DESCRIPTION
## Product Description

Network Managers (NMs) can now access the Audit functionality for their opportunities — previously this was restricted to Program Managers (PMs). A member or admin of the opportunity's network (delivery) organization can now open the audit pages and Weekly Performance Report, view audit reports, assign tasks to flagged frontline workers, and complete the review. Read-only viewers and users outside the opportunity's organizations remain blocked.

The audit pages render identically to the existing PM experience; the only change is who is allowed to reach them.

<img width="1840" height="662" alt="Screenshot_20260630_142554" src="https://github.com/user-attachments/assets/53f13b10-e1aa-405a-9431-d5e7cdeb216d" />

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2579)

This is a release path 3 feature — Experiments & early stage iterations of product area.

The six audit views are now gated behind `@org_member_required` and the pre-existing `@opportunity_required` decorators. This matches the access level already used for the analogous NM review actions (`approve_visits`/`reject_visits`).

This branch also fixes a pre-existing latent bug surfaced while testing: `Flag.is_active_for()` read a many-to-many relation without checking the instance was saved. When waffle evaluates a flag that doesn't exist in the DB (e.g. the `open_chat_studio_widget` check that runs in a context processor on every page render), it passes a transient unsaved `Flag`, and on a cold cache this raised a `ValueError` and 500'd the page. The fix guards against a missing primary key up front.

## Safety Assurance

### Safety story

The change only widens an authorization check on existing read/review endpoints; it adds no new data writes or migrations, and the audit feature itself remains gated behind the per-opportunity `weekly_performance_report` waffle flag, so the blast radius is limited to flagged opportunities. The permission change is fully reversible by reverting the decorator. Verified locally as a non-superuser NM member: access is granted on this branch and 404s when reverted to the old gating. The flags fix is strictly defensive (returns `False` earlier for an unsaved flag) and cannot change behavior for any saved flag.

### Automated test coverage

Tests cover the network-manager access matrix on the audit list (admin and member allowed, viewer denied) and confirm that an unrelated org's admin is rejected via both URL paths, plus that an NM member can assign tasks and complete a review. A regression test covers the flags fix, asserting an unsaved `Flag` is inactive instead of raising. Existing program-manager audit tests continue to pass unchanged.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
