### PR TITLE
CCCT-2589: Fix FLW summary double-counting already-assigned areas

### DIFF
--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -341,11 +341,7 @@
             </template>
             <!-- Panel 3: FLW Summary -->
             <div class="border-t border-gray-200 pt-3">
-              <h3 class="text-sm font-semibold mb-2">
-                {% translate "FLW Summary" %}
-                <i class="fa-solid fa-circle-info text-gray-400 ml-1 cursor-help"
-                   x-tooltip.raw="{% translate 'Totals reflect the counts currently assigned to this FLW, including any pending (unsaved) assignments.' %}"></i>
-              </h3>
+              <h3 class="text-sm font-semibold mb-2">{% translate "FLW Summary" %}</h3>
               <div class="mb-2">
                 <label class="block text-xs text-gray-500 mb-1">{% translate "Select FLW" %}</label>
                 <select x-ref="flwSummarySelect"
@@ -371,15 +367,15 @@
                     <div class="grid grid-cols-2 items-center gap-2 text-sm">
                       <dt class="text-gray-500">{% translate "Total Buildings" %}</dt>
                       <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                          x-text="flwSummary.assigned_buildings + getQueuedStatsForAssignee().buildings + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().buildings : 0)">
+                          x-text="formatFlwSummaryTotal(flwSummary.assigned_buildings, 'buildings')">
                       </dd>
                       <dt class="text-gray-500">{% translate "Total Expected Visits" %}</dt>
                       <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                          x-text="flwSummary.assigned_visits + getQueuedStatsForAssignee().visits + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().visits : 0)">
+                          x-text="formatFlwSummaryTotal(flwSummary.assigned_visits, 'visits')">
                       </dd>
                       <dt class="text-gray-500">{% translate "Total Work Areas" %}</dt>
                       <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
-                          x-text="flwSummary.assigned_work_areas + getQueuedStatsForAssignee().workAreas + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().workAreas : 0)">
+                          x-text="formatFlwSummaryTotal(flwSummary.assigned_work_areas, 'workAreas')">
                       </dd>
                     </div>
                   </dl>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -331,7 +331,7 @@
                       </div>
                       <button type="button"
                               @click="removeFromQueue(index)"
-                              class="text-red-500 hover:text-red-700 ml-2 shrink-0">
+                              class="text-red-500 hover:text-red-700 ml-2 shrink-0 cursor-pointer">
                         <i class="fa-solid fa-xmark"></i>
                       </button>
                     </div>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -417,17 +417,17 @@
                     </div>
                     <div class="flex justify-between">
                       <dt>{% translate "Work Areas" %}</dt>
-                      <dd class="font-semibold" x-text="entry.work_area_ids.length">
+                      <dd class="font-semibold" x-text="entry.total_work_areas">
                       </dd>
                     </div>
                     <div class="flex justify-between">
                       <dt>{% translate "Total Buildings" %}</dt>
-                      <dd class="font-semibold" x-text="entry.buildings">
+                      <dd class="font-semibold" x-text="entry.total_buildings">
                       </dd>
                     </div>
                     <div class="flex justify-between">
                       <dt>{% translate "Total Expected Visits" %}</dt>
-                      <dd class="font-semibold" x-text="entry.visits">
+                      <dd class="font-semibold" x-text="entry.total_visits">
                       </dd>
                     </div>
                   </dl>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -337,7 +337,11 @@
             </template>
             <!-- Panel 3: FLW Summary -->
             <div class="border-t border-gray-200 pt-3">
-              <h3 class="text-sm font-semibold mb-2">{% translate "FLW Summary" %}</h3>
+              <h3 class="text-sm font-semibold mb-2">
+                {% translate "FLW Summary" %}
+                <i class="fa-solid fa-circle-info text-gray-400 ml-1 cursor-help"
+                   x-tooltip.raw="{% translate 'Totals reflect the counts currently assigned to this FLW, including any pending (unsaved) assignments.' %}"></i>
+              </h3>
               <div class="mb-2">
                 <label class="block text-xs text-gray-500 mb-1">{% translate "Select FLW" %}</label>
                 <select x-ref="flwSummarySelect"
@@ -361,15 +365,15 @@
                 <div>
                   <dl class="space-y-2">
                     <div class="grid grid-cols-2 items-center gap-2 text-sm">
-                      <dt class="text-gray-500">{% translate "Count of Assigned Buildings" %}</dt>
+                      <dt class="text-gray-500">{% translate "Total Buildings" %}</dt>
                       <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
                           x-text="flwSummary.assigned_buildings + getQueuedStatsForAssignee().buildings + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().buildings : 0)">
                       </dd>
-                      <dt class="text-gray-500">{% translate "Count of Assigned Visits" %}</dt>
+                      <dt class="text-gray-500">{% translate "Total Expected Visits" %}</dt>
                       <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
                           x-text="flwSummary.assigned_visits + getQueuedStatsForAssignee().visits + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().visits : 0)">
                       </dd>
-                      <dt class="text-gray-500">{% translate "Count of Assigned Work Areas" %}</dt>
+                      <dt class="text-gray-500">{% translate "Total Work Areas" %}</dt>
                       <dd class="font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
                           x-text="flwSummary.assigned_work_areas + getQueuedStatsForAssignee().workAreas + (String(flwSummaryAssigneeId) === String(selectedAssigneeId) ? getSelectedStatsForSummary().workAreas : 0)">
                       </dd>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -323,7 +323,11 @@
                     <div class="flex items-center justify-between bg-gray-50 rounded-lg px-3 py-2 text-xs">
                       <div class="min-w-0">
                         <span class="font-medium truncate block" x-text="entry.assignee_name"></span>
-                        <span class="text-gray-500"><span x-text="entry.work_area_ids.length"></span> {% translate "work areas" %}</span>
+                        <span class="text-gray-500">
+                          <span x-text="entry.work_area_ids.length"></span> {% translate "work areas" %}
+                          · <span x-text="entry.buildings"></span> {% translate "buildings" %}
+                          · <span x-text="entry.visits"></span> {% translate "expected visits" %}
+                        </span>
                       </div>
                       <button type="button"
                               @click="removeFromQueue(index)"

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -407,6 +407,9 @@
               <p class="text-sm mb-4">
                 {% translate "Saving these changes will alert all impacted FLWs that their assignment has changed. Are you sure you want to continue?" %}
               </p>
+              <p class="text-xs text-gray-500 mb-3">
+                {% translate "Figures show each FLW's total assignment after saving, not just the changes." %}
+              </p>
               <div class="space-y-2 mb-4 max-h-60 overflow-auto">
                 <template x-for="(entry, index) in assignmentQueue" :key="index">
                   <dl class="text-sm space-y-1 bg-gray-50 rounded-lg p-3">
@@ -416,7 +419,7 @@
                       </dd>
                     </div>
                     <div class="flex justify-between">
-                      <dt>{% translate "Work Areas" %}</dt>
+                      <dt>{% translate "Total Work Areas" %}</dt>
                       <dd class="font-semibold" x-text="entry.total_work_areas">
                       </dd>
                     </div>

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -257,6 +257,10 @@
                     return;
                 }
 
+                // Show the summary spinner while this filter's areas load. Until they
+                // land, flwFilterWorkAreaIds is empty, so the live delta would transiently
+                // count the FLW's own existing areas as "new" and inflate the total.
+                this.flwSummaryLoading = true;
                 try {
                     const resp = await fetch(url);
                     const data = await resp.json();
@@ -288,6 +292,7 @@
             async updateFlwSummary() {
                 if (!this.flwSummaryAssigneeId) {
                     this.flwSummary = null;
+                    this.flwSummaryLoading = false;
                     return;
                 }
                 this.flwSummaryLoading = true;
@@ -319,15 +324,25 @@
             },
 
             getSelectedStatsForSummary() {
-                // Live preview of pending changes for the FLW summary. Only count
-                // selected work areas that are NOT already assigned to this FLW.
-                // selectByAssignee() auto-selects the FLW's existing areas (tracked in
-                // flwFilterWorkAreaIds); those are already reflected in flwSummary, so
-                // including them here would double-count buildings/visits/work areas.
+                // Live preview of pending changes for the FLW summary. Count only the
+                // net-new areas this selection would add, i.e. exclude:
+                //   - the FLW's existing DB areas (flwFilterWorkAreaIds), which
+                //     selectByAssignee() auto-selects and are already in flwSummary; and
+                //   - areas already queued for this FLW, which getQueuedStatsForAssignee()
+                //     already counts — re-selecting one would otherwise double-count it.
+                const alreadyQueued = this.getQueuedWorkAreaIdsForAssignee(this.selectedAssigneeId);
                 const pendingIds = Array.from(this.selectedWorkAreas).filter(
-                    id => !this.flwFilterWorkAreaIds.has(id)
+                    id => !this.flwFilterWorkAreaIds.has(id) && !alreadyQueued.has(id)
                 );
                 return { ...this.getStatsForIds(pendingIds), workAreas: pendingIds.length };
+            },
+
+            getQueuedWorkAreaIdsForAssignee(assigneeId) {
+                return new Set(
+                    this.assignmentQueue
+                        .filter(entry => String(entry.assignee_id) === String(assigneeId))
+                        .flatMap(entry => entry.work_area_ids)
+                );
             },
 
             getQueuedStatsForAssignee() {

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -224,62 +224,50 @@
                 this.updateFlwSummary();
             },
 
-            async selectGroup(groupId) {
-                // Clear previous group selections
-                for (const id of this.groupWorkAreaIds) {
-                    this.selectedWorkAreas.delete(id);
-                    this.setWorkAreaState(id, { assignment_selected: false });
-                }
-                this.groupWorkAreaIds.clear();
+            selectGroup(groupId) {
                 this.selectedGroupId = groupId || null;
-
-                if (!groupId) {
-                    this.updateFlwSummary();
-                    return;
-                }
-
-                try {
-                    const url = '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId);
-                    const resp = await fetch(url);
-                    const data = await resp.json();
-                    for (const wa of data.work_areas) {
-                        this.selectedWorkAreas.add(wa.id);
-                        this.groupWorkAreaIds.add(wa.id);
-                        this.workAreaProperties.set(wa.id, wa);
-                        this.setWorkAreaState(wa.id, { assignment_selected: true });
-                    }
-                } catch (e) {
-                    this.showToast("{% translate 'Failed to load group work areas' %}", true);
-                }
-                this.updateFlwSummary();
+                return this.replaceFilterSelection({
+                    trackingSet: this.groupWorkAreaIds,
+                    selectionId: groupId,
+                    url: '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId),
+                    errorMsg: "{% translate 'Failed to load group work areas' %}",
+                });
             },
 
-            async selectByAssignee(assigneeId) {
-                // Clear previous FLW-filter selections
-                for (const id of this.flwFilterWorkAreaIds) {
+            selectByAssignee(assigneeId) {
+                this.selectedFlwFilterId = assigneeId || null;
+                return this.replaceFilterSelection({
+                    trackingSet: this.flwFilterWorkAreaIds,
+                    selectionId: assigneeId,
+                    url: '{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId),
+                    errorMsg: "{% translate 'Failed to load FLW work areas' %}",
+                });
+            },
+
+            // Replaces the selection contributed by one filter (a group or an FLW).
+            async replaceFilterSelection({ trackingSet, selectionId, url, errorMsg }) {
+                for (const id of trackingSet) {
                     this.selectedWorkAreas.delete(id);
                     this.setWorkAreaState(id, { assignment_selected: false });
                 }
-                this.flwFilterWorkAreaIds.clear();
-                this.selectedFlwFilterId = assigneeId || null;
+                trackingSet.clear();
 
-                if (!assigneeId) {
+                if (!selectionId) {
                     this.updateFlwSummary();
                     return;
                 }
 
                 try {
-                    const url = '{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId);
                     const resp = await fetch(url);
                     const data = await resp.json();
                     for (const wa of data.work_areas) {
                         this.selectedWorkAreas.add(wa.id);
-                        this.flwFilterWorkAreaIds.add(wa.id);
+                        trackingSet.add(wa.id);
                         this.workAreaProperties.set(wa.id, wa);
                         this.setWorkAreaState(wa.id, { assignment_selected: true });
                     }
                 } catch (e) {
-                    this.showToast("{% translate 'Failed to load FLW work areas' %}", true);
+                    this.showToast(errorMsg, true);
                 }
                 this.updateFlwSummary();
             },

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -44,6 +44,10 @@
                 return status !== undefined && status !== 'NOT_VISITED';
             },
 
+            setWorkAreaState(id, state) {
+                this.map.setFeatureState({ source: 'workareas', sourceLayer: 'workareas', id }, state);
+            },
+
             openWorkAreaEditModal(workAreaId) {
                 const editWorkAreaUrl = '{{ edit_work_area_url|escapejs }}';
                 const url = editWorkAreaUrl + workAreaId + '/';
@@ -57,8 +61,11 @@
                     : this.selectedFeature._id;
             },
 
+            visitCircleOpacity() {
+                return this.highlightedWorkAreaId !== null ? 0.2 : 0.7;
+            },
+
             buildVisitCirclePaint() {
-                const hasSelection = this.highlightedWorkAreaId !== null;
                 return {
                     'circle-radius': [
                         'interpolate', ['linear'], ['zoom'],
@@ -66,7 +73,7 @@
                         14, 5,
                     ],
                     'circle-color': '#e74c3c',
-                    'circle-opacity': hasSelection ? 0.2 : 0.7,
+                    'circle-opacity': this.visitCircleOpacity(),
                     'circle-stroke-width': 1,
                     'circle-stroke-color': '#ffffff',
                     'circle-stroke-opacity': 0.5,
@@ -107,7 +114,7 @@
                     this.map.setPaintProperty(
                         'user-visits-circle',
                         'circle-opacity',
-                        this.highlightedWorkAreaId !== null ? 0.2 : 0.7,
+                        this.visitCircleOpacity(),
                     );
                 }
 
@@ -213,10 +220,7 @@
                     }
                 }
 
-                this.map.setFeatureState(
-                    { source: 'workareas', sourceLayer: 'workareas', id },
-                    { assignment_selected: this.selectedWorkAreas.has(id) }
-                );
+                this.setWorkAreaState(id, { assignment_selected: this.selectedWorkAreas.has(id) });
                 this.updateFlwSummary();
             },
 
@@ -224,10 +228,7 @@
                 // Clear previous group selections
                 for (const id of this.groupWorkAreaIds) {
                     this.selectedWorkAreas.delete(id);
-                    this.map.setFeatureState(
-                        { source: 'workareas', sourceLayer: 'workareas', id },
-                        { assignment_selected: false }
-                    );
+                    this.setWorkAreaState(id, { assignment_selected: false });
                 }
                 this.groupWorkAreaIds.clear();
                 this.selectedGroupId = groupId || null;
@@ -245,10 +246,7 @@
                         this.selectedWorkAreas.add(wa.id);
                         this.groupWorkAreaIds.add(wa.id);
                         this.workAreaProperties.set(wa.id, wa);
-                        this.map.setFeatureState(
-                            { source: 'workareas', sourceLayer: 'workareas', id: wa.id },
-                            { assignment_selected: true }
-                        );
+                        this.setWorkAreaState(wa.id, { assignment_selected: true });
                     }
                 } catch (e) {
                     this.showToast("{% translate 'Failed to load group work areas' %}", true);
@@ -260,10 +258,7 @@
                 // Clear previous FLW-filter selections
                 for (const id of this.flwFilterWorkAreaIds) {
                     this.selectedWorkAreas.delete(id);
-                    this.map.setFeatureState(
-                        { source: 'workareas', sourceLayer: 'workareas', id },
-                        { assignment_selected: false }
-                    );
+                    this.setWorkAreaState(id, { assignment_selected: false });
                 }
                 this.flwFilterWorkAreaIds.clear();
                 this.selectedFlwFilterId = assigneeId || null;
@@ -281,10 +276,7 @@
                         this.selectedWorkAreas.add(wa.id);
                         this.flwFilterWorkAreaIds.add(wa.id);
                         this.workAreaProperties.set(wa.id, wa);
-                        this.map.setFeatureState(
-                            { source: 'workareas', sourceLayer: 'workareas', id: wa.id },
-                            { assignment_selected: true }
-                        );
+                        this.setWorkAreaState(wa.id, { assignment_selected: true });
                     }
                 } catch (e) {
                     this.showToast("{% translate 'Failed to load FLW work areas' %}", true);
@@ -294,10 +286,7 @@
 
             clearSelection() {
                 for (const id of this.selectedWorkAreas) {
-                    this.map.setFeatureState(
-                        { source: 'workareas', sourceLayer: 'workareas', id },
-                        { assignment_selected: false }
-                    );
+                    this.setWorkAreaState(id, { assignment_selected: false });
                 }
                 this.selectedWorkAreas.clear();
                 this.groupWorkAreaIds.clear();
@@ -347,19 +336,10 @@
                 // selectByAssignee() auto-selects the FLW's existing areas (tracked in
                 // flwFilterWorkAreaIds); those are already reflected in flwSummary, so
                 // including them here would double-count buildings/visits/work areas.
-                let buildings = 0;
-                let visits = 0;
-                let workAreas = 0;
-                for (const id of this.selectedWorkAreas) {
-                    if (this.flwFilterWorkAreaIds.has(id)) continue;
-                    const props = this.workAreaProperties.get(id);
-                    if (props) {
-                        buildings += parseInt(props.building_count) || 0;
-                        visits += parseInt(props.expected_visit_count) || 0;
-                    }
-                    workAreas += 1;
-                }
-                return { buildings, visits, workAreas };
+                const pendingIds = Array.from(this.selectedWorkAreas).filter(
+                    id => !this.flwFilterWorkAreaIds.has(id)
+                );
+                return { ...this.getStatsForIds(pendingIds), workAreas: pendingIds.length };
             },
 
             getQueuedStatsForAssignee() {
@@ -376,19 +356,20 @@
                 return { buildings, visits, workAreas };
             },
 
+            findAssignee(assigneeId) {
+                return this.assignees.find(assignee => String(assignee.id) === String(assigneeId));
+            },
+
             getAssigneeName() {
-                const a = this.assignees.find(a => String(a.id) === String(this.selectedAssigneeId));
-                return a ? a.user__name : '';
+                return this.findAssignee(this.selectedAssigneeId)?.user__name ?? '';
             },
 
             getAssigneeUserId() {
-                const a = this.assignees.find(a => String(a.id) === String(this.selectedAssigneeId));
-                return a ? a.user__user_id : '';
+                return this.findAssignee(this.selectedAssigneeId)?.user__user_id ?? '';
             },
 
             getFlwSummaryUserId() {
-                const a = this.assignees.find(a => String(a.id) === String(this.flwSummaryAssigneeId));
-                return a ? a.user__user_id : '';
+                return this.findAssignee(this.flwSummaryAssigneeId)?.user__user_id ?? '';
             },
 
             addToQueue() {
@@ -502,10 +483,7 @@
                         const unassignedIds = data.unassigned_ids || [];
                         const failedIds = data.failed_ids || [];
                         for (const id of unassignedIds) {
-                            this.map.setFeatureState(
-                                { source: 'workareas', sourceLayer: 'workareas', id },
-                                { status: 'UNASSIGNED' }
-                            );
+                            this.setWorkAreaState(id, { status: 'UNASSIGNED' });
                             const props = this.workAreaProperties.get(id);
                             if (props) {
                                 props.status = 'UNASSIGNED';
@@ -518,10 +496,7 @@
                         this.clearSelection();
                         for (const id of failedIds) {
                             this.selectedWorkAreas.add(id);
-                            this.map.setFeatureState(
-                                { source: 'workareas', sourceLayer: 'workareas', id },
-                                { assignment_selected: true }
-                            );
+                            this.setWorkAreaState(id, { assignment_selected: true });
                         }
                         const msg = data.skipped || failedIds.length
                             ? "{% translate 'Unassigned' %} " + unassignedIds.length + " " + "{% translate 'work area(s).' %}"
@@ -590,17 +565,10 @@
                     }
 
                     // Always update map feature state
-                    this.map.setFeatureState(
-                        {
-                            source: 'workareas',
-                            sourceLayer: 'workareas',
-                            id: data.id
-                        },
-                        {
-                            group_id: data.group_id,
-                            expected_visit_count: data.expected_visit_count,
-                        }
-                    );
+                    this.setWorkAreaState(data.id, {
+                        group_id: data.group_id,
+                        expected_visit_count: data.expected_visit_count,
+                    });
 
                     this.showWorkAreaEditModal = false;
                     this.showToast("{% translate 'Work area updated successfully!' %}");
@@ -611,10 +579,7 @@
                     if (this.selectedFeature && this.selectedFeature._id === data.id) {
                         this.selectedFeature = { ...this.selectedFeature, status: data.status };
                     }
-                    this.map.setFeatureState(
-                        { source: 'workareas', sourceLayer: 'workareas', id: data.id },
-                        { status: data.status }
-                    );
+                    this.setWorkAreaState(data.id, { status: data.status });
                     this.showReviewInaccessibilityModal = false;
                     this.showToast("{% translate 'Work area review saved.' %}");
                 });
@@ -623,10 +588,7 @@
                     const excluded = e.detail?.excluded ?? [];
                     const skipped = e.detail?.skipped ?? 0;
                     for (const id of excluded) {
-                        this.map.setFeatureState(
-                            { source: 'workareas', sourceLayer: 'workareas', id },
-                            { status: 'EXCLUDED' }
-                        );
+                        this.setWorkAreaState(id, { status: 'EXCLUDED' });
                         this.excludedWorkAreaIds.add(id);
                     }
                     this.showExcludeModal = false;
@@ -803,10 +765,7 @@
                     this.map.on('sourcedata', (e) => {
                         if (e.sourceId === 'workareas' && e.isSourceLoaded) {
                             for (const id of this.selectedWorkAreas) {
-                                this.map.setFeatureState(
-                                    { source: 'workareas', sourceLayer: 'workareas', id },
-                                    { assignment_selected: true }
-                                );
+                                this.setWorkAreaState(id, { assignment_selected: true });
                             }
                         }
                     });
@@ -916,14 +875,7 @@
                     }
 
                     if (this.selectedFeature) {
-                        this.map.setFeatureState(
-                            {
-                                source: 'workareas',
-                                sourceLayer: 'workareas',
-                                id: this.selectedFeature._id
-                            },
-                            { selected: false }
-                        );
+                        this.setWorkAreaState(this.selectedFeature._id, { selected: false });
                     }
                     if (this.selectedFeature && this.selectedFeature._id === id) {
                         this.selectedFeature = null;
@@ -944,14 +896,7 @@
                         _id: id
                     };
 
-                    this.map.setFeatureState(
-                        {
-                            source: 'workareas',
-                            sourceLayer: 'workareas',
-                            id
-                        },
-                        { selected: true }
-                    );
+                    this.setWorkAreaState(id, { selected: true });
                 });
 
                 // Tracks the currently hovered feature to apply white fill highlight
@@ -963,25 +908,16 @@
                     const newId = feature.id;
                     if (newId === hoveredId) return;
                     if (hoveredId !== null) {
-                        this.map.setFeatureState(
-                            { source: 'workareas', sourceLayer: 'workareas', id: hoveredId },
-                            { hovered: false }
-                        );
+                        this.setWorkAreaState(hoveredId, { hovered: false });
                     }
                     hoveredId = newId;
-                    this.map.setFeatureState(
-                        { source: 'workareas', sourceLayer: 'workareas', id: hoveredId },
-                        { hovered: true }
-                    );
+                    this.setWorkAreaState(hoveredId, { hovered: true });
                 });
 
                 this.map.on('mouseleave', 'workareas-fill', () => {
                     this.map.getCanvasContainer().style.cursor = '';
                     if (hoveredId !== null) {
-                        this.map.setFeatureState(
-                            { source: 'workareas', sourceLayer: 'workareas', id: hoveredId },
-                            { hovered: false }
-                        );
+                        this.setWorkAreaState(hoveredId, { hovered: false });
                         hoveredId = null;
                     }
                 });

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -359,6 +359,22 @@
                 return { buildings, visits, workAreas };
             },
 
+            getFlwSummaryPendingDelta(kind) {
+                // Net-new count (kind: 'buildings' | 'visits' | 'workAreas') for the FLW
+                // shown in the summary: areas queued for them plus, if they're the
+                // active assignee, the live selection's net-new areas.
+                const queued = this.getQueuedStatsForAssignee()[kind];
+                const selected = String(this.flwSummaryAssigneeId) === String(this.selectedAssigneeId)
+                    ? this.getSelectedStatsForSummary()[kind]
+                    : 0;
+                return queued + selected;
+            },
+
+            formatFlwSummaryTotal(base, kind) {
+                const delta = this.getFlwSummaryPendingDelta(kind);
+                return delta > 0 ? `${base} + ${delta} (new)` : `${base}`;
+            },
+
             findAssignee(assigneeId) {
                 return this.assignees.find(assignee => String(assignee.id) === String(assigneeId));
             },

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -324,10 +324,10 @@
                 this.flwSummaryLoading = false;
             },
 
-            getSelectedStats() {
+            getStatsForIds(workAreaIds) {
                 let buildings = 0;
                 let visits = 0;
-                for (const id of this.selectedWorkAreas) {
+                for (const id of workAreaIds) {
                     const props = this.workAreaProperties.get(id);
                     if (props) {
                         buildings += parseInt(props.building_count) || 0;
@@ -335,6 +335,10 @@
                     }
                 }
                 return { buildings, visits };
+            },
+
+            getSelectedStats() {
+                return this.getStatsForIds(this.selectedWorkAreas);
             },
 
             getSelectedStatsForSummary() {
@@ -392,21 +396,38 @@
                 const newWorkAreaIds = Array.from(this.selectedWorkAreas).filter(
                     id => !this.flwFilterWorkAreaIds.has(id)
                 );
-                const newStats = this.getSelectedStatsForSummary();
-                const totalStats = this.getSelectedStats();
-                this.assignmentQueue.push({
-                    assignee_id: this.selectedAssigneeId,
-                    assignee_name: this.getAssigneeName(),
-                    // Delta (newly-selected areas only)
-                    work_area_ids: newWorkAreaIds,
-                    buildings: newStats.buildings,
-                    visits: newStats.visits,
-                    // Post-save totals (all selected areas, incl. the FLW's existing
-                    // areas auto-selected via the filter)
-                    total_work_areas: this.selectedWorkAreas.size,
-                    total_buildings: totalStats.buildings,
-                    total_visits: totalStats.visits,
-                });
+                const existing = this.assignmentQueue.find(
+                    e => String(e.assignee_id) === String(this.selectedAssigneeId)
+                );
+                if (existing) {
+                    // Consolidate into the FLW's existing entry, counting only areas not
+                    // already queued for them so re-selecting an area can't double-count.
+                    const alreadyQueued = new Set(existing.work_area_ids);
+                    const addedIds = newWorkAreaIds.filter(id => !alreadyQueued.has(id));
+                    const added = this.getStatsForIds(addedIds);
+                    existing.work_area_ids.push(...addedIds);
+                    existing.buildings += added.buildings;
+                    existing.visits += added.visits;
+                    existing.total_work_areas += addedIds.length;
+                    existing.total_buildings += added.buildings;
+                    existing.total_visits += added.visits;
+                } else {
+                    const newStats = this.getSelectedStatsForSummary();
+                    const totalStats = this.getSelectedStats();
+                    this.assignmentQueue.push({
+                        assignee_id: this.selectedAssigneeId,
+                        assignee_name: this.getAssigneeName(),
+                        // Delta (newly-selected areas only)
+                        work_area_ids: newWorkAreaIds,
+                        buildings: newStats.buildings,
+                        visits: newStats.visits,
+                        // Post-save totals (all selected areas, incl. the FLW's existing
+                        // areas auto-selected via the filter)
+                        total_work_areas: this.selectedWorkAreas.size,
+                        total_buildings: totalStats.buildings,
+                        total_visits: totalStats.visits,
+                    });
+                }
                 this.clearSelection();
                 if (this.$refs.assigneeSelect) this.$refs.assigneeSelect.value = '';
                 this.selectedAssigneeId = null;

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -389,12 +389,23 @@
 
             addToQueue() {
                 if (this.selectedWorkAreas.size === 0 || !this.selectedAssigneeId) return;
+                const newWorkAreaIds = Array.from(this.selectedWorkAreas).filter(
+                    id => !this.flwFilterWorkAreaIds.has(id)
+                );
+                const newStats = this.getSelectedStatsForSummary();
+                const totalStats = this.getSelectedStats();
                 this.assignmentQueue.push({
                     assignee_id: this.selectedAssigneeId,
                     assignee_name: this.getAssigneeName(),
-                    work_area_ids: Array.from(this.selectedWorkAreas),
-                    buildings: this.getSelectedStats().buildings,
-                    visits: this.getSelectedStats().visits,
+                    // Delta (newly-selected areas only)
+                    work_area_ids: newWorkAreaIds,
+                    buildings: newStats.buildings,
+                    visits: newStats.visits,
+                    // Post-save totals (all selected areas, incl. the FLW's existing
+                    // areas auto-selected via the filter)
+                    total_work_areas: this.selectedWorkAreas.size,
+                    total_buildings: totalStats.buildings,
+                    total_visits: totalStats.visits,
                 });
                 this.clearSelection();
                 if (this.$refs.assigneeSelect) this.$refs.assigneeSelect.value = '';


### PR DESCRIPTION
## Product Description

Fixes incorrect counts and clarifies wording in the work-area assignment map's **FLW Summary**, **Pending Assignments**, and confirmation modal.

Selecting an FLW auto-selects that FLW's already-assigned areas (for context / unassignment). Those areas were being double-counted, and the counts weren't clearly labelled. 

Changes:

- **FLW Summary** and **Pending Assignments** no longer double-count already-assigned or already-queued areas.
- **Pending Assignments** now shows only the *delta* (the new assignments being made), and now displays **Buildings** and **Expected Visits**.

<img width="980" height="250" alt="image" src="https://github.com/user-attachments/assets/16f52380-0f11-4d01-bc5f-254446e900c2" />
- Delta shown in **FLW Summary**  as + delta (new)

<img width="872" height="911" alt="image" src="https://github.com/user-attachments/assets/19201cbc-503d-4be0-b9cd-3fb29be6d590" />

- Message on the **confirmation modal** clarifying what its count represents.

<img width="960" height="579" alt="image" src="https://github.com/user-attachments/assets/608c5dce-eed5-4c72-b419-da2c3a221938" />

## Technical Summary

Ticket:[ CCCT-2589](https://dimagi.atlassian.net/browse/CCCT-2589)

- `addToQueue()` queues only newly-selected areas (excluding `flwFilterWorkAreaIds`); FLW Summary = server base + queued + live delta.
- `getSelectedStatsForSummary()` also excludes areas already queued for the FLW (new `getQueuedWorkAreaIdsForAssignee()` helper), so re-selecting a queued area isn't counted twice.
- Selecting an FLW clears `flwFilterWorkAreaIds` before an async fetch repopulates it; the summary now shows its spinner (`flwSummaryLoading`) during the fetch so no total renders against a half-updated filter (fixes a transient inflated count).

## Safety Assurance

### Safety story

Front-end-only change to count computation and labelling in the assignment map. The set of work areas persisted on save is unchanged; only displayed/queued counts and wording are corrected. Verified by tracing selection state through `selectByAssignee` → `addToQueue` → FLW Summary / Pending Assignments / confirm modal rendering.

### Automated test coverage

None — Alpine.js logic embedded in a Django template with no JS test harness in the repo. Manually verified.

### QA Plan

None.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
