### PR TITLE
Add microplanning work area tables to Superset replication

### DIFF
--- a/commcare_connect/multidb/constants.py
+++ b/commcare_connect/multidb/constants.py
@@ -1,3 +1,4 @@
+from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup, WorkAreaInaccessibilityRequest
 from commcare_connect.opportunity.models import (
     Assessment,
     CommCareApp,
@@ -56,4 +57,7 @@ REPLICATION_ALLOWED_MODELS = [
     UserAnalyticsData,
     UserCredential,
     PaymentInvoice,
+    WorkArea,
+    WorkAreaGroup,
+    WorkAreaInaccessibilityRequest,
 ]


### PR DESCRIPTION
## Product Description

No user-facing change.

## Technical Summary

[CI-763](https://dimagi.atlassian.net/browse/CI-763)

- WorkArea, WorkAreaGroup, and WorkAreaInaccessibilityRequest were absent from REPLICATION_ALLOWED_MODELS, so those tables appeared in Superset but had no data. This adds them to the logical replication publication.
- After deploying, run `./manage.py setup_logical_replication` on production to refresh the publication. The command handles ALTER PUBLICATION for existing publications, so no manual SQL needed.

## Safety Assurance

### Safety story

Read-only replication config change. No migrations, no API changes, no permissions touched. Adding models to the publication list cannot affect existing data in either database.

### Automated test coverage

No tests added; this is a config list with no logic to test.

### QA Plan

Not needed.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-763]: https://dimagi.atlassian.net/browse/CI-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ