### PR TITLE
Fix account-flow dogfooding issues: confusing email-confirm copy, password-reset dead-end

### DIFF
--- a/commcare_connect/templates/account/email/email_confirmation_message.txt
+++ b/commcare_connect/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,8 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans with site_domain=current_site.domain %}You're receiving this email to confirm that this address belongs to your account on {{ site_domain }}.
+
+To confirm your email address, go to {{ activate_url }}
+
+If you didn't request this, you can safely ignore this email.{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/commcare_connect/templates/account/email/email_confirmation_signup_message.txt
+++ b/commcare_connect/templates/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,8 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because you signed up for an account on {{ site_domain }}.
+
+To confirm your email address and finish creating your account, go to {{ activate_url }}
+
+If you didn't sign up, you can safely ignore this email.{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/commcare_connect/templates/account/email_confirm.html
+++ b/commcare_connect/templates/account/email_confirm.html
@@ -8,10 +8,9 @@
   <div class="w-full min-h-[620px] h-fit flex flex-col gap-4">
     <h1 class="title text-brand-deep-purple mb-4">{% translate "Confirm E-mail Address" %}</h1>
     {% if confirmation %}
-      {% user_display confirmation.email_address.user as user_display %}
       <p>
         {% blocktranslate with confirmation.email_address.email as email %}
-        Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.
+        Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is your e-mail address.
       {% endblocktranslate %}
       </p>
       <form method="post"

--- a/commcare_connect/templates/account/password_reset.html
+++ b/commcare_connect/templates/account/password_reset.html
@@ -26,8 +26,7 @@
     </div>
     <div class="flex justify-between items-center">
       <div></div>
-      <button class="button button-md outline-style"
-              @click="submitWithValidation()">
+      <button type="submit" class="button button-md outline-style">
         <span class="relative z-20">{% translate "Reset" %}</span>
       </button>
     </div>

--- a/commcare_connect/templates/account/password_reset_from_key.html
+++ b/commcare_connect/templates/account/password_reset_from_key.html
@@ -51,10 +51,8 @@
         </div>
         <div class="text-sm text-gray-400 text-center mt-auto border-t-gray-200 border-t-2 pt-4 ">
           Don't have an account?
-          <a href="#"
-             class="text-brand-indigo font-medium"
-             @click="submitWithValidation()"
-             @submit.prevent="submitWithValidation()">Signup</a>
+          <a href="{% url 'account_signup' %}"
+             class="text-brand-indigo font-medium">Signup</a>
         </div>
       </form>
     {% else %}

--- a/commcare_connect/templates/account/password_reset_from_key_done.html
+++ b/commcare_connect/templates/account/password_reset_from_key_done.html
@@ -6,6 +6,13 @@
 {% block inner %}
   <div class="w-full min-h-[620px] h-fit flex flex-col gap-4">
     <h1 class="title text-brand-deep-purple">{% translate "Change Password" %}</h1>
-    <p>{% translate 'Your password is now changed.' %}</p>
+    <p>{% translate 'Your password is now changed. You can now sign in with your new password.' %}</p>
+    <div class="flex justify-between items-center">
+      <div></div>
+      <a href="{% url 'account_login' %}"
+         class="button button-md primary-dark">
+        <span class="relative z-20">{% translate "Sign In" %}</span>
+      </a>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Addresses items from Jon's section of the Connect dogfooding feedback doc, in the django-allauth account flows. **Verified live against `runserver`** — the signup → confirm-email and password-reset flows were driven end to end; screenshots of each rendered page are below.

## 1. Email confirmation — confusing / invite-implying copy

**Page:** read *"<email> is an e-mail address for user <email>"* — redundant on self-signup. Now: *"Please confirm that <email> is your e-mail address."*

![Confirm e-mail address page](https://raw.githubusercontent.com/jjackson/commcare-connect/pr-1335-assets/01-email-confirm.png)

**Email:** read *"user X has given your e-mail address to register an account"*, which implies someone else invited you. Added `account/email/email_confirmation_signup_message.txt` overriding allauth's default so the signup email uses self-signup wording. Rendered output:

```
Hello from Connect!

You're receiving this email because you signed up for an account on commcare-connect.org.

To confirm your email address and finish creating your account, go to https://connect.dimagi.org/accounts/confirm-email/<key>/

If you didn't sign up, you can safely ignore this email.

Thank you for using Connect!
commcare-connect.org
```

## 2. Password reset — dead-end after completion

The *"Your password is now changed"* page had no link or button. Added a **Sign In** button linking to login.

![Password changed page with Sign In button](https://raw.githubusercontent.com/jjackson/commcare-connect/pr-1335-assets/03-password-reset-done.png)

Also removed three dead `@click`/`@submit` handlers calling an undefined `submitWithValidation()` in the reset-request and reset-from-key templates — the reset-request **Reset** button is now a plain `type="submit"` and the **Signup** link is a real `{% url %}`:

![Password reset request page](https://raw.githubusercontent.com/jjackson/commcare-connect/pr-1335-assets/02-password-reset.png)

## Note on the login "stale error" feedback item

The doc also flagged that the login error doesn't clear after you re-type a password. This needs **no code change**: login-password correctness is only knowable server-side at submit, and the existing behavior already clears the error exactly when the password passes (a correct password logs you in). Clearing it on keystroke would give false reassurance, so it's intentionally left as-is.

## Validation

- Drove the live signup → confirm-email flow and the password-reset flow on `runserver`: confirm page, confirmation email, and reset-done button all render as intended (screenshots above).
- Rendered the new email template through real Django + allauth — confirmed it shadows allauth's default.
- All templates compile and pass the repo's prek hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
