### PR TITLE
Show numerator/denominator breakdown for WA Coverage to Visit Ratio in audit report

### DIFF
--- a/commcare_connect/audit/calculations.py
+++ b/commcare_connect/audit/calculations.py
@@ -15,11 +15,15 @@ class Measurement:
     ``denominator`` overrides the displayed fraction's denominator for percentage
     calculations whose rate is taken over a different population than the gate;
     when ``None`` the denominator defaults to ``sample_size``.
+    ``components`` exposes the sub-fractions of a value that is itself built from
+    several fractions (e.g. a ratio-of-ratios); each entry is a
+    ``{"numerator", "denominator"}`` dict, rendered in order alongside the value.
     """
 
     value: Any
     sample_size: int
     denominator: int | None = None
+    components: list[dict] | None = None
 
 
 @dataclass
@@ -31,6 +35,7 @@ class CalculationResult:
     in_range: bool
     numerator: int | None = None
     denominator: int | None = None
+    components: list[dict] | None = None
 
     def to_dict(self) -> dict:
         d = {
@@ -43,6 +48,8 @@ class CalculationResult:
             d["numerator"] = self.numerator
         if self.denominator is not None:
             d["denominator"] = self.denominator
+        if self.components is not None:
+            d["components"] = self.components
         return d
 
 
@@ -105,6 +112,7 @@ class AuditCalculation(ABC):
             in_range=self._in_range(m.value),
             numerator=numerator,
             denominator=denominator,
+            components=m.components,
         )
 
     def _in_range(self, value) -> bool:
@@ -117,17 +125,29 @@ class AuditCalculation(ABC):
 
 def format_value(result: dict, with_fraction: bool = False) -> str:
     """Format a calculation result dict for display. Reads ``value`` and,
-    for percentages, ``numerator``/``denominator``."""
+    for percentages, ``numerator``/``denominator``; for values built from
+    sub-fractions, ``components``."""
     value = result.get("value")
     if value is None:
         return "-"
+    components = result.get("components")
+    if components:
+        return f"{_format_scalar(value)} ({_format_components(components)})"
     if result.get("numerator") is not None:
         if with_fraction:
             return f"{round(value)}% ({result['numerator']}/{result['denominator']})"
         return f"{round(value)}%"
+    return _format_scalar(value)
+
+
+def _format_scalar(value) -> str:
     if isinstance(value, float):
         return f"{value:.2f}"
     return str(value)
+
+
+def _format_components(components: list[dict]) -> str:
+    return " / ".join(f"({c['numerator']}/{c['denominator']})" for c in components)
 
 
 def register_calculation(cls):

--- a/commcare_connect/audit/calculations.py
+++ b/commcare_connect/audit/calculations.py
@@ -12,7 +12,7 @@ class Measurement:
     """Raw result of a calculation's ``compute()``: a ``value`` over a sample.
 
     ``sample_size`` is the gating quantity compared against ``min_sample_size``.
-    ``denominator`` overrides the displayed fraction's denominator for percentage
+    ``denominator_override`` sets the displayed fraction's denominator for percentage
     calculations whose rate is taken over a different population than the gate;
     when ``None`` the denominator defaults to ``sample_size``.
     ``components`` exposes the sub-fractions of a value that is itself built from
@@ -22,7 +22,7 @@ class Measurement:
 
     value: Any
     sample_size: int
-    denominator: int | None = None
+    denominator_override: int | None = None
     components: list[dict] | None = None
 
 
@@ -82,7 +82,7 @@ class AuditCalculation(ABC):
     @abstractmethod
     def compute(self, opportunity_access, period_start, period_end) -> Measurement:
         """Return a :class:`Measurement`. ``value`` may be ``None`` when
-        ``sample_size == 0``. Set ``denominator`` only when a percentage's rate
+        ``sample_size == 0``. Set ``denominator_override`` only when a percentage's rate
         is taken over a different population than the gating ``sample_size``.
         """
 
@@ -102,7 +102,7 @@ class AuditCalculation(ABC):
         if self.is_percentage and m.value is not None:
             # Denominator defaults to the gating sample unless compute() overrode
             # it; the numerator is derived from value so the two never diverge.
-            denominator = m.sample_size if m.denominator is None else m.denominator
+            denominator = m.sample_size if m.denominator_override is None else m.denominator_override
             numerator = round(m.value * denominator / 100)
         return CalculationResult(
             name=self.name,

--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -291,9 +291,17 @@ class WACoverageToVisitRatio(AuditCalculation):
         if not (total_eligible and expected_visits and actual_visits):
             return Measurement(None, 0)
 
-        coverage_ratio = wa_stats["visited_count"] / total_eligible
+        visited_count = wa_stats["visited_count"]
+        coverage_ratio = visited_count / total_eligible
         visit_ratio = actual_visits / expected_visits
-        return Measurement(coverage_ratio / visit_ratio, total_eligible)
+        return Measurement(
+            coverage_ratio / visit_ratio,
+            total_eligible,
+            components=[
+                {"numerator": visited_count, "denominator": total_eligible},
+                {"numerator": actual_visits, "denominator": expected_visits},
+            ],
+        )
 
 
 @register_calculation

--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -338,7 +338,7 @@ class InaccessibleWARateEarlyWarning(AuditCalculation):
         return Measurement(
             value=_percent(stats["inaccessible_count"], stats["total"]),
             sample_size=stats["terminal_count"],
-            denominator=stats["total"],
+            denominator_override=stats["total"],
         )
 
 

--- a/commcare_connect/audit/tests/test_calculations.py
+++ b/commcare_connect/audit/tests/test_calculations.py
@@ -24,6 +24,28 @@ from commcare_connect.audit.calculations import (
         ({"value": 56.44543, "numerator": 3, "denominator": 5}, True, "56% (3/5)"),
         ({"value": 0.564356}, True, "0.56"),
         ({"value": None}, True, "-"),
+        (
+            {
+                "value": 0.8,
+                "components": [
+                    {"numerator": 1, "denominator": 2},
+                    {"numerator": 10, "denominator": 20},
+                ],
+            },
+            False,
+            "0.80 ((1/2) / (10/20))",
+        ),
+        (
+            {
+                "value": 0.8,
+                "components": [
+                    {"numerator": 1, "denominator": 2},
+                    {"numerator": 10, "denominator": 20},
+                ],
+            },
+            True,
+            "0.80 ((1/2) / (10/20))",
+        ),
     ],
 )
 def test_format_value(result, with_fraction, expected):
@@ -100,6 +122,32 @@ class _PctCalc(AuditCalculation):
 
     def compute(self, opportunity_access, period_start, period_end):
         return self._measurement
+
+
+class _RatioCalc(AuditCalculation):
+    name = "ratio"
+    label = "Ratio"
+    min_sample_size = 1
+
+    def compute(self, opportunity_access, period_start, period_end):
+        return Measurement(
+            0.8,
+            2,
+            components=[
+                {"numerator": 1, "denominator": 2},
+                {"numerator": 10, "denominator": 20},
+            ],
+        )
+
+
+def test_components_flow_through_run_and_to_dict():
+    result = _RatioCalc().run(None, None, None)
+    components = [
+        {"numerator": 1, "denominator": 2},
+        {"numerator": 10, "denominator": 20},
+    ]
+    assert result.components == components
+    assert result.to_dict()["components"] == components
 
 
 def test_percentage_denominator_defaults_to_sample_size():

--- a/commcare_connect/audit/tests/test_calculations.py
+++ b/commcare_connect/audit/tests/test_calculations.py
@@ -158,7 +158,7 @@ def test_percentage_denominator_defaults_to_sample_size():
 
 def test_percentage_denominator_override_decouples_from_gating_sample():
     # Gate on sample_size=6 (>= min 5), but report the rate over 8.
-    result = _PctCalc(Measurement(25.0, 6, denominator=8)).run(None, None, None)
+    result = _PctCalc(Measurement(25.0, 6, denominator_override=8)).run(None, None, None)
     assert result.has_sufficient_data is True
     assert result.denominator == 8
     assert result.numerator == 2  # round(25.0 * 8 / 100), derived from value not sample_size

--- a/commcare_connect/audit/tests/test_chc_indicators.py
+++ b/commcare_connect/audit/tests/test_chc_indicators.py
@@ -455,6 +455,29 @@ class TestWACoverageToVisitRatio(BaseIndicatorTest):
         # VISITED + INACCESSIBLE = 2 eligible; coverage=1/2, visit_ratio=10/20 → ratio=1.0
         self.assert_compute_result(access, sample=2, value=1.0)
 
+    def test_components_expose_both_sub_fractions(self):
+        access, wag = make_access_and_wag()
+        wa = WorkAreaFactory(
+            opportunity=wag.opportunity,
+            work_area_group=wag,
+            opportunity_access=access,
+            status=WorkAreaStatus.VISITED,
+            expected_visit_count=10,
+        )
+        WorkAreaFactory(
+            opportunity=wag.opportunity,
+            work_area_group=wag,
+            opportunity_access=access,
+            status=WorkAreaStatus.NOT_VISITED,
+            expected_visit_count=10,
+        )
+        make_visits(10, access, work_area=wa)
+        # coverage = 1 visited / 2 eligible; visits = 10 actual / 20 expected
+        assert self.compute(access).components == [
+            {"numerator": 1, "denominator": 2},
+            {"numerator": 10, "denominator": 20},
+        ]
+
     def test_no_actual_visits_returns_insufficient_data(self):
         access, wag = make_access_and_wag()
         WorkAreaFactory(


### PR DESCRIPTION
## Product Description

The **WA Coverage to Visit Ratio** column in the weekly performance audit report now shows the numbers behind the ratio. Because this indicator is a ratio of two ratios, the cell now displays both sub-fractions alongside the value — the coverage fraction (visited / eligible work areas) and the visit fraction (actual / expected visits) — rendered as `value ((a/b) / (c/d))`, e.g. `1.00 ((2/5) / (16/40))`. Previously only the final value (`1.00`) was shown, with no way to see how it was derived. 

**Old:**
<img width="1575" height="728" alt="Screenshot_20260701_124259" src="https://github.com/user-attachments/assets/58be582a-965b-4b00-a46f-0ad72a13ca39" />

**New:**
<img width="1593" height="700" alt="Screenshot_20260701_125259" src="https://github.com/user-attachments/assets/6133d62a-a995-48f5-a09b-aa9bd3dd30c3" />

The same breakdown appears in the flagged-worker review modal:
<img width="762" height="447" alt="Screenshot_20260701_163126" src="https://github.com/user-attachments/assets/3aaef821-4fc7-4413-abda-5637a4033b5f" />

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2480)

This is a release path 3 feature — Experiments & early stage iterations of product area.

The existing result model only carried a single `numerator`/`denominator` pair (derived automatically for percentage indicators), which can't express a ratio-of-ratios. Rather than special-casing this one indicator in the renderer, a generic optional `components` list was added to `Measurement`/`CalculationResult` so any future multi-fraction indicator can reuse it; it serializes into the stored results JSON and renders in `format_value()`. A second, independent commit renames `Measurement.denominator` to `denominator_override` (it is an optional override that falls back to `sample_size`); `CalculationResult.denominator` and the persisted dict key are deliberately left unchanged, since there the value is the resolved display denominator and the key lives in stored report data.

## Safety Assurance

### Safety story

The change is additive and display-only: `components` is a new optional field populated by a single indicator, so existing stored report results are unaffected (they simply lack the key and render exactly as before), and no data migration is required. The renamed field lives only on the transient `Measurement` object, which is never persisted. The audit report remains behind its existing feature flag. Verified locally by recomputing pending reports and confirming the breakdown renders correctly.

### Automated test coverage

Tests cover `format_value` rendering of the new `components` (with and without the fraction flag), the flow of components through `run()` into `to_dict()`, and the ratio indicator's `compute()` emitting both the coverage and visit sub-fractions; the existing percentage-denominator tests were updated for the rename and continue to pass.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
