### PR TITLE
Add transcript and translation editing for audio attachments

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -23,6 +23,7 @@ from commcare_connect.opportunity.app_xml import get_task_units_for_app
 from commcare_connect.opportunity.models import (
     AssignedTask,
     AssignedTaskStatus,
+    AudioAttachment,
     CommCareApp,
     CompletedWork,
     CompletedWorkStatus,
@@ -2141,3 +2142,32 @@ class EditAssignedTaskForm(forms.ModelForm):
     def has_changed(self):
         # Ignore "reason" field if no updated due date is given
         return "due_date" in self.changed_data
+
+
+class AudioAttachmentTranscribeForm(forms.ModelForm):
+    class Meta:
+        model = AudioAttachment
+        fields = ["transcript", "translation"]
+        labels = {
+            "transcript": _("Transcript"),
+            "translation": _("English Translation"),
+        }
+        widgets = {
+            "transcript": forms.Textarea(
+                attrs={
+                    "rows": 6,
+                    "placeholder": _("Type or paste the transcript..."),
+                }
+            ),
+            "translation": forms.Textarea(
+                attrs={
+                    "rows": 6,
+                    "placeholder": _("Type or paste the English translation..."),
+                }
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2,6 +2,7 @@ import inspect
 from datetime import UTC, date, datetime, time, timedelta
 from http import HTTPStatus
 from unittest import mock
+from urllib.parse import urlencode
 from uuid import uuid4
 
 import pytest
@@ -2817,3 +2818,66 @@ def test_user_visit_details_renders_audio_player(client, organization, org_user_
     )
     assert audio_url.encode() in response.content
     assert b"hello world" in response.content
+
+
+@pytest.mark.django_db
+class TestAudioAttachmentTranscribe:
+    def _url(self, organization, opportunity, audio):
+        return reverse(
+            "opportunity:audio_attachment_transcribe",
+            args=(organization.slug, opportunity.opportunity_id, audio.pk),
+        )
+
+    def test_get_renders_form(self, client, organization, org_user_member, opportunity):
+        worker = UserFactory(name="Gabriella Nelson")
+        visit = UserVisitFactory.create(opportunity=opportunity, user=worker)
+        audio = AudioAttachmentFactory.create(user_visit=visit)
+
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity, audio))
+
+        assert response.status_code == 200
+        assert opportunity.program.name.encode() in response.content
+        assert b"Connect Workers" in response.content
+        assert b"Gabriella Nelson" in response.content
+
+    def test_post_saves_transcript_and_translation(self, client, organization, org_user_member, opportunity):
+        visit = UserVisitFactory.create(opportunity=opportunity)
+        audio = AudioAttachmentFactory.create(user_visit=visit)
+
+        client.force_login(org_user_member)
+        response = client.post(
+            self._url(organization, opportunity, audio),
+            data={"transcript": "hello", "translation": "bonjour"},
+        )
+
+        audio.refresh_from_db()
+        assert audio.transcript == "hello"
+        assert audio.translation == "bonjour"
+        assert response.status_code == 302
+        assert response.url == (
+            f"{reverse('opportunity:user_visits_list', args=(organization.slug, opportunity.opportunity_id))}"
+            f"?{urlencode({'user': visit.user.user_id})}"
+        )
+
+    def test_program_manager_cannot_access(
+        self, client, organization, program_manager_org, program_manager_org_user_admin
+    ):
+        program = ProgramFactory(organization=program_manager_org)
+        managed_opp = OpportunityFactory(program=program, organization=organization)
+        visit = UserVisitFactory.create(opportunity=managed_opp)
+        audio = AudioAttachmentFactory.create(user_visit=visit)
+
+        client.force_login(program_manager_org_user_admin)
+        response = client.get(self._url(program_manager_org, managed_opp, audio))
+
+        assert response.status_code == 404
+
+    def test_wrong_opportunity_returns_404(self, client, organization, org_user_member, opportunity):
+        other_visit = UserVisitFactory.create()  # belongs to a different opportunity
+        audio = AudioAttachmentFactory.create(user_visit=other_visit)
+
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity, audio))
+
+        assert response.status_code == 404

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 from commcare_connect.opportunity import views
 from commcare_connect.opportunity.views import (
     AssignedTaskListView,
+    AudioAttachmentTranscribe,
     EditAssignedTask,
     EditTaskType,
     OpportunityCompletedWorkTable,
@@ -105,6 +106,11 @@ urlpatterns = [
         "<slug:opp_id>/fetch_audio_attachment/<int:pk>",
         view=fetch_audio_attachment,
         name="fetch_audio_attachment",
+    ),
+    path(
+        "<slug:opp_id>/audio_attachment/<int:pk>/transcribe/",
+        view=AudioAttachmentTranscribe.as_view(),
+        name="audio_attachment_transcribe",
     ),
     path(
         "<slug:opp_id>/completed_work_table/",

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -16,6 +16,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.contrib.messages.views import SuccessMessageMixin
 from django.core.cache import cache
 from django.core.files.storage import default_storage, storages
 from django.db import transaction
@@ -79,6 +80,7 @@ from commcare_connect.opportunity.forms import (
     AddBudgetExistingUsersForm,
     AddBudgetNewUsersForm,
     AddTaskTypeForm,
+    AudioAttachmentTranscribeForm,
     AutomatedPaymentInvoiceForm,
     CreateTaskForm,
     DeliverUnitFlagsForm,
@@ -1160,6 +1162,61 @@ def fetch_audio_attachment(request, org_slug, opp_id, pk):
     except FileNotFoundError:
         return HttpResponseNotFound()
     return FileResponse(attachment, filename=audio.name, content_type=audio.content_type)
+
+
+class AudioAttachmentTranscribe(
+    SuccessMessageMixin, OrganizationUserMemberRoleMixin, OpportunityObjectMixin, UpdateView
+):
+    model = AudioAttachment
+    form_class = AudioAttachmentTranscribeForm
+    template_name = "opportunity/audio_attachment_transcribe.html"
+    success_message = gettext_lazy("Transcript saved.")
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.is_opportunity_pm:
+            raise Http404()
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_object(self, queryset=None):
+        return get_object_or_404(
+            AudioAttachment.objects.select_related("user_visit__user", "user_visit__opportunity__program"),
+            pk=self.kwargs["pk"],
+            user_visit__opportunity=self.get_opportunity(),
+        )
+
+    def get_visit_details_url(self):
+        return (
+            f"{reverse('opportunity:user_visits_list', args=(self.kwargs['org_slug'], self.kwargs['opp_id']))}"
+            f"?{urlencode({'user': self.object.user_visit.user.user_id})}"
+        )
+
+    def get_breadcrumbs(self, org_slug, opp_id):
+        user_visit = self.object.user_visit
+        opportunity = user_visit.opportunity
+
+        return [
+            {"title": opportunity.program.name, "url": reverse("program:home", args=(org_slug,))},
+            {"title": _("Opportunities"), "url": reverse("opportunity:list", args=(org_slug,))},
+            {
+                "title": opportunity.name,
+                "url": reverse("opportunity:detail", args=(org_slug, opp_id)),
+            },
+            {
+                "title": _("Connect Workers"),
+                "url": reverse("opportunity:worker_deliver", args=(org_slug, opp_id)),
+            },
+            {"title": user_visit.user.name, "url": self.get_visit_details_url()},
+            {"title": _("Transcribe Audio"), "url": self.request.path},
+        ]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["path"] = self.get_breadcrumbs(self.kwargs["org_slug"], self.kwargs["opp_id"])
+        context["visit_details_url"] = self.get_visit_details_url()
+        return context
+
+    def get_success_url(self):
+        return self.get_visit_details_url()
 
 
 @org_member_required

--- a/commcare_connect/templates/opportunity/audio_attachment_transcribe.html
+++ b/commcare_connect/templates/opportunity/audio_attachment_transcribe.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% block title %}
+  {{ request.org }} - {% translate "Transcribe Audio" %}
+{% endblock title %}
+{% block content %}
+  {% include "components/breadcrumbs.html" with path=path %}
+  <div class="card_bg md:max-w-screen-md mx-auto flex flex-col gap-6">
+    <h1 class="card_title">{% translate "Transcribe Audio" %}</h1>
+    <audio controls preload="metadata" class="w-full">
+      <source src="{% url 'opportunity:fetch_audio_attachment' org_slug=request.org.slug opp_id=object.user_visit.opportunity.opportunity_id pk=object.pk %}"
+              type="{{ object.content_type }}">
+      {% translate "Your browser does not support the audio element." %}
+    </audio>
+    <form method="post" class="flex flex-col gap-4">
+      {% csrf_token %}
+      {% crispy form %}
+      <div class="flex justify-end gap-3">
+        <a href="{{ visit_details_url }}" class="button button-md outline-style">{% translate "Cancel" %}</a>
+        <button type="submit" class="button button-md primary-dark">{% translate "Save" %}</button>
+      </div>
+    </form>
+  </div>
+{% endblock content %}

--- a/commcare_connect/templates/opportunity/user_visit_details.html
+++ b/commcare_connect/templates/opportunity/user_visit_details.html
@@ -114,6 +114,16 @@
               <p class="text-sm font-normal text-brand-deep-purple">{{ audio.translation }}</p>
             </div>
           {% endif %}
+          {% if not request.is_opportunity_pm %}
+            <a href="{% url 'opportunity:audio_attachment_transcribe' org_slug=request.org.slug opp_id=user_visit.opportunity.opportunity_id pk=audio.pk %}"
+               class="button button-sm outline-style w-fit">
+              {% if audio.transcript or audio.translation %}
+                <i class="fa-regular fa-pen-to-square mr-1"></i>{% translate "Edit Transcript" %}
+              {% else %}
+                <i class="fa-solid fa-plus mr-1"></i>{% translate "Add Transcript" %}
+              {% endif %}
+            </a>
+          {% endif %}
         </div>
       {% endfor %}
     </div>

--- a/commcare_connect/templates/opportunity/user_visit_details.html
+++ b/commcare_connect/templates/opportunity/user_visit_details.html
@@ -103,15 +103,33 @@
             {% translate "Your browser does not support the audio element." %}
           </audio>
           {% if audio.transcript %}
-            <div>
+            <div x-data="{ expanded: false, overflowing: false }"
+                 x-init="$nextTick(() => overflowing = $refs.transcriptText.scrollHeight > $refs.transcriptText.clientHeight)">
               <p class="text-sm font-medium text-brand-blue-light">{% translate "Transcript" %}</p>
-              <p class="text-sm font-normal text-brand-deep-purple">{{ audio.transcript }}</p>
+              <p x-ref="transcriptText"
+                 class="text-sm font-normal text-brand-deep-purple"
+                 :class="expanded ? '' : 'line-clamp-3'">{{ audio.transcript }}</p>
+              <button type="button"
+                      x-show="overflowing"
+                      x-cloak
+                      @click="expanded = !expanded"
+                      class="block w-fit ml-auto text-sm font-medium text-brand-blue-light hover:underline"
+                      x-text="expanded ? '{% translate 'Show less' %}' : '{% translate 'Show more' %}'"></button>
             </div>
           {% endif %}
           {% if audio.translation %}
-            <div>
+            <div x-data="{ expanded: false, overflowing: false }"
+                 x-init="$nextTick(() => overflowing = $refs.translationText.scrollHeight > $refs.translationText.clientHeight)">
               <p class="text-sm font-medium text-brand-blue-light">{% translate "Translation" %}</p>
-              <p class="text-sm font-normal text-brand-deep-purple">{{ audio.translation }}</p>
+              <p x-ref="translationText"
+                 class="text-sm font-normal text-brand-deep-purple"
+                 :class="expanded ? '' : 'line-clamp-3'">{{ audio.translation }}</p>
+              <button type="button"
+                      x-show="overflowing"
+                      x-cloak
+                      @click="expanded = !expanded"
+                      class="block w-fit ml-auto text-sm font-medium text-brand-blue-light hover:underline"
+                      x-text="expanded ? '{% translate 'Show less' %}' : '{% translate 'Show more' %}'"></button>
             </div>
           {% endif %}
           {% if not request.is_opportunity_pm %}


### PR DESCRIPTION
## Product Description
<img width="1792" height="1005" alt="Screenshot 2026-07-02 at 12 30 06 AM" src="https://github.com/user-attachments/assets/11745073-309c-43e2-9691-ced7a20865fd" />
<img width="1796" height="1005" alt="Screenshot 2026-07-02 at 12 30 36 AM" src="https://github.com/user-attachments/assets/9e598938-224c-4d57-86a4-1332ae2e5848" />



## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-2607

Depends on #1339 (audio attachment model and playback), so this diff only shows the transcribe feature on top of it. Program managers are blocked from the transcribe page since transcripts fall outside their scope. Saving redirects back to the worker's filtered visit list rather than the single visit detail page, since that's where reviewers land this feature from.

## Safety Assurance

### Safety story

Tested locally: submitting a transcript/translation saves correctly, the transcribe page 404s for a mismatched opportunity or a program manager, and the existing audio playback tests still pass.

### Automated test coverage

Added tests for rendering the transcribe form, saving it, and the two 404 cases; all passing.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change