### PR TITLE
Add visits-completed, and work-area slug to work-area selection div

### DIFF
--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -676,6 +676,11 @@ class ModifyWorkAreaUpdateView(UpdateView):
             )
             return super().form_invalid(form)
 
+        visits_completed = UserVisit.objects.filter(
+            opportunity=work_area.opportunity,
+            work_area=work_area,
+            status=VisitValidationStatus.approved,
+        ).count()
         response = HttpResponse(status=204)
         response["HX-Trigger"] = json.dumps(
             {
@@ -684,6 +689,8 @@ class ModifyWorkAreaUpdateView(UpdateView):
                     "expected_visit_count": work_area.expected_visit_count,
                     "group_id": work_area.work_area_group_id,
                     "group_name": getattr(work_area.work_area_group, "name", None),
+                    "slug": work_area.slug,
+                    "visits_completed": visits_completed,
                 }
             }
         )

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -392,7 +392,17 @@ def import_status(request, org_slug, opp_id):
 
 class WorkAreaVectorLayer(VectorLayer):
     id = "workareas"
-    tile_fields = ("id", "status", "building_count", "expected_visit_count", "group_id", "group_name", "assignee_name")
+    tile_fields = (
+        "id",
+        "status",
+        "building_count",
+        "expected_visit_count",
+        "group_id",
+        "group_name",
+        "assignee_name",
+        "slug",
+        "visits_completed",
+    )
     geom_field = "boundary"
     min_zoom = WORKAREA_MIN_ZOOM
 
@@ -406,6 +416,7 @@ class WorkAreaVectorLayer(VectorLayer):
             group_id=F("work_area_group__id"),
             group_name=F("work_area_group__name"),
             assignee_name=F("opportunity_access__user__name"),
+            visits_completed=Count("uservisit", filter=Q(uservisit__status=VisitValidationStatus.approved)),
         )
         return WorkAreaMapFilterSet(self.filter_params, queryset=qs, opportunity=self.opportunity).qs
 

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -189,9 +189,17 @@
                     <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
                         x-text="selectedFeature.group_name ?? '—'">
                     </dd>
+                    <dt class="text-sm text-gray-500">{% translate "Area Slug" %}</dt>
+                    <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
+                        x-text="selectedFeature.slug ?? '—'">
+                    </dd>
                     <dt class="text-sm text-gray-500">{% translate "Expected Visit Count" %}</dt>
                     <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
                         x-text="selectedFeature.expected_visit_count ?? '—'">
+                    </dd>
+                    <dt class="text-sm text-gray-500">{% translate "Number of Visits Completed" %}</dt>
+                    <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"
+                        x-text="selectedFeature.visits_completed ?? '—'">
                     </dd>
                     <dt class="text-sm text-gray-500">{% translate "Number of Buildings" %}</dt>
                     <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50"

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -554,6 +554,8 @@
                             expected_visit_count: data.expected_visit_count,
                             group_id: data.group_id,
                             group_name: data.group_name,
+                            slug: data.slug,
+                            visits_completed: data.visits_completed,
                         };
                     }
 


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2587

Adds `Area Slug` and `Number of Visits Completed` info to `Select Work Area` section on microplanning page.

## Technical Summary

Pretty trivial addition of a model field for area slug, and a simple visit calculation for completed visits data. 

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
