### PR TITLE
Fix incorrect per-visit cost in add-budget confirm modal

### DIFF
--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 from datetime import UTC, date, datetime, time, timedelta
 from http import HTTPStatus
 from unittest import mock
@@ -181,6 +182,29 @@ def test_add_budget_existing_users_for_managed_opportunity(
     form = response.context["form"]
     assert "number_of_visits" in form.errors
     assert form.errors["number_of_visits"][0] == "The number of visits being increased exceeds the opportunity budget."
+
+
+@pytest.mark.django_db
+def test_add_budget_existing_users_per_visit_cost_includes_org_amount(
+    organization: Organization, org_user_member: User, opportunity: Opportunity, mobile_user: User, client: Client
+):
+    payment_unit_1 = PaymentUnitFactory(opportunity=opportunity, amount=3000, org_amount=30984, max_total=12)
+    payment_unit_2 = PaymentUnitFactory(opportunity=opportunity, amount=0, org_amount=0, max_total=12)
+    opportunity.organization = organization
+    opportunity.total_budget = 1_000_000
+    opportunity.save()
+
+    access = OpportunityAccess.objects.get(opportunity=opportunity, user=mobile_user)
+    claim = OpportunityClaimFactory(opportunity_access=access, end_date=opportunity.end_date)
+    OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit_1, max_visits=12)
+    OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit_2, max_visits=12)
+
+    url = reverse("opportunity:add_budget_existing_users", args=(organization.slug, opportunity.pk))
+    client.force_login(org_user_member)
+    response = client.get(url)
+
+    per_visit_costs = json.loads(response.context["per_visit_costs_json"])
+    assert per_visit_costs[str(claim.id)] == 33984
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -23,6 +23,7 @@ from django.db.models import (
     Case,
     Count,
     DecimalField,
+    F,
     FloatField,
     Func,
     IntegerField,
@@ -646,7 +647,13 @@ def review_visit_import(request, org_slug=None, opp_id=None):
 def add_budget_existing_users(request, org_slug=None, opp_id=None):
     opportunity_access = OpportunityAccess.objects.filter(opportunity=request.opportunity)
     opportunity_claims = OpportunityClaim.objects.filter(opportunity_access__in=opportunity_access).annotate(
-        total_max_visits=Coalesce(Sum("opportunityclaimlimit__max_visits"), Value(0))
+        total_max_visits=Coalesce(Sum("opportunityclaimlimit__max_visits"), Value(0)),
+        total_per_visit_cost=Coalesce(
+            Sum(
+                F("opportunityclaimlimit__payment_unit__amount") + F("opportunityclaimlimit__payment_unit__org_amount")
+            ),
+            Value(0),
+        ),
     )
 
     form = AddBudgetExistingUsersForm(
@@ -708,7 +715,7 @@ def add_budget_existing_users(request, org_slug=None, opp_id=None):
             "tabs": tabs,
             "path": path,
             "opportunity_claims": opportunity_claims,
-            "budget_per_visit": request.opportunity.budget_per_visit,
+            "per_visit_costs_json": json.dumps({claim.id: claim.total_per_visit_cost for claim in opportunity_claims}),
             "opportunity": request.opportunity,
         },
     )

--- a/commcare_connect/templates/opportunity/add_visits_existing_users.html
+++ b/commcare_connect/templates/opportunity/add_visits_existing_users.html
@@ -29,12 +29,12 @@
     }
   }
 
-  function handleExistingBudgetComponent(budgetPerVisit) {
+  function handleExistingBudgetComponent(perVisitCosts) {
     return {
       modalOpen: false,
       numberOfVisits: null,
       adjustmentType: null,
-      budgetPerVisit: budgetPerVisit,
+      perVisitCosts: perVisitCosts,
       selected_users: [],
       end_date: '',
       openModal() {
@@ -60,7 +60,12 @@
         return this.selected_users.length * (parseInt(this.numberOfVisits) || 0);
       },
       calculatedBudget() {
-        return (this.totalVisits() * budgetPerVisit)
+        const numberOfVisits = parseInt(this.numberOfVisits) || 0;
+        const selectedCost = this.selected_users.reduce(
+          (total, id) => total + (this.perVisitCosts[id] || 0),
+          0
+        );
+        return numberOfVisits * selectedCost;
       },
       // Validation methods
       hasnumberOfVisitsOrEndDate() {
@@ -128,7 +133,7 @@
       <!-- Add budget for existing users-->
       <div x-show="selectedTab === 'existing_workers'">
         <form method="post"
-              x-data="handleExistingBudgetComponent({{ budget_per_visit }})">
+              x-data="handleExistingBudgetComponent({{ per_visit_costs_json|safe }})">
           {% csrf_token %}
           {% if form.non_field_errors %}
             <div class="text-sm text-red-600 mt-1">

--- a/commcare_connect/templates/opportunity/add_visits_existing_users.html
+++ b/commcare_connect/templates/opportunity/add_visits_existing_users.html
@@ -133,7 +133,7 @@
       <!-- Add budget for existing users-->
       <div x-show="selectedTab === 'existing_workers'">
         <form method="post"
-              x-data="handleExistingBudgetComponent({{ per_visit_costs_json|safe }})">
+              x-data='handleExistingBudgetComponent({{ per_visit_costs_json|safe }})'>
           {% csrf_token %}
           {% if form.non_field_errors %}
             <div class="text-sm text-red-600 mt-1">


### PR DESCRIPTION
## Product Description

The **"Add Budget – Existing Users"** confirmation modal now calculates the budget increase using the total per-visit cost (`amount + org_amount`).

The preview now matches the actual budget deducted on save and the server-side budget validation.

| Before `1 × amount (2) = 2` | After `1 × (amount (2) + org_amount (5)) = 7` |
|--------|--------|
| <img width="1732" alt="Before" src="https://github.com/user-attachments/assets/6eccd284-a347-49ba-b1a3-7d5735f2d32a" /> | <img width="1906" alt="After" src="https://github.com/user-attachments/assets/7e4920e7-68cf-429e-8058-ab6eb1b24710" /> |

## Technical Summary

[CI-775](https://dimagi.atlassian.net/browse/CI-775)

Opportunity.budget_per_visit` excludes `org_amount`, but the backend validation includes it — so the preview and the actual check were out of sync.

## Safety Assurance

### Safety story

Change is scoped to the confirm-modal preview calculation and the context passed to it; the server-side budget validation logic (`AddBudgetExistingUsersForm`) is untouched. Verified existing tests for this view still pass, and ran `prek run -a` clean.

### Automated test coverage

Added `test_add_budget_existing_users_per_visit_cost_includes_org_amount` to assert the per-visit cost passed to the template includes `org_amount`, not just `amount`, across multiple payment units for a claim.

### QA Plan
Not Needed tested locally

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CI-775]: https://dimagi.atlassian.net/browse/CI-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
