### PR TITLE
Cs/ccct 2551 login button

### DIFF
--- a/commcare_connect/opportunity/tests/test_ocs_connect_context.py
+++ b/commcare_connect/opportunity/tests/test_ocs_connect_context.py
@@ -1,0 +1,36 @@
+import pytest
+from allauth.socialaccount.models import SocialAccount
+
+from commcare_connect.opportunity.views import _ocs_connect_context
+
+
+@pytest.mark.django_db
+def test_next_url_prefers_hx_current_url_over_path(rf, user):
+    request = rf.get("/a/org/opportunity/create_task/", HTTP_HX_CURRENT_URL="/a/org/opportunity/tasks/")
+    request.user = user
+
+    context = _ocs_connect_context(request)
+
+    assert context["ocs_next_url"] == "/a/org/opportunity/tasks/"
+
+
+@pytest.mark.django_db
+def test_next_url_falls_back_to_full_path(rf, user):
+    request = rf.get("/a/org/opportunity/tasks/")
+    request.user = user
+
+    context = _ocs_connect_context(request)
+
+    assert context["ocs_next_url"] == "/a/org/opportunity/tasks/"
+
+
+@pytest.mark.django_db
+def test_ocs_connected_reflects_social_account(rf, user):
+    request = rf.get("/a/org/opportunity/tasks/")
+    request.user = user
+
+    assert _ocs_connect_context(request)["ocs_connected"] is False
+
+    SocialAccount.objects.create(user=user, provider="ocs", uid="uid-ocs")
+
+    assert _ocs_connect_context(request)["ocs_connected"] is True

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -217,6 +217,7 @@ from commcare_connect.utils.datetime import get_start_end_date_range_with_time
 from commcare_connect.utils.db import get_object_by_uuid_or_int
 from commcare_connect.utils.file import get_file_extension
 from commcare_connect.utils.flags import FlagLabels, Flags
+from commcare_connect.utils.ocs_api import user_has_connected_ocs
 from commcare_connect.utils.tables import (
     DEFAULT_PAGE_SIZE,
     PAGE_SIZE_OPTIONS,
@@ -2145,6 +2146,7 @@ class UserTasksView(WorkerPageView, FilterMixin):
         context.update(self.get_filter_context())
         if can_manage_tasks:
             context["create_task_form"] = CreateTaskForm(opportunity=self.opportunity, access=self.opportunity_access)
+            context.update(_ocs_connect_context(self.request))
             create_url = reverse(
                 "opportunity:create_task", args=(self.request.org.slug, self.opportunity.opportunity_id)
             )
@@ -3419,6 +3421,7 @@ class AssignedTaskListView(OpportunityObjectMixin, OrganizationUserMixin, Filter
         context["can_manage_tasks"] = can_manage_tasks
         if can_manage_tasks:
             context["create_task_form"] = CreateTaskForm(opportunity=opportunity)
+            context.update(_ocs_connect_context(self.request))
             context["create_task_url"] = reverse(
                 "opportunity:create_task", args=(self.request.org.slug, opportunity.opportunity_id)
             )
@@ -3465,6 +3468,13 @@ class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMember
         return HttpResponse(headers={"HX-Redirect": redirect_url})
 
 
+def _ocs_connect_context(request):
+    return {
+        "ocs_connected": user_has_connected_ocs(request.user),
+        "ocs_next_url": request.headers.get("HX-Current-URL") or request.get_full_path(),
+    }
+
+
 @require_POST
 @org_member_required
 @opportunity_required
@@ -3485,6 +3495,7 @@ def create_task(request, org_slug, opp_id):
                 "form": form,
                 "modal_name": "showCreateTaskModal",
                 "create_task_url": request.get_full_path(),
+                **_ocs_connect_context(request),
             },
         )
 

--- a/commcare_connect/templates/tasks/new_task_modal.html
+++ b/commcare_connect/templates/tasks/new_task_modal.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
-{% load socialaccount %}
 {% load static %}
 <link rel="stylesheet" href="{% static 'bundles/css/tomselect.css' %}">
 <script src="{% static 'bundles/js/tomselect-bundle.js' %}"></script>
@@ -38,15 +37,9 @@
           <i class="fa-solid fa-xmark cursor-pointer" aria-hidden="true"></i>
         </button>
       </div>
-      {# TEMP: OCS OAuth connect test button — remove after testing (CCCT-2551) #}
-      <form method="post"
-            action="{% provider_login_url 'ocs' process='connect' %}"
-            class="mb-4">
-        {% csrf_token %}
-        <button type="submit" class="button button-md primary-dark w-full">
-          {% trans "Connect OCS account (TEMP TEST)" %}
-        </button>
-      </form>
+      {% if not ocs_connected %}
+        {% include 'ocs/_connect_prompt.html' with next_url=ocs_next_url %}
+      {% endif %}
       <div id="create-task-form-wrapper">
         <form id="create-task-form"
               method="post"

--- a/commcare_connect/templates/tasks/new_task_modal.html
+++ b/commcare_connect/templates/tasks/new_task_modal.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% load socialaccount %}
 {% load static %}
 <link rel="stylesheet" href="{% static 'bundles/css/tomselect.css' %}">
 <script src="{% static 'bundles/js/tomselect-bundle.js' %}"></script>
@@ -37,6 +38,15 @@
           <i class="fa-solid fa-xmark cursor-pointer" aria-hidden="true"></i>
         </button>
       </div>
+      {# TEMP: OCS OAuth connect test button — remove after testing (CCCT-2551) #}
+      <form method="post"
+            action="{% provider_login_url 'ocs' process='connect' %}"
+            class="mb-4">
+        {% csrf_token %}
+        <button type="submit" class="button button-md primary-dark w-full">
+          {% trans "Connect OCS account (TEMP TEST)" %}
+        </button>
+      </form>
       <div id="create-task-form-wrapper">
         <form id="create-task-form"
               method="post"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -373,6 +373,8 @@ COMMCARE_HQ_URL = env("COMMCARE_HQ_URL", default="https://staging.commcarehq.org
 # Open Chat Studio (OCS) integration settings
 OCS_BASE_URL = env("OCS_BASE_URL", default="https://www.openchatstudio.com")
 
+SOCIALACCOUNT_LOGIN_ON_GET = True
+
 # ConnectID integration settings
 CONNECTID_URL = env("CONNECTID_URL", default="http://localhost:8080")
 


### PR DESCRIPTION
## Product Description

Adds a "connect to OCS" prompt to the task-creation modal for users who haven't yet linked their OCS account, so they can connect before creating a task.

## Technical Summary

Part of the [CCCT-2551 OCS OAuth](https://dimagi.atlassian.net/browse/CCCT-2551) work.

- Adds an `_ocs_connect_context` helper exposing `ocs_connected` (whether the user has a linked OCS social account) and `ocs_next_url` (the page to return to after connecting).
- Wires this context into the task list/detail views and the `create_task` response, and shows the connect prompt in `new_task_modal.html` when the user isn't connected.
- Enables `SOCIALACCOUNT_LOGIN_ON_GET` so the connect link initiates the OAuth flow on click.

## Safety Assurance

### Safety story

Additive, UI-gated change: the prompt only appears for users who aren't connected, and existing task-creation behaviour is unchanged.

### Automated test coverage

`test_ocs_connect_context.py` covers the `next_url` resolution (HX-Current-URL vs. full path) and that `ocs_connected` reflects the presence of an OCS social account.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
