### PR TITLE
Accrue payment for each auto-approved duplicate visit

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -566,7 +566,8 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
             if completed_work_needs_save:
                 completed_work.save()
 
-    update_payment_accrued_for_user(access, incremental=True)
+    completed_work_id = completed_work.id if completed_work is not None else None
+    update_payment_accrued_for_user(access, incremental=True, completed_work_id=completed_work_id)
     transaction.on_commit(partial(download_user_visit_attachments.delay, user_visit.id))
 
 

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -603,6 +603,31 @@ def test_auto_approve_visits_and_payments(
     validate_saved_fields(completed_work)
 
 
+def test_auto_approve_duplicate_visit_accrues_payment_for_each_visit(
+    user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
+):
+    form_json = _create_opp_and_form_json(opportunity, user=user_with_connectid_link)
+    opportunity.auto_approve_visits = True
+    opportunity.auto_approve_payments = True
+    opportunity.save()
+    oauth_application = opportunity.hq_server.oauth_application
+
+    make_request(api_client, form_json, user_with_connectid_link, oauth_application=oauth_application)
+    duplicate_json = deepcopy(form_json)
+    duplicate_json["id"] = duplicate_json["metadata"]["instanceID"] = str(uuid4())
+    make_request(api_client, duplicate_json, user_with_connectid_link, oauth_application=oauth_application)
+
+    visits = UserVisit.objects.filter(user=user_with_connectid_link).order_by("id")
+    assert visits.count() == 2
+    assert [v.status for v in visits] == [VisitValidationStatus.approved, VisitValidationStatus.approved]
+
+    access = OpportunityAccess.objects.get(user=user_with_connectid_link, opportunity=opportunity)
+    completed_work = CompletedWork.objects.get(opportunity_access=access)
+    assert completed_work.saved_approved_count == 2
+    assert access.payment_accrued == completed_work.payment_accrued == 2 * completed_work.payment_unit.amount
+    validate_saved_fields(completed_work)
+
+
 @pytest.mark.parametrize(
     "opportunity",
     [

--- a/commcare_connect/opportunity/visit_import.py
+++ b/commcare_connect/opportunity/visit_import.py
@@ -8,6 +8,7 @@ from decimal import Decimal, InvalidOperation
 from django.core.cache import cache
 from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
+from django.db.models import Q
 from django.utils.html import escape, format_html, format_html_join
 from django.utils.timezone import now
 from tablib import Dataset
@@ -235,18 +236,23 @@ def update_payment_accrued(opportunity: Opportunity, users: list, incremental=Fa
         update_payment_accrued_for_user(access, incremental)
 
 
-def update_payment_accrued_for_user(opportunity_access, incremental):
-    filter_kwargs = {}
-    exclude_status = []
+def update_payment_accrued_for_user(opportunity_access, incremental, completed_work_id=None):
+    """Recalculate payment for the access's CompletedWork records.
+    When incremental, CompletedWork already fully processed (approved, with its
+    payment already computed) is skipped for performance. Pass completed_work_id
+    to always include that specific record regardless — e.g. a CompletedWork that
+    was already approved but just received another auto-approved visit (duplicate
+    entity submission), whose payment total is now stale.
+    """
+    incremental_filter = Q()
     if incremental:
-        exclude_status.append(CompletedWorkStatus.approved)
-        filter_kwargs["saved_approved_count"] = 0
+        incremental_filter = Q(saved_approved_count=0) & ~Q(status=CompletedWorkStatus.approved)
+        if completed_work_id is not None:
+            incremental_filter |= Q(id=completed_work_id)
 
     with cache.lock(f"update_payment_accrued_lock_{opportunity_access.id}", timeout=900):
-        completed_works = (
-            opportunity_access.completedwork_set.filter(**filter_kwargs)
-            .exclude(status__in=exclude_status)
-            .select_related("payment_unit")
+        completed_works = opportunity_access.completedwork_set.filter(incremental_filter).select_related(
+            "payment_unit"
         )
         update_status(completed_works, opportunity_access, compute_payment=True)
 


### PR DESCRIPTION
## Product Description

No user facing change

## Technical Summary

[CI-764](https://dimagi.atlassian.net/browse/CI-764)

- The incremental payment recalculation skips any CompletedWork already marked approved, on the assumption its payment is already settled. A duplicate visit re-approves that same CompletedWork without ever triggering a recalculation, so its payment stayed pinned to the first visit's total.
- The auto-approval path now passes the id of the CompletedWork it just touched, forcing that record through recalculation even when the incremental filter would otherwise skip it.

## Safety Assurance

### Safety story

Added a regression test that fails on the old code and passes on the new code, then reran the full form_receiver and opportunity_receiver test suites (642 tests) locally with no regressions. The change only adds one explicit inclusion to an existing filter, so every other CompletedWork keeps its prior behavior unchanged.

### Automated test coverage

Added a test covering two auto-approved visits for the same entity; confirmed it fails without the fix (payment stuck at 1x) and passes with it (payment correctly doubles).

### QA Plan

No QA ticket needed

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CI-764]: https://dimagi.atlassian.net/browse/CI-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ