### PR TITLE
Point footer Privacy link to terms-privacy-dimagi in pre-login pages

### DIFF
--- a/commcare_connect/templates/prelogin/contact.html
+++ b/commcare_connect/templates/prelogin/contact.html
@@ -287,7 +287,7 @@
       <div class="foot-bottom">
         <span>&copy; 2026 DIMAGI, INC.</span>
         <span class="foot-legal-links">
-          <a href="https://dimagi.com/terms-privacy/"
+          <a href="https://dimagi.com/terms-privacy-dimagi/"
              target="_blank"
              rel="noopener">PRIVACY</a>
           <a href="https://dimagi.com/terms-of-service/"

--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -3537,7 +3537,7 @@
   <div class="foot-bottom">
     <span>© 2026 DIMAGI, INC.</span>
     <span class="foot-legal-links">
-      <a href="https://dimagi.com/terms-privacy/" target="_blank" rel="noopener">PRIVACY</a>
+      <a href="https://dimagi.com/terms-privacy-dimagi/" target="_blank" rel="noopener">PRIVACY</a>
       <a href="https://dimagi.com/terms-of-service/" target="_blank" rel="noopener">TERMS</a>
       <a href="https://dimagi.com/terms-aup/" target="_blank" rel="noopener">Acceptable Use Policy</a>
       <a href="https://dimagi.safebase.us/" target="_blank" rel="noopener">SECURITY</a>


### PR DESCRIPTION
## Product Description

Updates the footer PRIVACY link on the Connect marketing pages (/ and /contact/) to point to https://dimagi.com/terms-privacy-dimagi/ instead of https://dimagi.com/terms-privacy/, now that Connect has its own site-specific privacy page. Reduces confusion between the general Dimagi privacy page and the Connect-specific one.

## Technical Summary

One-line href change in the footer of commcare_connect/templates/prelogin/home.html and commcare_connect/templates/prelogin/contact.html. account/signup.html already links to terms-privacy-dimagi, confirming this is an existing, valid URL. Already 

## Safety Assurance

This update should only impact pre-login marketing pages

### Safety story

Single static href swap, no template logic, no backend changes. Confirmed via git diff that only the intended href value changed in both files, and confirmed contact.html still passes djlint formatting (home.html is excluded from djlint per .pre-commit-config.yaml).

### Automated test coverage

None

### QA Plan

Already verified on labs.connect.dimagi.com after merge/deploy there. Will manually load connect.dimagi.com/ and connect.dimagi.com/contact/ after this deploys and confirm the PRIVACY footer link points to terms-privacy-dimagi.

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
@calellowitz pinging for your review!