### PR TITLE
Add opportunity breadcrumbs to microplanning pages

### DIFF
--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -159,6 +159,14 @@ def microplanning_home(request, *args, **kwargs):
         "mapbox_api_key": settings.MAPBOX_TOKEN,
         "task_id": request.GET.get("task_id"),
         "opportunity": opportunity,
+        "path": [
+            {"title": _("Opportunities"), "url": reverse("opportunity:list", kwargs={"org_slug": request.org.slug})},
+            {
+                "title": opportunity.name,
+                "url": reverse("opportunity:detail", args=(request.org.slug, opportunity.opportunity_id)),
+            },
+            {"title": _("Progress Map")},
+        ],
         "metrics": get_metrics_for_microplanning(opportunity),
         "tiles_url": tiles_url,
         "visit_tiles_url": visit_tiles_url,
@@ -1002,6 +1010,11 @@ def coverage_progress(request, *args, **kwargs):
         "filter_form": filterset.form,
         "export_hrefs": export_hrefs,
         "path": [
+            {"title": _("Opportunities"), "url": reverse("opportunity:list", kwargs={"org_slug": request.org.slug})},
+            {
+                "title": opportunity.name,
+                "url": reverse("opportunity:detail", args=(request.org.slug, opportunity.opportunity_id)),
+            },
             {
                 "title": _("Progress Map"),
                 "url": reverse(

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -12,6 +12,7 @@
 {% endblock javascript %}
 {% block content %}
   <div class="min-w-0">
+    {% include 'components/breadcrumbs.html' with path=path %}
     <h2 class="mb-4 text-brand-deep-purple font-medium">{% translate "Select Opportunity Area" %}</h2>
     <!-- Top header section -->
     <header class="mb-2">


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->
The microplanning **Progress Map** page had no breadcrumb navigation, so there was no way to get back to the opportunity or the opportunities list from it. The related **Progress Tracker** (Coverage Progress) page had a breadcrumb, but it only went back as far as the Progress Map.

This adds the standard opportunity breadcrumb chain to both pages so navigation is consistent:
- **Progress Map**: `Opportunities › [opportunity] › Progress Map`
- **Progress Tracker**: `Opportunities › [opportunity] › Progress Map › Progress Tracker`

**BEFORE**

<img width="679" height="320" alt="image" src="https://github.com/user-attachments/assets/d226b612-cdcb-4c74-b508-755ea615a1d6" />

--------------

<img width="679" height="320" alt="image" src="https://github.com/user-attachments/assets/071b4ba0-3b15-417d-96ed-cf9650362355" />

--------------
**AFTER**

<img width="642" height="273" alt="image" src="https://github.com/user-attachments/assets/d33b70a4-107c-47eb-880b-39f67cbde768" />

--------------

<img width="616" height="226" alt="image" src="https://github.com/user-attachments/assets/51092538-e8c2-497d-a6df-16cf26209d64" />


## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/CCCT-2591

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Low risk, presentation-only change. Tested locally for UI changes.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
