### PR TITLE
Fix org invite acceptance redirecting non-admins to a 404

### DIFF
--- a/commcare_connect/organization/tests/test_views.py
+++ b/commcare_connect/organization/tests/test_views.py
@@ -161,17 +161,25 @@ class TestAcceptInviteView:
     def _url(org_slug, invite_id):
         return reverse("organization:accept_invite", args=(org_slug, invite_id))
 
-    def test_valid_invite_redirects_to_org_home(self, client, user, organization):
+    def test_valid_invite_redirects_to_opportunity_list(self, client, user, organization):
         membership = organization.memberships.first()
         client.force_login(user)
 
         response = client.get(self._url(organization.slug, membership.invite_id))
 
         assert response.status_code == 302
-        assert response.url == reverse("organization:home", args=(organization.slug,))
+        assert response.url == reverse("opportunity:list", args=(organization.slug,))
         messages = list(get_messages(response.wsgi_request))
         assert len(messages) == 1
         assert organization.slug in str(messages[0])
+
+    def test_non_admin_invitee_lands_on_accessible_page(self, client, org_user_member, organization):
+        membership = UserOrganizationMembership.objects.get(user=org_user_member, organization=organization)
+        client.force_login(org_user_member)
+
+        response = client.get(self._url(organization.slug, membership.invite_id), follow=True)
+
+        assert response.status_code == 200
 
     def test_invalid_invite_id_returns_404(self, client, user, organization):
         client.force_login(user)
@@ -179,6 +187,17 @@ class TestAcceptInviteView:
         response = client.get(self._url(organization.slug, "nonexistent-invite-id"))
 
         assert response.status_code == 404
+
+    def test_invite_id_for_different_org_slug_returns_404_without_message(
+        self, client, user, organization, program_manager_org
+    ):
+        membership = organization.memberships.first()
+        client.force_login(user)
+
+        response = client.get(self._url(program_manager_org.slug, membership.invite_id))
+
+        assert response.status_code == 404
+        assert not list(get_messages(response.wsgi_request))
 
 
 @pytest.mark.django_db

--- a/commcare_connect/organization/views.py
+++ b/commcare_connect/organization/views.py
@@ -98,11 +98,11 @@ def remove_members(request, org_slug):
 
 @login_required
 def accept_invite(request, org_slug, invite_id):
-    get_object_or_404(UserOrganizationMembership, invite_id=invite_id)
+    get_object_or_404(UserOrganizationMembership, invite_id=invite_id, organization__slug=org_slug)
     messages.success(
         request, message=gettext("Accepted invite for joining {org_slug} workspace.").format(org_slug=org_slug)
     )
-    return redirect("organization:home", org_slug)
+    return redirect("opportunity:list", org_slug)
 
 
 @require_GET


### PR DESCRIPTION
## Product Description

Members invited to a workspace as non-admins (the default role) now land on a working page after accepting their invite, instead of a page that showed a success message next to a 404 error.

## Technical Summary

[CI-785](https://dimagi.atlassian.net/browse/CI-785)

- The invite acceptance view redirected everyone to the admin-only workspace settings page. That page 404s for any non-admin, which is the default role for invitees.
- The success message was queued before the redirect, so it survived and rendered on the 404 page since both pages share the same base template.
- Added an org slug check to the invite lookup so a mismatched org slug 404s immediately, before the message is queued.

## Safety Assurance

### Safety story

Tested locally by accepting invites as both an admin and a regular member. The new redirect target is the opportunity list page, which every org member can already access, so this doesn't grant any new permissions.

### Automated test coverage

Updated the existing accept-invite test and added two tests covering the non-admin flow and the org slug mismatch case; all pass.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-785]: https://dimagi.atlassian.net/browse/CI-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ