### PR TITLE
Hide opportunity edit menu icon for view-only members

### DIFF
--- a/commcare_connect/templates/opportunity/dashboard.html
+++ b/commcare_connect/templates/opportunity/dashboard.html
@@ -30,16 +30,13 @@
            x-data="{ isOpen: false }">
         <h3 class="text-sm font-medium text-brand-sky flex-1">{{ object.program.name }}</h3>
         {% if object.is_test %}<span class="badge badge-md primary-light">Test</span>{% endif %}
-        {% if request.org_membership.is_viewer %}
-          <i class="fa-solid opacity-50"
-             :class="[isTest ? 'text-gray-800' : 'text-white', isOpen ? 'fa-xmark' : 'fa-bars']"></i>
-        {% else %}
+        {% if not request.org_membership.is_viewer %}
           <i class="fa-solid cursor-pointer"
              :class="[isTest ? 'text-gray-800' : 'text-white', isOpen ? 'fa-xmark' : 'fa-bars']"
              @click="isOpen = !isOpen"></i>
+          <!-- Dropdown Menu -->
+          {% include "opportunity/opportunity_menu.html" with request=request opportunity=object is_opportunity_pm=request.is_opportunity_pm %}
         {% endif %}
-        <!-- Dropdown Menu -->
-        {% include "opportunity/opportunity_menu.html" with request=request opportunity=object is_opportunity_pm=request.is_opportunity_pm %}
       </div>
       <div class="flex justify-between items-end">
         <div class="flex flex-col gap-2">


### PR DESCRIPTION
## Product Description

Workspace members with view-only access no longer see the opportunity edit menu icon on the opportunity dashboard.

<img width="1793" height="1006" alt="viewer" src="https://github.com/user-attachments/assets/cf122533-9cd9-4014-b37c-ae51649b0b52" />



## Technical Summary

[CI-787](https://dimagi.atlassian.net/browse/CI-787)

- The menu icon was already rendered for viewers before this change, just visually disabled with no click handler, so the dropdown could never open. It looked like a broken button instead of an absent one.
- Now the icon and its dropdown are omitted entirely for viewers, matching how the dropdown already hides PM-only items for non-PM users.

## Safety Assurance

### Safety story

Tested locally by loading the opportunity dashboard as both a viewer and a regular member: the icon is gone for the viewer and works as before for the member. This is a template-only change with no permission or view logic touched.

### Automated test coverage

No automated tests added; this is a small template visibility change, verified manually as described above.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-787]: https://dimagi.atlassian.net/browse/CI-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ