### PR TITLE
Hide unconfigured opportunity dashboard tiles

### DIFF
--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -19,6 +19,8 @@ from django_tables2 import RequestConfig
 from waffle.testutils import override_switch
 
 from commcare_connect.connect_id_client.models import ConnectIdUser
+from commcare_connect.flags.flag_names import MICROPLANNING, WEEKLY_PERFORMANCE_REPORT
+from commcare_connect.flags.models import Flag
 from commcare_connect.flags.switch_names import WORKER_VISITS_TASKS
 from commcare_connect.microplanning.tests.factories import WorkAreaInaccessibilityRequestFactory
 from commcare_connect.opportunity.exceptions import TaskAlreadyAssignedError
@@ -2906,3 +2908,66 @@ class TestAudioAttachmentTranscribe:
         response = client.get(self._url(organization, opportunity, audio))
 
         assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestOpportunityDeliveryStatsTiles:
+    def _url(self, organization, opportunity):
+        return reverse("opportunity:delivery_stats", args=(organization.slug, opportunity.opportunity_id))
+
+    def test_tiles_hidden_by_default(self, client, organization, org_user_member, opportunity):
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity))
+
+        assert response.status_code == 200
+        assert b"View Progress Map" not in response.content
+        assert b"Audit Opportunity" not in response.content
+        assert b"Tasks Assigned to Connect Workers" not in response.content
+
+    @pytest.mark.parametrize("scope", ["opportunity", "program", "organization"])
+    def test_progress_map_shown_when_flag_enabled(self, client, organization, org_user_member, opportunity, scope):
+        flag = Flag.objects.create(name=MICROPLANNING)
+        if scope == "opportunity":
+            flag.opportunities.add(opportunity)
+        elif scope == "program":
+            program = ProgramFactory(organization=organization)
+            opportunity.program = program
+            opportunity.save(update_fields=["program"])
+            flag.programs.add(program)
+        elif scope == "organization":
+            flag.organizations.add(organization)
+
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity))
+
+        assert b"View Progress Map" in response.content
+
+    def test_audit_tile_shown_only_when_flag_scoped_to_opportunity(
+        self, client, organization, org_user_member, opportunity
+    ):
+        program = ProgramFactory(organization=organization)
+        opportunity.program = program
+        opportunity.save(update_fields=["program"])
+        Flag.objects.create(name=WEEKLY_PERFORMANCE_REPORT).programs.add(program)
+
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity))
+        assert b"Audit Opportunity" not in response.content
+
+        Flag.objects.get(name=WEEKLY_PERFORMANCE_REPORT).opportunities.add(opportunity)
+        response = client.get(self._url(organization, opportunity))
+        assert b"Audit Opportunity" in response.content
+
+    def test_tasks_tile_shown_only_with_switch_and_configured_task_type(
+        self, client, organization, org_user_member, opportunity
+    ):
+        client.force_login(org_user_member)
+
+        with override_switch(WORKER_VISITS_TASKS, active=True):
+            response = client.get(self._url(organization, opportunity))
+        assert b"Tasks Assigned to Connect Workers" not in response.content
+
+        TaskTypeFactory(opportunity=opportunity, is_active=True)
+        with override_switch(WORKER_VISITS_TASKS, active=True):
+            response = client.get(self._url(organization, opportunity))
+        assert b"Tasks Assigned to Connect Workers" in response.content

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -57,10 +57,10 @@ from django_tables2 import RequestConfig, SingleTableView
 from django_tables2.export import TableExport
 from django_weasyprint.views import WeasyTemplateResponse
 from geopy import distance
-from waffle import switch_is_active
+from waffle import flag_is_active, switch_is_active
 
 from commcare_connect.connect_id_client import fetch_users
-from commcare_connect.flags.flag_names import MICROPLANNING
+from commcare_connect.flags.flag_names import MICROPLANNING, WEEKLY_PERFORMANCE_REPORT
 from commcare_connect.flags.switch_names import WORKER_VISITS_TASKS
 from commcare_connect.flags.utils import is_flag_active
 from commcare_connect.form_receiver.serializers import XFormSerializer
@@ -3149,57 +3149,71 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
             "url": f"{delivery_url}?{urlencode({'sort': '-last_active'})}",
             "incr": stats.deliveries_from_yesterday,
         },
-        {
-            "icon": "fa-map-location-dot",
-            "name": _("View Progress Map"),
-            "status": "",
-            "value": "",
-            "url": microplanning_url,
-        },
-        {
-            "icon": "fa-magnifying-glass",
-            "name": _("Audit Opportunity"),
-            "status": "",
-            "value": "",
-            "url": reverse(
-                "opportunity:audit:audit_report_list",
-                kwargs={"org_slug": org_slug, "opp_id": opp_id},
-            ),
-        },
     ]
+    if flag_is_active(request, MICROPLANNING):
+        deliveries_panels.append(
+            {
+                "icon": "fa-map-location-dot",
+                "name": _("View Progress Map"),
+                "status": "",
+                "value": "",
+                "url": microplanning_url,
+            }
+        )
+    if is_flag_active(WEEKLY_PERFORMANCE_REPORT, request.opportunity):
+        deliveries_panels.append(
+            {
+                "icon": "fa-magnifying-glass",
+                "name": _("Audit Opportunity"),
+                "status": "",
+                "value": "",
+                "url": reverse(
+                    "opportunity:audit:audit_report_list",
+                    kwargs={"org_slug": org_slug, "opp_id": opp_id},
+                ),
+            }
+        )
 
     tasks_url = reverse("opportunity:assigned_task_list", args=(org_slug, opp_id))
+    connect_worker_panels = [
+        {
+            "icon": "fa-user-group",
+            "name": _("Connect Workers"),
+            "status": "",
+            "value": "",
+            "url": status_url,
+        },
+        {
+            "icon": "fa-clipboard-list",
+            "name": _("Connect Workers"),
+            "status": _("Inactive last 3 days"),
+            "url": f"{delivery_url}?{urlencode({'last_active': '3'})}",
+            "value": header_with_tooltip(
+                stats.inactive_workers, _("Did not submit a Learn or Deliver form in the last 3 days")
+            ),
+            **panel_type_2,
+        },
+    ]
+    if (
+        switch_is_active(WORKER_VISITS_TASKS)
+        and TaskType.objects.filter(opportunity=request.opportunity, is_active=True).exists()
+    ):
+        connect_worker_panels.append(
+            {
+                "icon": "fa-list-check",
+                "name": _("Tasks Assigned to Connect Workers"),
+                "status": "",
+                "value": stats.active_tasks_count,
+                "url": tasks_url,
+            }
+        )
+
     opp_stats = [
         {
             "title": _("Connect Workers"),
             "sub_heading": "",
             "value": "",
-            "panels": [
-                {
-                    "icon": "fa-user-group",
-                    "name": _("Connect Workers"),
-                    "status": "",
-                    "value": "",
-                    "url": status_url,
-                },
-                {
-                    "icon": "fa-clipboard-list",
-                    "name": _("Connect Workers"),
-                    "status": _("Inactive last 3 days"),
-                    "url": f"{delivery_url}?{urlencode({'last_active': '3'})}",
-                    "value": header_with_tooltip(
-                        stats.inactive_workers, _("Did not submit a Learn or Deliver form in the last 3 days")
-                    ),
-                    **panel_type_2,
-                },
-                {
-                    "icon": "fa-list-check",
-                    "name": _("Tasks Assigned to Connect Workers"),
-                    "status": "",
-                    "value": stats.active_tasks_count,
-                    "url": tasks_url,
-                },
-            ],
+            "panels": connect_worker_panels,
         },
         {
             "title": _("Services Delivered"),


### PR DESCRIPTION
## Product Description

The opportunity dashboard now hides the "View Progress Map", "Audit Opportunity", and "Tasks Assigned to Connect Workers" tiles when the underlying feature isn't enabled or configured for that opportunity, instead of always showing them.

<img width="1796" height="1006" alt="image" src="https://github.com/user-attachments/assets/8612c435-ff94-480c-9472-877fa3cb7b2a" />


## Technical Summary

[CI-786](https://dimagi.atlassian.net/browse/CI-786)

- The Progress Map tile checks the flag through the request (org, program, or opportunity level), matching how the real microplanning routes resolve it. The Audit tile deliberately stays opportunity-only, matching the audit route's own access check, so we never show a tile that leads to a 404.
- The Tasks tile requires both the feature switch and at least one active task type configured for the opportunity, not just the switch alone.

## Safety Assurance

### Safety story

Tested locally with the flag/switch on and off, and with the microplanning flag set at the opportunity, program, and organization level, to confirm each tile only appears when its feature actually works and never links to a dead page.

### Automated test coverage

Added a test class covering all three tiles: hidden by default, shown at each flag scope for Progress Map, opportunity-only scoping for Audit, and switch-plus-configuration for Tasks. All pass.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-786]: https://dimagi.atlassian.net/browse/CI-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ