### PR TITLE
Fix allauth account-flow UX gaps: dead-end pages, redundant copy

### DIFF
--- a/commcare_connect/templates/account/email/email_confirmation_signup_message.txt
+++ b/commcare_connect/templates/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,6 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans with site_domain=current_site.domain %}You're receiving this e-mail because you signed up for an account on {{ site_domain }}.
+
+To confirm your e-mail address, go to {{ activate_url }}{% endblocktrans %}{% endautoescape %}{% endblock %}

--- a/commcare_connect/templates/account/email_confirm.html
+++ b/commcare_connect/templates/account/email_confirm.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 {% load i18n %}
-{% load account %}
 {% block head_title %}
   {% translate "Confirm E-mail Address" %}
 {% endblock %}
@@ -8,10 +7,9 @@
   <div class="w-full min-h-[620px] h-fit flex flex-col gap-4">
     <h1 class="title text-brand-deep-purple mb-4">{% translate "Confirm E-mail Address" %}</h1>
     {% if confirmation %}
-      {% user_display confirmation.email_address.user as user_display %}
       <p>
         {% blocktranslate with confirmation.email_address.email as email %}
-        Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.
+        Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is your e-mail address.
       {% endblocktranslate %}
       </p>
       <form method="post"

--- a/commcare_connect/templates/account/login.html
+++ b/commcare_connect/templates/account/login.html
@@ -17,7 +17,11 @@
       <h6 class="title text-brand-deep-purple">Login</h6>
       <span class="text-sm text-gray-600">Please enter your details</span>
       {% if messages %}
-        {% for message in messages %}<p class="text-sm text-red-600">* {{ message }}</p>{% endfor %}
+        {% for message in messages %}
+          <p class="text-sm {% if 'error' in message.tags or 'warning' in message.tags %}text-red-600{% else %}text-green-600{% endif %}">
+            * {{ message }}
+          </p>
+        {% endfor %}
       {% endif %}
       {% if form.non_field_errors %}
         {% for error in form.non_field_errors %}<p class="text-sm text-red-600">* {{ error }}</p>{% endfor %}

--- a/commcare_connect/templates/account/password_reset.html
+++ b/commcare_connect/templates/account/password_reset.html
@@ -26,14 +26,14 @@
     </div>
     <div class="flex justify-between items-center">
       <div></div>
-      <button class="button button-md outline-style"
-              @click="submitWithValidation()">
+      <button class="button button-md outline-style" type="submit">
         <span class="relative z-20">{% translate "Reset" %}</span>
       </button>
     </div>
     <div class="text-sm text-gray-400 text-center mt-auto border-t-gray-200 border-t-2 pt-4 ">
       {% translate "Don't have an account?" %}
-      <a href="{{ signup_url }}" class="text-brand-indigo font-medium">{% translate "Signup" %}</a>
+      <a href="{% url 'account_signup' %}"
+         class="text-brand-indigo font-medium">{% translate "Signup" %}</a>
     </div>
   </form>
 {% endblock %}

--- a/commcare_connect/templates/account/password_reset_done.html
+++ b/commcare_connect/templates/account/password_reset_done.html
@@ -11,5 +11,7 @@
     <p class="mt-2">
       {% blocktranslate %}We have sent you an e-mail. Please contact us if you do not receive it within a few minutes.{% endblocktranslate %}
     </p>
+    <a href="{% url 'account_login' %}"
+       class="button button-md primary-dark w-fit">{% translate "Sign In" %}</a>
   </div>
 {% endblock %}

--- a/commcare_connect/templates/account/password_reset_from_key.html
+++ b/commcare_connect/templates/account/password_reset_from_key.html
@@ -50,15 +50,17 @@
           </button>
         </div>
         <div class="text-sm text-gray-400 text-center mt-auto border-t-gray-200 border-t-2 pt-4 ">
-          Don't have an account?
-          <a href="#"
-             class="text-brand-indigo font-medium"
-             @click="submitWithValidation()"
-             @submit.prevent="submitWithValidation()">Signup</a>
+          {% translate "Don't have an account?" %}
+          <a href="{% url 'account_signup' %}"
+             class="text-brand-indigo font-medium">{% translate "Signup" %}</a>
         </div>
       </form>
     {% else %}
-      <p>{% translate 'Your password is now changed.' %}</p>
+      {# Silently drain messages — this page already says it #}
+      {% for message in messages %}{% endfor %}
+      <p>{% translate 'Your password is now changed. You can now sign in with your new password.' %}</p>
+      <a href="{% url 'account_login' %}"
+         class="button button-md primary-dark w-fit">{% translate "Sign In" %}</a>
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/commcare_connect/templates/account/password_reset_from_key_done.html
+++ b/commcare_connect/templates/account/password_reset_from_key_done.html
@@ -6,6 +6,10 @@
 {% block inner %}
   <div class="w-full min-h-[620px] h-fit flex flex-col gap-4">
     <h1 class="title text-brand-deep-purple">{% translate "Change Password" %}</h1>
-    <p>{% translate 'Your password is now changed.' %}</p>
+    {# Silently drain messages — this page already says it #}
+    {% for message in messages %}{% endfor %}
+    <p>{% translate 'Your password is now changed. You can now sign in with your new password.' %}</p>
+    <a href="{% url 'account_login' %}"
+       class="button button-md primary-dark w-fit">{% translate "Sign In" %}</a>
   </div>
 {% endblock %}

--- a/commcare_connect/templates/account/verification_sent.html
+++ b/commcare_connect/templates/account/verification_sent.html
@@ -4,10 +4,14 @@
   {% translate "Verify Your E-mail Address" %}
 {% endblock %}
 {% block inner %}
-  <div class="w-full min-h-[620px] h-fit">
+  <div class="w-full min-h-[620px] h-fit flex flex-col gap-4">
     <h1 class="title text-brand-deep-purple mb-4">{% translate "Verify Your E-mail Address" %}</h1>
+    {# Silently drain messages — this page already says it #}
+    {% for message in messages %}{% endfor %}
     <p class="text-sm">
       {% blocktranslate %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktranslate %}
     </p>
+    <a href="{% url 'account_login' %}"
+       class="button button-md primary-dark w-fit">{% translate "Sign In" %}</a>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Product Description

Signup and password-reset screens now always give users a way back to sign in, drop copy that implied an invite ("is an e-mail address for user X"), and no longer stack redundant flash messages on pages that already state the outcome.

[page@4e4ac221b26bec7b6affafd41b44d85d.webm](https://github.com/user-attachments/assets/8dab0250-d95a-4caf-9cb7-11e93e89013d)



## Technical Summary

[CI-767](https://dimagi.atlassian.net/browse/CI-767)

- Added a signup-specific confirmation email template so self-signup no longer reuses the invite-style wording from allauth's default template.
- Pages that already state the outcome in their own copy (verification-sent, password-changed) drain the flash messages instead of displaying them, so they don't leak onto the next page like login.
- Removed dead Alpine `submitWithValidation()` handlers left over from an old form setup; those buttons now submit normally.

## Safety Assurance

### Safety story

Tested the full signup, email confirmation, login, logout, and password-reset flow manually against a local dev server, including invalid-password and invalid-reset-link cases.

### Automated test coverage

No automated tests added or changed; this is a template and copy only change.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-767]: https://dimagi.atlassian.net/browse/CI-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ