### PR TITLE
Fix clickthrough icon overlapping delta badge on Payments Earned card

### DIFF
--- a/commcare_connect/templates/opportunity/opportunity_delivery_stat.html
+++ b/commcare_connect/templates/opportunity/opportunity_delivery_stat.html
@@ -52,7 +52,7 @@
                 <p class="text-sm text-white {{ panel.text_color }}">{{ panel.status }}</p>
               </div>
               <h3 class="text-2xl font-medium text-white {{ panel.text_color }}">{{ panel.value }}</h3>
-              <div class="w-17">
+              <div>
                 {% if panel.incr is not None %}
                   <span x-data
                         x-tooltip.raw="Increment in last 24 hours"


### PR DESCRIPTION
## Product Description

Fixed the delta badge overlapping the clickthrough icon on the Payments Earned card in Worker Payments.

| Before | After |
|---|---|
| <img width="900" alt="Before" src="https://github.com/user-attachments/assets/c1fc5ddf-3c9c-4d3b-bd41-d481964be133" /> | <img width="900" alt="After" src="https://github.com/user-attachments/assets/2f242c23-48be-4cf4-9671-a270abb4cdc5" /> |

## Technical Summary

[CI-730](https://dimagi.atlassian.net/browse/CI-730)

## Safety Assurance

### Safety story

Just removed the fixed width.

### Automated test coverage

No automated tests added or changed. This is a template-only style fix with no logic to test.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CI-730]: https://dimagi.atlassian.net/browse/CI-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ