### PR TITLE
CI-791: Shareable deep link to a specific visit on the verification page

### DIFF
--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -99,6 +99,7 @@ class UserVisitDataSerializer(serializers.ModelSerializer):
         model = UserVisit
         fields = [
             "id",
+            "user_visit_id",
             "opportunity_id",
             "username",
             "deliver_unit",

--- a/commcare_connect/data_export/tests/test_user_visit_export.py
+++ b/commcare_connect/data_export/tests/test_user_visit_export.py
@@ -213,3 +213,12 @@ class TestUserVisitDataViewV2:
         assert len(all_results) == 5
         ids = [r["id"] for r in all_results]
         assert len(set(ids)) == 5
+
+    def test_includes_user_visit_id(self, api_client_v2, opportunity, org_user_member):
+        visit = UserVisitFactory(opportunity=opportunity, user=org_user_member)
+        _add_export_credentials(api_client_v2, org_user_member)
+
+        response = api_client_v2.get(_get_url(opportunity.id))
+
+        assert response.status_code == 200
+        assert response.json()["results"][0]["user_visit_id"] == str(visit.user_visit_id)

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2971,3 +2971,88 @@ class TestOpportunityDeliveryStatsTiles:
         with override_switch(WORKER_VISITS_TASKS, active=True):
             response = client.get(self._url(organization, opportunity))
         assert b"Tasks Assigned to Connect Workers" in response.content
+
+
+@pytest.mark.django_db
+class TestUserVisitRedirect:
+    def _url(self, organization, opportunity, visit_id):
+        return reverse(
+            "opportunity:user_visit_redirect",
+            args=(organization.slug, opportunity.opportunity_id, visit_id),
+        )
+
+    def test_redirects_to_verification_page_with_user_and_visit(
+        self, client, organization, org_user_member, opportunity
+    ):
+        visit = UserVisitFactory.create(opportunity=opportunity)
+
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity, visit.user_visit_id))
+
+        assert response.status_code == 302
+        assert response.url == (
+            f"{reverse('opportunity:user_visits_list', args=(organization.slug, opportunity.opportunity_id))}"
+            f"?{urlencode({'user': visit.user.user_id, 'visit': visit.user_visit_id})}"
+        )
+
+    def test_visit_from_other_opportunity_returns_404(self, client, organization, org_user_member, opportunity):
+        other_visit = UserVisitFactory.create()  # belongs to a different opportunity
+
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity, other_visit.user_visit_id))
+
+        assert response.status_code == 404
+
+    def test_unknown_visit_returns_404(self, client, organization, org_user_member, opportunity):
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity, uuid4()))
+
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestUserVisitVerificationDeepLink:
+    def _url(self, organization, opportunity, **params):
+        url = reverse("opportunity:user_visits_list", args=(organization.slug, opportunity.opportunity_id))
+        return f"{url}?{urlencode(params)}"
+
+    def _details_url(self, organization, opportunity, visit):
+        return reverse(
+            "opportunity:user_visit_details",
+            args=(organization.slug, opportunity.opportunity_id, visit.user_visit_id),
+        )
+
+    def test_visit_param_auto_opens_details(self, client, organization, org_user_member, opportunity):
+        access = OpportunityAccessFactory(opportunity=opportunity)
+        visit = UserVisitFactory.create(opportunity=opportunity, user=access.user, opportunity_access=access)
+
+        client.force_login(org_user_member)
+        response = client.get(
+            self._url(organization, opportunity, user=access.user.user_id, visit=visit.user_visit_id)
+        )
+
+        assert response.status_code == 200
+        assert self._details_url(organization, opportunity, visit).encode() in response.content
+
+    def test_visit_param_for_other_worker_is_ignored(self, client, organization, org_user_member, opportunity):
+        access = OpportunityAccessFactory(opportunity=opportunity)
+        other_access = OpportunityAccessFactory(opportunity=opportunity)
+        other_visit = UserVisitFactory.create(
+            opportunity=opportunity, user=other_access.user, opportunity_access=other_access
+        )
+
+        client.force_login(org_user_member)
+        response = client.get(
+            self._url(organization, opportunity, user=access.user.user_id, visit=other_visit.user_visit_id)
+        )
+
+        assert response.status_code == 200
+        assert self._details_url(organization, opportunity, other_visit).encode() not in response.content
+
+    def test_invalid_visit_param_is_ignored(self, client, organization, org_user_member, opportunity):
+        access = OpportunityAccessFactory(opportunity=opportunity)
+
+        client.force_login(org_user_member)
+        response = client.get(self._url(organization, opportunity, user=access.user.user_id, visit="not-a-uuid"))
+
+        assert response.status_code == 200

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -3051,8 +3051,10 @@ class TestUserVisitVerificationDeepLink:
 
     def test_invalid_visit_param_is_ignored(self, client, organization, org_user_member, opportunity):
         access = OpportunityAccessFactory(opportunity=opportunity)
+        visit = UserVisitFactory.create(opportunity=opportunity, user=access.user, opportunity_access=access)
 
         client.force_login(org_user_member)
         response = client.get(self._url(organization, opportunity, user=access.user.user_id, visit="not-a-uuid"))
 
         assert response.status_code == 200
+        assert self._details_url(organization, opportunity, visit).encode() not in response.content

--- a/commcare_connect/opportunity/urls.py
+++ b/commcare_connect/opportunity/urls.py
@@ -84,6 +84,7 @@ urlpatterns = [
     path("<slug:opp_id>/user_status_export/", view=export_user_status, name="user_status_export"),
     path("<slug:opp_id>/deliver_status_export/", view=export_deliver_status, name="deliver_status_export"),
     path("<slug:opp_id>/user_visits/", view=views.UserVisitVerificationView.as_view(), name="user_visits_list"),
+    path("<slug:opp_id>/user_visits/visit/<slug:pk>/", view=views.user_visit_redirect, name="user_visit_redirect"),
     path("<slug:opp_id>/user_tasks/", view=views.UserTasksView.as_view(), name="user_tasks_list"),
     path(
         "<slug:opp_id>/user_tasks_table/",

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -18,6 +18,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage, storages
 from django.db import transaction
 from django.db.models import (
@@ -2188,7 +2189,21 @@ class UserVisitVerificationView(WorkerPageView):
         context = super().get_context_data(**kwargs)
         context["MAPBOX_TOKEN"] = settings.MAPBOX_TOKEN
         context["show_worker_tasks_tabs"] = switch_is_active(WORKER_VISITS_TASKS)
+        context["initial_visit_details_url"] = self._get_initial_visit_details_url()
         return context
+
+    def _get_initial_visit_details_url(self):
+        visit_id = self.request.GET.get("visit")
+        if not visit_id:
+            return None
+        try:
+            user_visit = UserVisit.objects.get(user_visit_id=visit_id, opportunity_access=self.opportunity_access)
+        except (UserVisit.DoesNotExist, ValidationError, ValueError):
+            return None
+        return reverse(
+            "opportunity:user_visit_details",
+            args=(self.request.org.slug, self.opportunity.opportunity_id, user_visit.user_visit_id),
+        )
 
 
 def _can_manage_tasks(request, opportunity):
@@ -2439,6 +2454,22 @@ def visit_verification_table_view(request, org_slug, opp_id):
     if switch_is_active(WORKER_VISITS_TASKS):
         return WorkerVisitTableView.as_view()(request, org_slug=org_slug, opp_id=opp_id)
     return VisitVerificationTableView.as_view()(request, org_slug=org_slug, opp_id=opp_id)
+
+
+@org_viewer_required
+@opportunity_required
+def user_visit_redirect(request, org_slug, opp_id, pk):
+    """Canonical shareable URL for a single visit.
+
+    Resolves the visit's worker and redirects to the visit verification page,
+    which requires a ``user`` param and auto-opens the visit via ``visit``.
+    """
+    user_visit = get_object_or_404(
+        UserVisit.objects.select_related("user"), user_visit_id=pk, opportunity=request.opportunity
+    )
+    url = reverse("opportunity:user_visits_list", args=(org_slug, opp_id))
+    query = urlencode({"user": user_visit.user.user_id, "visit": user_visit.user_visit_id})
+    return redirect(f"{url}?{query}")
 
 
 @org_viewer_required

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2193,6 +2193,7 @@ class UserVisitVerificationView(WorkerPageView):
         return context
 
     def _get_initial_visit_details_url(self):
+        """Return the details URL for a valid ``visit`` query param, so the template auto-opens it."""
         visit_id = self.request.GET.get("visit")
         if not visit_id:
             return None

--- a/commcare_connect/templates/opportunity/user_visit_verification.html
+++ b/commcare_connect/templates/opportunity/user_visit_verification.html
@@ -32,6 +32,7 @@
             </div>
             <div class="p-4 rounded-lg shadow-sm flex-1 bg-white overflow-y-auto scrollbar-hide scrollbar-default">
               <div id="visit-details"
+                   {% if initial_visit_details_url %} hx-get="{{ initial_visit_details_url }}" hx-trigger="load" hx-indicator="#visit-loading-indicator" {% endif %}
                    hx-on:before-swap="removeMap()"
                    hx-on::after-settle="loadMap()">
                 <div class="flex justify-items-center align-items-center">


### PR DESCRIPTION
## Product Description

Adds a shareable URL for a specific visit. Opening
`/a/<org_slug>/opportunity/<opp_id>/user_visits/visit/<user_visit_id>/`
takes you to the visit verification page for that visit's worker with the visit's
details panel already open — no need to manually pick the worker and hunt for the
row. Anywhere a visit is referenced outside Connect (audit tools, spreadsheets,
chat), reviewers can now jump straight to it.

## Technical Summary

Jira: [CI-791](https://dimagi.atlassian.net/browse/CI-791)

Today there is no URL that identifies a visit: the verification page 404s without a
valid `?user=` param, details open only via HTMX row clicks, and `user_visit_details`
renders a fragment keyed by `user_visit_id` — a UUID not exposed through `data_export`.

Three small pieces:

1. **`opportunity:user_visit_redirect`** (`user_visits/visit/<user_visit_id>/`) — resolves
   the visit (scoped to the opportunity, same `@org_viewer_required @opportunity_required`
   guards as `user_visit_details`) and redirects to `user_visits_list` with
   `?user=<user_id>&visit=<user_visit_id>`. This is the canonical link external tools construct.
2. **Auto-open on `?visit=`** — `UserVisitVerificationView` resolves the `visit` param against
   the current worker's `opportunity_access` and, when valid, the `#visit-details` div gets
   `hx-get`/`hx-trigger="load"` so the details panel loads immediately (same swap path as a row
   click). Invalid/foreign visit ids are silently ignored — the page renders normally.
3. **`user_visit_id` in `UserVisitDataSerializer`** — so `data_export` API consumers
   (e.g. CommCare Connect Labs audit review) have the identifier needed to build the link.

## Safety Assurance

### Safety story

Additive only: a new URL, a new optional query param, and one new read-only serializer
field. No writes, no changes to existing behavior when the param is absent. The redirect
and the param resolution reuse the exact permission guards and worker scoping of the
existing views (visit must belong to the opportunity in the URL; the auto-open lookup is
additionally scoped to the worker's `opportunity_access`, so a `?visit=` for another
worker's visit is ignored rather than leaked). Malformed UUIDs are caught and ignored.

Tested locally: full `opportunity/tests/test_views.py` + `data_export` suites pass
(224 passed).

### Automated test coverage

- `TestUserVisitRedirect` — redirect carries `user` + `visit` params; 404 for a visit from
  another opportunity; 404 for an unknown id.
- `TestUserVisitVerificationDeepLink` — `?visit=` auto-opens the details panel; a visit
  belonging to a different worker is ignored; malformed ids are ignored.
- `TestUserVisitDataViewV2::test_includes_user_visit_id` — export payload carries the UUID.

### QA Plan

Manual spot-check on staging: open a visit's row on the verification page, copy its
`user_visit_id`, and confirm `/user_visits/visit/<uuid>/` lands on the page with that
visit's details open; confirm a bogus uuid 404s on the redirect URL and is ignored as a
`?visit=` param.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CI-791]: https://dimagi.atlassian.net/browse/CI-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ