### PR TITLE
Add user_id to visit export for shareable visit links

### DIFF
--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -94,6 +94,7 @@ class OpportunityUserDataSerializer(serializers.Serializer):
 
 class UserVisitDataSerializer(serializers.ModelSerializer):
     username = serializers.SerializerMethodField()
+    user_id = serializers.UUIDField(source="user.user_id")
 
     class Meta:
         model = UserVisit
@@ -101,6 +102,8 @@ class UserVisitDataSerializer(serializers.ModelSerializer):
             "id",
             "opportunity_id",
             "username",
+            "user_id",
+            "user_visit_id",
             "deliver_unit",
             "entity_id",
             "entity_name",

--- a/commcare_connect/data_export/tests/test_user_visit_export.py
+++ b/commcare_connect/data_export/tests/test_user_visit_export.py
@@ -197,6 +197,16 @@ class TestUserVisitDataViewV2:
             }
         ]
 
+    def test_includes_user_id_and_user_visit_id(self, api_client_v2, opportunity, org_user_member):
+        visit = UserVisitFactory(opportunity=opportunity, user=org_user_member)
+        _add_export_credentials(api_client_v2, org_user_member)
+
+        response = api_client_v2.get(_get_url(opportunity.id))
+
+        data = response.json()["results"][0]
+        assert data["user_id"] == str(org_user_member.user_id)
+        assert data["user_visit_id"] == str(visit.user_visit_id)
+
     def test_pagination_traversal(self, api_client_v2, opportunity, org_user_member):
         UserVisitFactory.create_batch(5, opportunity=opportunity, user=org_user_member)
         _add_export_credentials(api_client_v2, org_user_member)

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -814,6 +814,17 @@ class WorkerVisitTable(tables.Table):
     last_activity = DMYTColumn(verbose_name=gettext_lazy("Last Activity"), accessor="status_modified_date")
     status = columns.Column(verbose_name=gettext_lazy("Status"), accessor="status")
 
+    @staticmethod
+    def get_visit_url(record, table):
+        return reverse(
+            "opportunity:user_visit_details",
+            args=[
+                table.organization.slug,
+                record.opportunity.opportunity_id,
+                record.user_visit_id,
+            ],
+        )
+
     class Meta:
         model = UserVisit
         sequence = (
@@ -834,6 +845,10 @@ class WorkerVisitTable(tables.Table):
             "hx-get": lambda record, table: reverse(
                 "opportunity:user_visit_details",
                 args=[table.organization.slug, record.opportunity.opportunity_id, record.user_visit_id],
+            ),
+            "hx-push-url": lambda record, table: (
+                f"{reverse('opportunity:user_visits_list', args=[table.organization.slug, record.opportunity.opportunity_id])}"  # noqa
+                f"?{urlencode({'user': record.user.user_id, 'visit_id': record.user_visit_id})}"
             ),
             "hx-trigger": "click",
             "hx-indicator": "#visit-loading-indicator",

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -814,17 +814,6 @@ class WorkerVisitTable(tables.Table):
     last_activity = DMYTColumn(verbose_name=gettext_lazy("Last Activity"), accessor="status_modified_date")
     status = columns.Column(verbose_name=gettext_lazy("Status"), accessor="status")
 
-    @staticmethod
-    def get_visit_url(record, table):
-        return reverse(
-            "opportunity:user_visit_details",
-            args=[
-                table.organization.slug,
-                record.opportunity.opportunity_id,
-                record.user_visit_id,
-            ],
-        )
-
     class Meta:
         model = UserVisit
         sequence = (

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2338,7 +2338,7 @@ class WorkerVisitTableView(WorkerTableView):
         return kwargs
 
     def get_queryset(self):
-        queryset = UserVisit.objects.filter(opportunity=self.opportunity)
+        queryset = UserVisit.objects.filter(opportunity=self.opportunity).select_related("user", "opportunity")
         user_id = self.request.GET.get("user")
         if user_id:
             queryset = queryset.filter(user__user_id=user_id)


### PR DESCRIPTION
## Product Description

Visits can now be linked to directly: clicking a visit row updates the browser URL, and the data export API now includes enough information to build that link from outside Connect too.

## Technical Summary

[CI-791](https://dimagi.atlassian.net/browse/CI-791)

- The verification page already auto-opens a visit's details and jumps to the right table page when `user` and `visit_id` are in the URL. The only real gap was that the export API didn't expose enough to build that URL, so we added `user_id` and `user_visit_id` to it.
- Clicking a visit row now also pushes that URL into the browser's address bar, so it's copyable straight from the UI.
- Added `select_related` on the visit queryset, since the new per-row user lookup would otherwise have added a query per row.

## Safety Assurance

### Safety story

Both new serializer fields are read-only and additive, and the queryset change is a plain `select_related`, so no behavior changes for existing callers. Ran the full opportunity view and data_export test suites locally against the change.

### Automated test coverage

Added a test asserting the export payload includes `user_id` and `user_visit_id`; existing opportunity view and data_export suites all pass.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-791]: https://dimagi.atlassian.net/browse/CI-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ