### PR TITLE
Fix broken Sign In link on marketing landing page

### DIFF
--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -98,7 +98,7 @@
       <a href="/portfolio" data-route="/portfolio">Portfolio</a>
       <a href="/frontline-network" data-route="/frontline-network">Frontline Network</a>
       <div class="nav-cta">
-        <a href="{{ app_login_url }}" class="btn btn-ghost">Sign In</a>
+        <a href="{% url 'account_login' %}" class="btn btn-ghost">Sign In</a>
         <a href="/contact/" class="btn btn-primary">Request a conversation</a>
       </div>
     </nav>
@@ -113,7 +113,7 @@
     <a href="/platform" data-route="/platform">Platform</a>
     <a href="/portfolio" data-route="/portfolio">Portfolio</a>
     <a href="/frontline-network" data-route="/frontline-network">Frontline Network</a>
-    <a href="{{ app_login_url }}" class="mobile-nav-cta-secondary">Sign In</a>
+    <a href="{% url 'account_login' %}" class="mobile-nav-cta-secondary">Sign In</a>
     <a href="/contact/" class="mobile-nav-cta">Request a conversation</a>
   </nav>
 </header>
@@ -3514,7 +3514,7 @@
         <li><a href="https://dimagi.atlassian.net/wiki/spaces/connectpublic/overview?homepageId=3145401509" target="_blank" rel="noopener">Help Site ↗</a></li>
         <li><a href="/release-notes">Release Notes</a></li>
         <li><a href="/contact/">Request a conversation</a></li>
-        <li><a href="{{ app_login_url }}">Sign In</a></li>
+        <li><a href="{% url 'account_login' %}">Sign In</a></li>
       </ul>
     </div>
     <div class="foot-col">


### PR DESCRIPTION
## Technical Summary

[PR #1341](https://github.com/dimagi/commcare-connect/pull/1341) swapped `{% url 'account_login' %}` for `{{ app_login_url }}` while updating the CTAs on this page. That variable is never set anywhere in the view or context processors, so Django rendered it as an empty string and the link pointed at `href=""`.

- Restored `{% url 'account_login' %}` in all three spots (desktop nav, mobile nav, footer)
- Confirmed `account_login` resolves through the existing `allauth.urls` include in `config/urls.py`

## Safety Assurance

### Safety story

Template-only change that reverts a link back to how it worked before PR #1341. `account_login` is the same URL name already used elsewhere in this template and in `account/login.html`.

### Automated test coverage

No existing automated tests cover this static marketing template.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
