### PR TITLE
Legacy invoice drift report 

### DIFF
--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.md
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.md
@@ -1,0 +1,73 @@
+# Legacy Invoice Drift Report
+
+A **read-only** management command. For each automated service-delivery invoice it reconstructs
+what was billed at generation time and compares it to what is owed
+today (current agreement-gated rules). The difference is the **drift**. It writes two CSVs
+(one per invoice, one per completed work) plus a summary. Nothing in the database is changed.
+
+## Two kinds of drift
+
+### 1. Late-delivery drift (under-billed)
+
+Deliveries that were approved _after_ the invoice was generated, and so were never billed.
+
+Each completed work is linked to exactly one invoice, and only deliveries approved on/before the
+generation date were billed. Later approvals are never picked up by a future invoice.
+
+- Columns: `late_delivery_units`, `late_delivery_drift`.
+- Positive drift — potentially correctable.
+
+### 2. Over-billing drift (over-billed)
+
+Deliveries that _were_ billed but are not owed today — duplicates counted at billing time by
+approval status that were never PM-agreed (or were later disagreed).
+
+- Columns: `overbilled_units`, `overbilled_drift`.
+- Negative drift — the amount was already billed/paid, so it cannot be reliably corrected.
+
+> **Both only occur on works that allow duplicates** (more than one delivery). The first delivery
+> needs a PM "agree" for the work to be billable at all; duplicate deliveries were counted by
+> approval status alone. So only the duplicates can diverge from today's agreed count.
+
+## How drift is computed
+
+1. **Reconstruct the billed count** per work as of the invoice's _generation date_ using the old status-only rule — before CCCT-2505 restricted counts to PM-agreed visits. This is a **best estimate** of what was actually billed.
+2. **Desired count today** = the work's current agreement-gated `approved_count`.
+3. **Drift = desired − reconstructed**: positive → late / under-billed, negative → over-billed.
+   Drift amounts are valued at the full per-unit rate (FLW amount + org amount).
+
+## Confidence check: `reconstruction_gap`
+
+`reconstruction_gap = frozen invoice amount − reconstructed FLW amount`. It tells us whether the
+reconstruction even reproduces the original invoice, so we know how far to trust the drift numbers:
+
+- **≈ 0** → reconstruction reproduces the invoice exactly (FLW-era); trust the drift.
+- **≈ `org_pay_drift`** → the invoice already billed org pay (generated after the org-pay fix); org pay is not actually missing.
+- **anything else** → reconstruction can't reproduce the frozen amount — review.
+
+An invoice is only reported when it has late or over-billed units, or an _unexplained_ gap.
+
+## Edge case: visits with no approval date
+
+Some approved visits have a `NULL` status_modified_date (a data-quality gap — the approval
+timestamp was never recorded). We can't place these in time, so we assume they were billed and
+count them; excluding them would manufacture phantom late-delivery drift. If that assumption is
+wrong the reconstruction over-counts, `reconstruction_gap` goes non-zero and flags the row, and
+`legacy_null_status_date_visits` shows how many such visits are involved.
+
+## Org pay (informational only)
+
+`org_pay_drift` = reconstructed units × org rate — org pay omitted on billed units before the
+CCCT-2470 fix. Reported for visibility; on its own it does **not** mark an invoice as drifting
+(the same treatment we gave org pay previously).
+
+## Next steps (decision this report informs)
+
+1. **No correction** — communicate to the delivery team as needed. Consistent with how we handled
+   org pay omitted from invoices. Simple and safe.
+2. **Positive-drift correction** — a backfill could roll positive (late) drift into a future
+   invoice. Moderately complex.
+
+> Negative (over-billing) drift cannot be reliably corrected.
+
+Spec is available here: https://github.com/dimagi/commcare-connect/blob/36b3c25d462cf594b0e472936cbc273526c059a7/docs/superpowers/specs/2026-06-08-invoice-line-item-locking-design.md#good-to-have--legacy-drift-report.

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -1,0 +1,30 @@
+import datetime
+
+from commcare_connect.opportunity.models import InvoiceStatus, PaymentInvoice
+
+EXCLUDED_STATUSES = [InvoiceStatus.CANCELLED_BY_NM, InvoiceStatus.REJECTED_BY_PM]
+
+# Automated service-delivery invoicing only went live on 2026-01-01. Invoices generated before then were
+# not produced by that pipeline, so the pre-agreement reconstruction does not apply — exclude them.
+AUTOMATED_INVOICE_START_DATE = datetime.date(2026, 1, 1)
+
+
+def service_delivery_invoices(opportunity_id=None, program_id=None, exclude_test=True):
+    qs = (
+        PaymentInvoice.objects.filter(
+            service_delivery=True,
+            end_date__isnull=False,
+            date__gte=AUTOMATED_INVOICE_START_DATE,
+        )
+        .exclude(status__in=EXCLUDED_STATUSES)
+        .filter(completedwork__isnull=False)
+        .select_related("opportunity__organization")
+        .distinct()
+    )
+    if exclude_test:
+        qs = qs.filter(opportunity__is_test=False)
+    if opportunity_id:
+        qs = qs.filter(opportunity_id=opportunity_id)
+    if program_id:
+        qs = qs.filter(opportunity__program_id=program_id)
+    return qs.order_by("opportunity_id", "id")

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -199,6 +199,8 @@ class InvoiceDrift:
     #   anything else    → reconstruction can't reproduce the frozen amount; drift numbers are unreliable —
     #                      review this.
     reconstruction_gap: Decimal
+    # Per-line exposure roll-up, NOT a distinct-visit count: a composite's child visit is counted on both
+    # the child and parent rows (intentional — a child visit explains the parent's drift), so it sums twice.
     legacy_null_status_date_visits: int
     works: list = field(default_factory=list)
 

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -2,19 +2,23 @@ import argparse
 import csv
 import datetime
 import os
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from decimal import Decimal
 
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.urls import reverse
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
+    DeliverUnit,
     InvoiceStatus,
     PaymentInvoice,
+    PaymentUnit,
+    UserVisit,
+    VisitReviewStatus,
     VisitValidationStatus,
 )
 
@@ -205,6 +209,79 @@ class InvoiceDrift:
     works: list = field(default_factory=list)
 
 
+@dataclass
+class _InvoiceLookups:
+    recon: dict  # completed_work_id -> Counter(deliver_unit_id -> n): approved by status, date-bounded or NULL
+    agreed: dict  # completed_work_id -> Counter(deliver_unit_id -> n): approved AND agreed (current owed basis)
+    late: dict  # completed_work_id -> n: approved with status_modified_date after as_of_date
+    null: dict  # completed_work_id -> n: approved with NULL status_modified_date
+    du_meta: dict  # payment_unit_id -> (required_deliver_unit_ids, optional_deliver_unit_ids)
+    parents_with_children: set  # payment_unit_ids that have child payment units
+
+
+def _build_invoice_lookups(invoice, as_of_date):
+    """Batch every per-completed-work count this invoice's works need into a handful of grouped queries.
+
+    Replaces the per-work N+1 (each work previously issued ~6-8 queries, so a 10k-work invoice ran ~75k
+    queries) with a constant number of queries per invoice. Scoped to the invoice's own works; child
+    (composite) works are rare and still resolved via the query path inside the count functions.
+    """
+    approved = VisitValidationStatus.approved
+    invoice_visits = UserVisit.objects.filter(completed_work__invoice=invoice, status=approved)
+
+    recon = defaultdict(Counter)
+    for row in (
+        invoice_visits.filter(Q(status_modified_date__date__lte=as_of_date) | Q(status_modified_date__isnull=True))
+        .values("completed_work_id", "deliver_unit_id")
+        .annotate(n=Count("id"))
+    ):
+        recon[row["completed_work_id"]][row["deliver_unit_id"]] = row["n"]
+
+    agreed = defaultdict(Counter)
+    for row in (
+        invoice_visits.filter(review_status=VisitReviewStatus.agree)
+        .values("completed_work_id", "deliver_unit_id")
+        .annotate(n=Count("id"))
+    ):
+        agreed[row["completed_work_id"]][row["deliver_unit_id"]] = row["n"]
+
+    late = {
+        row["completed_work_id"]: row["n"]
+        for row in invoice_visits.filter(status_modified_date__date__gt=as_of_date)
+        .values("completed_work_id")
+        .annotate(n=Count("id"))
+    }
+    null = {
+        row["completed_work_id"]: row["n"]
+        for row in invoice_visits.filter(status_modified_date__isnull=True)
+        .values("completed_work_id")
+        .annotate(n=Count("id"))
+    }
+
+    pu_ids = list(CompletedWork.objects.filter(invoice=invoice).values_list("payment_unit_id", flat=True).distinct())
+    du_meta = {pu_id: ([], []) for pu_id in pu_ids}
+    for row in DeliverUnit.objects.filter(payment_unit_id__in=pu_ids).values("payment_unit_id", "id", "optional"):
+        required, optional = du_meta[row["payment_unit_id"]]
+        (optional if row["optional"] else required).append(row["id"])
+
+    parents_with_children = set(
+        PaymentUnit.objects.filter(parent_payment_unit_id__in=pu_ids).values_list("parent_payment_unit_id", flat=True)
+    )
+
+    return _InvoiceLookups(recon, agreed, late, null, du_meta, parents_with_children)
+
+
+def _delivery_count(unit_counts, required, optional):
+    """min-across-required delivery count, capped by the optional total; from a deliver_unit_id -> n map.
+
+    Same rule as reconstruct_billed_count / calculate_completed for a work with no children.
+    """
+    number = min((unit_counts[du_id] for du_id in required), default=0)
+    if optional:
+        number = min(number, sum(unit_counts[du_id] for du_id in optional))
+    return number
+
+
 def compute_invoice_drift(invoice, base_url=""):
     works = []
     reconstructed_flw_amount = Decimal(0)
@@ -213,16 +290,29 @@ def compute_invoice_drift(invoice, base_url=""):
     # later that same day (after the invoice was cut) it is slightly over-counted, which reconstruction_gap
     # surfaces if ever material.
     billed_through = invoice.date
+    lookups = _build_invoice_lookups(invoice, billed_through)
     for cw in completed_works:
-        reconstructed_deliveries_count = reconstruct_billed_count(cw, billed_through)
-        desired_deliveries_count = cw.approved_count
+        is_composite = cw.payment_unit_id in lookups.parents_with_children
+        if is_composite:
+            reconstructed_deliveries_count = reconstruct_billed_count(cw, billed_through)
+            desired_deliveries_count = cw.approved_count
+        else:
+            required, optional = lookups.du_meta[cw.payment_unit_id]
+            reconstructed_deliveries_count = _delivery_count(lookups.recon.get(cw.id, Counter()), required, optional)
+            desired_deliveries_count = _delivery_count(lookups.agreed.get(cw.id, Counter()), required, optional)
+
         flw_amount = cw.payment_unit.amount
         org_amount = cw.payment_unit.org_amount
         full_rate = flw_amount + org_amount
         late_units = max(0, desired_deliveries_count - reconstructed_deliveries_count)
         over_units = max(0, reconstructed_deliveries_count - desired_deliveries_count)
-        late_approved_visits = _late_approved_visit_count(cw, billed_through) if late_units else 0
-        null_date_visits = _null_status_date_approved_visit_count(cw)
+
+        if is_composite:
+            late_approved_visits = _late_approved_visit_count(cw, billed_through) if late_units else 0
+            null_date_visits = _null_status_date_approved_visit_count(cw)
+        else:
+            late_approved_visits = lookups.late.get(cw.id, 0) if late_units else 0
+            null_date_visits = lookups.null.get(cw.id, 0)
         works.append(
             WorkDrift(
                 completed_work_id=cw.id,
@@ -318,8 +408,15 @@ def invoice_has_drift(drift):
 
 
 def iter_invoice_drift(invoices, base_url=""):
-    for invoice in invoices:
-        yield compute_invoice_drift(invoice, base_url)
+    invoices = list(invoices)
+    total = len(invoices)
+    print(f"Scanning {total} invoices...", flush=True)
+    for i, invoice in enumerate(invoices, 1):
+        print(f"[{i}/{total}] {invoice.id}  computing drift...", flush=True)
+        drift = compute_invoice_drift(invoice, base_url)
+        # Per-invoice progress: the run is a per-completed-work N+1, so a slow line = an invoice with many works.
+        print(f"[{i}/{total}] {invoice.id}  works={len(drift.works)}  gap={drift.reconstruction_gap}", flush=True)
+        yield drift
 
 
 def invoice_row(drift):
@@ -427,6 +524,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        print("Generating invoice drift report...")
         invoices = service_delivery_invoices(
             opportunity_id=options["opportunity"],
             program_id=options["program"],

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -1,5 +1,7 @@
 import datetime
 from collections import Counter
+from dataclasses import dataclass, field
+from decimal import Decimal
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
@@ -92,3 +94,124 @@ def reconstruct_billed_count(completed_work, as_of_date):
         child_count = sum(reconstruct_billed_count(child, as_of_date) for child in children)
         number_approved = min(number_approved, child_count)
     return number_approved
+
+
+@dataclass
+class WorkDrift:
+    completed_work_id: int
+    payment_unit_name: str
+    entity_name: str
+    reconstructed_deliveries_count: int  # old logic, in-invoice-window (what was billed)
+    desired_deliveries_count: int  # current agreement-gated logic, all-time (what is owed now)
+    late_delivery_units: int  # max(0, desired - reconstructed)
+    # Late-delivery drift, valued at the FULL per-unit rate (flw_amount + org_amount). Org pay is INCLUDED here.
+    late_delivery_drift: Decimal
+    # overbilled_units: max(0, reconstructed - desired): billed under the legacy rule but never
+    # PM-agreed (or otherwise not owed now) — a clawback candidate.
+    overbilled_units: int
+    # Over-billing drift, also valued at the FULL rate (flw_amount + org_amount); org pay included.
+    overbilled_drift: Decimal
+    # reconstructed_deliveries_count * org_amount: org omitted on billed units (reporting only).
+    org_pay_drift: Decimal
+
+
+@dataclass
+class InvoiceDrift:
+    invoice_id: int
+    invoice_number: str
+    opportunity_id: int
+    opportunity_name: str
+    org_name: str
+    status: str
+    invoice_date: object
+    frozen_amount: Decimal
+    reconstructed_flw_amount: Decimal  # Σ reconstructed_deliveries_count * flw_amount;
+    late_delivery_units: int
+    late_delivery_drift: Decimal
+    overbilled_units: int
+    overbilled_drift: Decimal
+    # org pay omitted on the units that WERE billed (before CCCT-2470 fix)
+    org_pay_drift: Decimal
+    # reconstruction_gap = frozen_amount - reconstructed_flw_amount.
+    # This compares the ACTUAL frozen invoice vs our reconstruction of old-logic
+    # billing i.e. "does our reconstruction even reproduce what was billed?" It is the confidence gauge for
+    # every other number on the row. Interpret:
+    #   ≈ 0              → reconstruction reproduces the invoice (only FLW amounts); trust the drift.
+    #   ≈ org_pay_drift  → the invoice already billed org pay, so org_pay_drift is NOT actually missing
+    #                      (a false positive for this row).
+    #   anything else    → reconstruction can't reproduce the frozen amount; drift numbers are unreliable —
+    #                      review this.
+    reconstruction_gap: Decimal
+    works: list = field(default_factory=list)
+
+
+def compute_invoice_drift(invoice):
+    works = []
+    reconstructed_flw_amount = Decimal(0)
+    completed_works = CompletedWork.objects.filter(invoice=invoice).select_related("payment_unit")
+    # invoice.date is date-only, so the whole generation day is counted; in the rare case a visit was approved
+    # later that same day (after the invoice was cut) it is slightly over-counted, which reconstruction_gap
+    # surfaces if ever material.
+    billed_through = invoice.date
+    for cw in completed_works:
+        reconstructed_deliveries_count = reconstruct_billed_count(cw, billed_through)
+        desired_deliveries_count = cw.approved_count
+        flw_amount = cw.payment_unit.amount
+        org_amount = cw.payment_unit.org_amount
+        full_rate = flw_amount + org_amount
+        late_units = max(0, desired_deliveries_count - reconstructed_deliveries_count)
+        over_units = max(0, reconstructed_deliveries_count - desired_deliveries_count)
+        works.append(
+            WorkDrift(
+                completed_work_id=cw.id,
+                payment_unit_name=cw.payment_unit.name,
+                entity_name=cw.entity_name or "",
+                reconstructed_deliveries_count=reconstructed_deliveries_count,
+                desired_deliveries_count=desired_deliveries_count,
+                late_delivery_units=late_units,
+                late_delivery_drift=Decimal(late_units * full_rate),
+                overbilled_units=over_units,
+                overbilled_drift=Decimal(over_units * full_rate),
+                org_pay_drift=Decimal(reconstructed_deliveries_count * org_amount),
+            )
+        )
+        reconstructed_flw_amount += reconstructed_deliveries_count * flw_amount
+
+    frozen = invoice.amount
+    return InvoiceDrift(
+        invoice_id=invoice.id,
+        invoice_number=invoice.invoice_number,
+        opportunity_id=invoice.opportunity_id,
+        opportunity_name=invoice.opportunity.name,
+        org_name=invoice.opportunity.organization.name,
+        status=invoice.status,
+        invoice_date=invoice.date,
+        frozen_amount=frozen,
+        reconstructed_flw_amount=reconstructed_flw_amount,
+        late_delivery_units=sum(w.late_delivery_units for w in works),
+        late_delivery_drift=sum((w.late_delivery_drift for w in works), Decimal(0)),
+        overbilled_units=sum(w.overbilled_units for w in works),
+        overbilled_drift=sum((w.overbilled_drift for w in works), Decimal(0)),
+        org_pay_drift=sum((w.org_pay_drift for w in works), Decimal(0)),
+        reconstruction_gap=frozen - reconstructed_flw_amount,
+        works=works,
+    )
+
+
+def gap_is_unexplained(drift):
+    """True when the reconstruction gap is NOT explained by the invoice's era.
+    gap == 0            → FLW-era invoice(only flw amounts), reconstruction reproduces it exactly.
+    gap == org_pay_drift → recent org-era invoice(flw + org amounts) that already billed org pay (org not missing).
+    Anything else is a genuine model-fit anomaly.
+    """
+    return drift.reconstruction_gap not in (Decimal(0), drift.org_pay_drift)
+
+
+def invoice_has_drift(drift):
+    """True if the invoice shows correctable or anomalous drift, i.e. worth showing."""
+    return drift.late_delivery_units > 0 or drift.overbilled_units > 0 or gap_is_unexplained(drift)
+
+
+def iter_invoice_drift(invoices):
+    for invoice in invoices:
+        yield compute_invoice_drift(invoice)

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
+from django.db.models import Q
 from django.urls import reverse
 
 from commcare_connect.opportunity.models import (
@@ -46,10 +47,17 @@ def service_delivery_invoices(opportunity_id=None, program_id=None, exclude_test
 
 
 def _approved_deliver_unit_ids(completed_work, as_of_date):
-    """Deliver-unit ids for visits approved by STATUS ONLY on/before as_of_date."""
+    """Deliver-unit ids for visits approved by STATUS ONLY on/before as_of_date.
+
+    Visits with a NULL status_modified_date ARE counted: a NULL means the approval date was never
+    recorded (a data-quality gap), so we can't place the visit in time and assume it was billed (excluding
+    them manufactured phantom late-delivery drift). If that assumption is wrong the reconstruction
+    over-counts and reconstruction_gap goes non-zero, flagging the row — legacy_null_status_date_visits
+    shows how many such visits are involved.
+    """
     return completed_work.uservisit_set.filter(
+        Q(status_modified_date__date__lte=as_of_date) | Q(status_modified_date__isnull=True),
         status=VisitValidationStatus.approved,
-        status_modified_date__date__lte=as_of_date,
     ).values_list("deliver_unit_id", flat=True)
 
 
@@ -83,6 +91,15 @@ def _late_approved_visit_count(completed_work, as_of_date):
     return count
 
 
+def _null_status_date_approved_visit_count(completed_work):
+    count = completed_work.uservisit_set.filter(
+        status=VisitValidationStatus.approved,
+        status_modified_date__isnull=True,
+    ).count()
+    count += sum(_null_status_date_approved_visit_count(child) for child in _child_completed_works(completed_work))
+    return count
+
+
 def invoice_review_url(invoice, base_url=""):
     opportunity = invoice.opportunity
     path = reverse(
@@ -105,7 +122,8 @@ def reconstruct_billed_count(completed_work, as_of_date):
     billed. Bounding at end_date instead would drop them and manufacture phantom late-delivery drift.
 
     Mirrors CompletedWork.calculate_completed(approved=True) but (1) counts visits by approval STATUS only
-    (no review_status=agree gate) and (2) bounds them to status_modified_date <= as_of_date. Child payment units are
+    (no review_status=agree gate) and (2) bounds them to status_modified_date <= as_of_date, treating a
+    NULL status_modified_date as billed (see _approved_deliver_unit_ids). Child payment units are
     reconstructed recursively with the same rules rather than via the live, agreement-gated approved_count.
     """
     unit_counts = Counter(_approved_deliver_unit_ids(completed_work, as_of_date))
@@ -149,6 +167,8 @@ class WorkDrift:
     overbilled_drift: Decimal
     # reconstructed_deliveries_count * org_amount: org omitted on billed units (reporting only).
     org_pay_drift: Decimal
+    # Approved visits counted with an unrecorded status date (see _null_status_date_approved_visit_count).
+    legacy_null_status_date_visits: int
 
 
 @dataclass
@@ -179,6 +199,7 @@ class InvoiceDrift:
     #   anything else    → reconstruction can't reproduce the frozen amount; drift numbers are unreliable —
     #                      review this.
     reconstruction_gap: Decimal
+    legacy_null_status_date_visits: int
     works: list = field(default_factory=list)
 
 
@@ -199,6 +220,7 @@ def compute_invoice_drift(invoice, base_url=""):
         late_units = max(0, desired_deliveries_count - reconstructed_deliveries_count)
         over_units = max(0, reconstructed_deliveries_count - desired_deliveries_count)
         late_approved_visits = _late_approved_visit_count(cw, billed_through) if late_units else 0
+        null_date_visits = _null_status_date_approved_visit_count(cw)
         works.append(
             WorkDrift(
                 completed_work_id=cw.id,
@@ -212,6 +234,7 @@ def compute_invoice_drift(invoice, base_url=""):
                 overbilled_units=over_units,
                 overbilled_drift=Decimal(over_units * full_rate),
                 org_pay_drift=Decimal(reconstructed_deliveries_count * org_amount),
+                legacy_null_status_date_visits=null_date_visits,
             )
         )
         reconstructed_flw_amount += reconstructed_deliveries_count * flw_amount
@@ -234,6 +257,7 @@ def compute_invoice_drift(invoice, base_url=""):
         overbilled_drift=sum((w.overbilled_drift for w in works), Decimal(0)),
         org_pay_drift=sum((w.org_pay_drift for w in works), Decimal(0)),
         reconstruction_gap=frozen - reconstructed_flw_amount,
+        legacy_null_status_date_visits=sum(w.legacy_null_status_date_visits for w in works),
         works=works,
     )
 
@@ -255,6 +279,7 @@ INVOICE_CSV_HEADER = [
     "overbilled_units",
     "overbilled_drift",
     "org_pay_drift",
+    "legacy_null_status_date_visits",
 ]
 
 WORK_CSV_HEADER = [
@@ -272,6 +297,7 @@ WORK_CSV_HEADER = [
     "overbilled_units",
     "overbilled_drift",
     "org_pay_drift",
+    "legacy_null_status_date_visits",
 ]
 
 
@@ -312,6 +338,7 @@ def invoice_row(drift):
         drift.overbilled_units,
         drift.overbilled_drift,
         drift.org_pay_drift,
+        drift.legacy_null_status_date_visits,
     ]
 
 
@@ -339,6 +366,7 @@ def work_rows(drift):
             work.overbilled_units,
             work.overbilled_drift,
             work.org_pay_drift,
+            work.legacy_null_status_date_visits,
         ]
 
 

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -1,6 +1,12 @@
 import datetime
+from collections import Counter
 
-from commcare_connect.opportunity.models import InvoiceStatus, PaymentInvoice
+from commcare_connect.opportunity.models import (
+    CompletedWork,
+    InvoiceStatus,
+    PaymentInvoice,
+    VisitValidationStatus,
+)
 
 EXCLUDED_STATUSES = [InvoiceStatus.CANCELLED_BY_NM, InvoiceStatus.REJECTED_BY_PM]
 
@@ -28,3 +34,61 @@ def service_delivery_invoices(opportunity_id=None, program_id=None, exclude_test
     if program_id:
         qs = qs.filter(opportunity__program_id=program_id)
     return qs.order_by("opportunity_id", "id")
+
+
+def _approved_deliver_unit_ids(completed_work, as_of_date):
+    """Deliver-unit ids for visits approved by STATUS ONLY on/before as_of_date."""
+    return completed_work.uservisit_set.filter(
+        status=VisitValidationStatus.approved,
+        status_modified_date__date__lte=as_of_date,
+    ).values_list("deliver_unit_id", flat=True)
+
+
+def _child_completed_works(completed_work):
+    """Completed works for this work's child payment units (same access + entity), or an empty queryset."""
+    child_payment_units = completed_work.payment_unit.child_payment_units.all()
+    if not child_payment_units:
+        return CompletedWork.objects.none()
+    return CompletedWork.objects.filter(
+        opportunity_access=completed_work.opportunity_access,
+        payment_unit__in=child_payment_units,
+        entity_id=completed_work.entity_id,
+    )
+
+
+def reconstruct_billed_count(completed_work, as_of_date):
+    """Reconstruct the approved count billed at invoice time, using the *pre-agreement* rules.
+
+    Pre-agreement (before CCCT-2505): a work needed >=1 PM-agreed visit to be billable, but the billed
+    COUNT then came from approval STATUS (status=approved), not the agreed visits. CCCT-2505 restricted
+    the count to agreed visits only. Counting by status alone is safe here because we only reconstruct
+    already-invoiced works, where that "at least one agreed" gate was already met.
+
+    ``as_of_date`` is the invoice GENERATION date (invoice.date), not its service-period end_date: an
+    invoice freezes its count at generation, so visits approved between end_date and then were still
+    billed. Bounding at end_date instead would drop them and manufacture phantom late-delivery drift.
+
+    Mirrors CompletedWork.calculate_completed(approved=True) but (1) counts visits by approval STATUS only
+    (no review_status=agree gate) and (2) bounds them to status_modified_date <= as_of_date. Child payment units are
+    reconstructed recursively with the same rules rather than via the live, agreement-gated approved_count.
+    """
+    unit_counts = Counter(_approved_deliver_unit_ids(completed_work, as_of_date))
+    deliver_units = completed_work.payment_unit.deliver_units.values("id", "optional")
+
+    required = []
+    optional = []
+    for du in deliver_units:
+        if du["optional"]:
+            optional.append(du["id"])
+        else:
+            required.append(du["id"])
+
+    number_approved = min((unit_counts[du_id] for du_id in required), default=0)
+    if optional:
+        number_approved = min(number_approved, sum(unit_counts[du_id] for du_id in optional))
+
+    children = _child_completed_works(completed_work)
+    if children:
+        child_count = sum(reconstruct_billed_count(child, as_of_date) for child in children)
+        number_approved = min(number_approved, child_count)
+    return number_approved

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -1,7 +1,12 @@
+import argparse
+import csv
 import datetime
+import os
 from collections import Counter
 from dataclasses import dataclass, field
 from decimal import Decimal
+
+from django.core.management import BaseCommand
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
@@ -198,6 +203,41 @@ def compute_invoice_drift(invoice):
     )
 
 
+INVOICE_CSV_HEADER = [
+    "opportunity_id",
+    "opportunity_name",
+    "org_name",
+    "invoice_id",
+    "invoice_number",
+    "invoice_status",
+    "invoice_date",
+    "frozen_amount",
+    "reconstructed_flw_amount",
+    "reconstruction_gap",
+    "late_delivery_units",
+    "late_delivery_drift",
+    "overbilled_units",
+    "overbilled_drift",
+    "org_pay_drift",
+]
+
+WORK_CSV_HEADER = [
+    "invoice_id",
+    "invoice_number",
+    "opportunity_id",
+    "completed_work_id",
+    "payment_unit",
+    "entity_name",
+    "reconstructed_deliveries_count",
+    "desired_deliveries_count",
+    "late_delivery_units",
+    "late_delivery_drift",
+    "overbilled_units",
+    "overbilled_drift",
+    "org_pay_drift",
+]
+
+
 def gap_is_unexplained(drift):
     """True when the reconstruction gap is NOT explained by the invoice's era.
     gap == 0            → FLW-era invoice(only flw amounts), reconstruction reproduces it exactly.
@@ -215,3 +255,133 @@ def invoice_has_drift(drift):
 def iter_invoice_drift(invoices):
     for invoice in invoices:
         yield compute_invoice_drift(invoice)
+
+
+def invoice_row(drift):
+    return [
+        drift.opportunity_id,
+        drift.opportunity_name,
+        drift.org_name,
+        drift.invoice_id,
+        drift.invoice_number,
+        drift.status,
+        drift.invoice_date,
+        drift.frozen_amount,
+        drift.reconstructed_flw_amount,
+        drift.reconstruction_gap,
+        drift.late_delivery_units,
+        drift.late_delivery_drift,
+        drift.overbilled_units,
+        drift.overbilled_drift,
+        drift.org_pay_drift,
+    ]
+
+
+def work_has_drift(work):
+    """A work is worth a row only if it under- or over-delivered (positive or negative count drift)."""
+    return work.late_delivery_units > 0 or work.overbilled_units > 0
+
+
+def work_rows(drift):
+    for work in drift.works:
+        if not work_has_drift(work):
+            continue
+        yield [
+            drift.invoice_id,
+            drift.invoice_number,
+            drift.opportunity_id,
+            work.completed_work_id,
+            work.payment_unit_name,
+            work.entity_name,
+            work.reconstructed_deliveries_count,
+            work.desired_deliveries_count,
+            work.late_delivery_units,
+            work.late_delivery_drift,
+            work.overbilled_units,
+            work.overbilled_drift,
+            work.org_pay_drift,
+        ]
+
+
+def write_invoice_csv(drifts, path):
+    """One row per drifting invoice."""
+    with open(path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(INVOICE_CSV_HEADER)
+        for drift in drifts:
+            if invoice_has_drift(drift):
+                writer.writerow(invoice_row(drift))
+
+
+def write_work_csv(drifts, path):
+    """One row per completed work, for drifting invoices only; join to the invoice report on invoice_id."""
+    with open(path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(WORK_CSV_HEADER)
+        for drift in drifts:
+            if not invoice_has_drift(drift):
+                continue
+            for row in work_rows(drift):
+                writer.writerow(row)
+
+
+def summary_lines(drifts):
+    reportable = [d for d in drifts if invoice_has_drift(d)]
+    late = sum(1 for d in drifts if d.late_delivery_units > 0)
+    late_units = sum(d.late_delivery_units for d in drifts)
+    over = sum(1 for d in drifts if d.overbilled_units > 0)
+    over_units = sum(d.overbilled_units for d in drifts)
+    unexplained_gap = sum(1 for d in drifts if gap_is_unexplained(d))
+    return [
+        f"Invoices scanned: {len(drifts)}",
+        f"Invoices shown (correctable / anomalous drift): {len(reportable)}",
+        f"Late-delivery drift (incl org): {late} invoice(s), {late_units} unit(s)",
+        f"Over-billing drift (clawback, incl org): {over} invoice(s), {over_units} unit(s)",
+        f"Reconstruction gap unexplained (model-fit anomalies): {unexplained_gap} invoice(s)",
+    ]
+
+
+class Command(BaseCommand):
+    help = "Read-only legacy invoice drift report (CCCT-2524). Writes a CSV and prints a summary."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--opportunity", type=int, default=None)
+        parser.add_argument("--program", type=int, default=None)
+        parser.add_argument(
+            "--output", type=str, default="/tmp/invoice_drift_report.csv", help="Invoice-level report path."
+        )
+        parser.add_argument(
+            "--exclude-test",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Exclude test opportunities (is_test=True). Defaults to True; --no-exclude-test to include them.",
+        )
+
+    def handle(self, *args, **options):
+        invoices = service_delivery_invoices(
+            opportunity_id=options["opportunity"],
+            program_id=options["program"],
+            exclude_test=options["exclude_test"],
+        )
+        drifts = list(iter_invoice_drift(invoices))
+
+        for drift in drifts:
+            if gap_is_unexplained(drift):
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"Reconstruction gap for invoice {drift.invoice_number}: frozen "
+                        f"{drift.frozen_amount} vs reconstructed_flw_amount {drift.reconstructed_flw_amount} "
+                        f"(gap {drift.reconstruction_gap})"
+                    )
+                )
+        for line in summary_lines(drifts):
+            self.stdout.write(line)
+
+        if drifts:
+            invoice_output = options["output"]
+            base, ext = os.path.splitext(invoice_output)
+            work_output = f"{base}_works{ext}"
+            write_invoice_csv(drifts, invoice_output)
+            write_work_csv(drifts, work_output)
+            self.stdout.write(self.style.SUCCESS(f"Invoice report written to {os.path.abspath(invoice_output)}"))
+            self.stdout.write(self.style.SUCCESS(f"Work report written to {os.path.abspath(work_output)}"))

--- a/commcare_connect/opportunity/management/commands/report_invoice_drift.py
+++ b/commcare_connect/opportunity/management/commands/report_invoice_drift.py
@@ -6,7 +6,9 @@ from collections import Counter
 from dataclasses import dataclass, field
 from decimal import Decimal
 
+from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
+from django.urls import reverse
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
@@ -63,6 +65,33 @@ def _child_completed_works(completed_work):
     )
 
 
+def _late_approved_visit_count(completed_work, as_of_date):
+    """Raw count of visits approved AFTER the invoice generation date (status=approved, status_modified_date > it).
+
+    These are the deliveries that landed too late to be billed on this invoice and therefore explain
+    late-delivery drift. Sums this completed work's late visits plus those of its child completed works
+    recursively.
+
+    NOTE: this is a raw visit tally, NOT a delivery count, so it does NOT equal late_delivery_units in
+    general.
+    """
+    count = completed_work.uservisit_set.filter(
+        status=VisitValidationStatus.approved,
+        status_modified_date__date__gt=as_of_date,
+    ).count()
+    count += sum(_late_approved_visit_count(child, as_of_date) for child in _child_completed_works(completed_work))
+    return count
+
+
+def invoice_review_url(invoice, base_url=""):
+    opportunity = invoice.opportunity
+    path = reverse(
+        "opportunity:invoice_review",
+        args=(opportunity.organization.slug, opportunity.opportunity_id, invoice.payment_invoice_id),
+    )
+    return f"{base_url.rstrip('/')}{path}" if base_url else path
+
+
 def reconstruct_billed_count(completed_work, as_of_date):
     """Reconstruct the approved count billed at invoice time, using the *pre-agreement* rules.
 
@@ -109,6 +138,8 @@ class WorkDrift:
     reconstructed_deliveries_count: int  # old logic, in-invoice-window (what was billed)
     desired_deliveries_count: int  # current agreement-gated logic, all-time (what is owed now)
     late_delivery_units: int  # max(0, desired - reconstructed)
+    # deliveries approved after the invoice end date; the raw evidence behind late-delivery drift.
+    late_approved_visit_count: int
     # Late-delivery drift, valued at the FULL per-unit rate (flw_amount + org_amount). Org pay is INCLUDED here.
     late_delivery_drift: Decimal
     # overbilled_units: max(0, reconstructed - desired): billed under the legacy rule but never
@@ -124,6 +155,7 @@ class WorkDrift:
 class InvoiceDrift:
     invoice_id: int
     invoice_number: str
+    invoice_url: str
     opportunity_id: int
     opportunity_name: str
     org_name: str
@@ -150,7 +182,7 @@ class InvoiceDrift:
     works: list = field(default_factory=list)
 
 
-def compute_invoice_drift(invoice):
+def compute_invoice_drift(invoice, base_url=""):
     works = []
     reconstructed_flw_amount = Decimal(0)
     completed_works = CompletedWork.objects.filter(invoice=invoice).select_related("payment_unit")
@@ -166,6 +198,7 @@ def compute_invoice_drift(invoice):
         full_rate = flw_amount + org_amount
         late_units = max(0, desired_deliveries_count - reconstructed_deliveries_count)
         over_units = max(0, reconstructed_deliveries_count - desired_deliveries_count)
+        late_approved_visits = _late_approved_visit_count(cw, billed_through) if late_units else 0
         works.append(
             WorkDrift(
                 completed_work_id=cw.id,
@@ -174,6 +207,7 @@ def compute_invoice_drift(invoice):
                 reconstructed_deliveries_count=reconstructed_deliveries_count,
                 desired_deliveries_count=desired_deliveries_count,
                 late_delivery_units=late_units,
+                late_approved_visit_count=late_approved_visits,
                 late_delivery_drift=Decimal(late_units * full_rate),
                 overbilled_units=over_units,
                 overbilled_drift=Decimal(over_units * full_rate),
@@ -186,6 +220,7 @@ def compute_invoice_drift(invoice):
     return InvoiceDrift(
         invoice_id=invoice.id,
         invoice_number=invoice.invoice_number,
+        invoice_url=invoice_review_url(invoice, base_url),
         opportunity_id=invoice.opportunity_id,
         opportunity_name=invoice.opportunity.name,
         org_name=invoice.opportunity.organization.name,
@@ -209,6 +244,7 @@ INVOICE_CSV_HEADER = [
     "org_name",
     "invoice_id",
     "invoice_number",
+    "invoice_url",
     "invoice_status",
     "invoice_date",
     "frozen_amount",
@@ -231,6 +267,7 @@ WORK_CSV_HEADER = [
     "reconstructed_deliveries_count",
     "desired_deliveries_count",
     "late_delivery_units",
+    "late_approved_visit_count",
     "late_delivery_drift",
     "overbilled_units",
     "overbilled_drift",
@@ -252,9 +289,9 @@ def invoice_has_drift(drift):
     return drift.late_delivery_units > 0 or drift.overbilled_units > 0 or gap_is_unexplained(drift)
 
 
-def iter_invoice_drift(invoices):
+def iter_invoice_drift(invoices, base_url=""):
     for invoice in invoices:
-        yield compute_invoice_drift(invoice)
+        yield compute_invoice_drift(invoice, base_url)
 
 
 def invoice_row(drift):
@@ -264,6 +301,7 @@ def invoice_row(drift):
         drift.org_name,
         drift.invoice_id,
         drift.invoice_number,
+        drift.invoice_url,
         drift.status,
         drift.invoice_date,
         drift.frozen_amount,
@@ -296,6 +334,7 @@ def work_rows(drift):
             work.reconstructed_deliveries_count,
             work.desired_deliveries_count,
             work.late_delivery_units,
+            work.late_approved_visit_count,
             work.late_delivery_drift,
             work.overbilled_units,
             work.overbilled_drift,
@@ -363,7 +402,8 @@ class Command(BaseCommand):
             program_id=options["program"],
             exclude_test=options["exclude_test"],
         )
-        drifts = list(iter_invoice_drift(invoices))
+        base_url = f"https://{Site.objects.get_current().domain}"
+        drifts = list(iter_invoice_drift(invoices, base_url=base_url))
 
         for drift in drifts:
             if gap_is_unexplained(drift):

--- a/commcare_connect/opportunity/tests/test_invoice_drift.py
+++ b/commcare_connect/opportunity/tests/test_invoice_drift.py
@@ -6,8 +6,13 @@ import pytest
 from commcare_connect.opportunity.management.commands.report_invoice_drift import (
     compute_invoice_drift,
     invoice_has_drift,
+    iter_invoice_drift,
     reconstruct_billed_count,
     service_delivery_invoices,
+    summary_lines,
+    work_rows,
+    write_invoice_csv,
+    write_work_csv,
 )
 from commcare_connect.opportunity.models import InvoiceStatus, UserVisit, VisitReviewStatus, VisitValidationStatus
 from commcare_connect.opportunity.tests.factories import (
@@ -324,3 +329,35 @@ def test_overbilling_negative_drift_with_clean_reconciliation(opportunity):
     assert drift.overbilled_units == 1
     assert drift.overbilled_drift == Decimal(100)
     assert drift.late_delivery_units == 0
+
+
+def test_iter_and_summary_end_to_end(opportunity, tmp_path):
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(100),
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    _completed_work_with_visits(
+        invoice, opportunity, amount=100, org_amount=0, agreed_in_window=1, agreed_late=1
+    )  # desired 2, reconstructed 1 → +1 late unit
+
+    drifts = list(iter_invoice_drift(service_delivery_invoices()))
+    assert len(drifts) == 1
+    assert list(work_rows(drifts[0]))  # at least one work row
+
+    invoice_out = tmp_path / "invoice_drift.csv"
+    write_invoice_csv(drifts, str(invoice_out))
+    invoice_contents = invoice_out.read_text()
+    assert invoice.invoice_number in invoice_contents
+    # Invoice-level report has exactly one data row (header + 1).
+    assert len(invoice_contents.strip().splitlines()) == 2
+
+    work_out = tmp_path / "work_drift.csv"
+    write_work_csv(drifts, str(work_out))
+    assert invoice.invoice_number in work_out.read_text()
+
+    summary = "\n".join(summary_lines(drifts))
+    assert "Invoices scanned: 1" in summary

--- a/commcare_connect/opportunity/tests/test_invoice_drift.py
+++ b/commcare_connect/opportunity/tests/test_invoice_drift.py
@@ -1,0 +1,57 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from commcare_connect.opportunity.management.commands.report_invoice_drift import (
+    service_delivery_invoices,
+)
+from commcare_connect.opportunity.models import InvoiceStatus
+from commcare_connect.opportunity.tests.factories import (
+    CompletedWorkFactory,
+    OpportunityAccessFactory,
+    OpportunityFactory,
+    PaymentInvoiceFactory,
+    PaymentUnitFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+END = datetime.date(2026, 1, 31)
+
+
+def _invoice_with_work(opportunity, *, amount, status=InvoiceStatus.PAID, service_delivery=True):
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(amount),
+        service_delivery=service_delivery,
+        status=status,
+        end_date=END,
+        date=END,
+    )
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    pu = PaymentUnitFactory(opportunity=opportunity, amount=100, org_amount=0)
+    cw = CompletedWorkFactory(opportunity_access=access, payment_unit=pu, saved_approved_count=1)
+    cw.invoice = invoice
+    cw.save()
+    return invoice, cw, pu
+
+
+def test_query_excludes_cancelled_rejected_and_non_service_delivery(opportunity):
+    live, _, _ = _invoice_with_work(opportunity, amount=100, status=InvoiceStatus.PAID)
+    _invoice_with_work(opportunity, amount=100, status=InvoiceStatus.CANCELLED_BY_NM)
+    _invoice_with_work(opportunity, amount=100, status=InvoiceStatus.REJECTED_BY_PM)
+    _invoice_with_work(opportunity, amount=100, service_delivery=False)
+
+    result = list(service_delivery_invoices())
+    assert [i.id for i in result] == [live.id]
+
+
+def test_query_excludes_test_opportunities_by_default(opportunity):
+    real = OpportunityFactory(is_test=False)
+    test_opp = OpportunityFactory(is_test=True)
+    real_invoice, _, _ = _invoice_with_work(real, amount=100, status=InvoiceStatus.PAID)
+    test_invoice, _, _ = _invoice_with_work(test_opp, amount=100, status=InvoiceStatus.PAID)
+
+    assert [i.id for i in service_delivery_invoices()] == [real_invoice.id]
+    assert test_invoice.id in {i.id for i in service_delivery_invoices(exclude_test=False)}

--- a/commcare_connect/opportunity/tests/test_invoice_drift.py
+++ b/commcare_connect/opportunity/tests/test_invoice_drift.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 import pytest
 
 from commcare_connect.opportunity.management.commands.report_invoice_drift import (
+    compute_invoice_drift,
+    invoice_has_drift,
     reconstruct_billed_count,
     service_delivery_invoices,
 )
@@ -129,3 +131,196 @@ def test_reconstruct_child_constraint_uses_pre_agreement_basis(opportunity):
 
     assert parent_cw.approved_count == 0  # live, agreement-gated logic drops it
     assert reconstruct_billed_count(parent_cw, END) == 1  # legacy basis keeps it, parent constrained by child
+
+
+IN_WINDOW = datetime.datetime(2026, 1, 15, tzinfo=datetime.UTC)
+AFTER_WINDOW = datetime.datetime(2026, 2, 15, tzinfo=datetime.UTC)
+# An invoice whose service period ends END (Jan 31) but that was generated later (Feb 28): visits
+# approved between END and the generation date were still billed.
+GENERATED_ON = datetime.date(2026, 2, 28)
+
+
+def _completed_work_with_visits(
+    invoice,
+    opportunity,
+    *,
+    amount,
+    org_amount,
+    agreed_in_window=0,
+    approved_only_in_window=0,
+    agreed_late=0,
+):
+    """Build a completed work linked to `invoice` from real visits, so both counts are recalculated:
+
+    reconstructed (old logic, status-only, <= end_date) = agreed_in_window + approved_only_in_window
+    desired (cw.approved_count, agreement-gated, all-time) = agreed_in_window + agreed_late
+    """
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    pu = PaymentUnitFactory(opportunity=opportunity, amount=amount, org_amount=org_amount)
+    du = DeliverUnitFactory(payment_unit=pu, optional=False)
+    cw = CompletedWorkFactory(opportunity_access=access, payment_unit=pu)
+    cw.invoice = invoice
+    cw.save()
+    for _ in range(agreed_in_window):
+        _approved_visit(cw, du, on=IN_WINDOW, agree=True)
+    for _ in range(approved_only_in_window):
+        _approved_visit(cw, du, on=IN_WINDOW, agree=False)
+    for _ in range(agreed_late):
+        _approved_visit(cw, du, on=AFTER_WINDOW, agree=True)
+    return cw
+
+
+def test_no_drift(opportunity):
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(100),
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    _completed_work_with_visits(invoice, opportunity, amount=100, org_amount=0, agreed_in_window=1)
+
+    drift = compute_invoice_drift(invoice)
+    assert drift.reconstructed_flw_amount == Decimal(100)
+    assert drift.reconstruction_gap == Decimal(0)
+    assert drift.late_delivery_units == 0
+    assert drift.overbilled_units == 0
+    assert drift.org_pay_drift == Decimal(0)
+    assert drift.works[0].desired_deliveries_count == 1
+
+
+def test_late_delivery_drift_is_per_work(opportunity):
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(100),
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    # 1 agreed in-window + 1 agreed only after end_date (orphaned) → desired 2, reconstructed 1 → +1 unit.
+    _completed_work_with_visits(invoice, opportunity, amount=100, org_amount=0, agreed_in_window=1, agreed_late=1)
+
+    drift = compute_invoice_drift(invoice)
+    assert drift.works[0].reconstructed_deliveries_count == 1
+    assert drift.works[0].desired_deliveries_count == 2
+    assert drift.works[0].late_delivery_units == 1
+    assert drift.late_delivery_units == 1
+    assert drift.late_delivery_drift == Decimal(100)
+    assert drift.overbilled_units == 0
+    assert drift.org_pay_drift == Decimal(0)
+
+
+def test_overbilling_when_billed_visit_never_agreed(opportunity):
+    # 1 approved-but-never-agreed visit → billed under old logic (reconstructed 1) but not owed now
+    # (desired 0) → 1 unit over-billed = clawback candidate.
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(100),
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    _completed_work_with_visits(invoice, opportunity, amount=100, org_amount=0, approved_only_in_window=1)
+
+    drift = compute_invoice_drift(invoice)
+    assert drift.works[0].reconstructed_deliveries_count == 1
+    assert drift.works[0].desired_deliveries_count == 0
+    assert drift.overbilled_units == 1
+    assert drift.overbilled_drift == Decimal(100)
+    assert drift.late_delivery_units == 0
+
+
+@pytest.mark.parametrize("frozen_amount", [Decimal(100), Decimal(120)])
+def test_org_pay_drift_is_reported_separately(opportunity, frozen_amount):
+    # flw=100, org=20. org_pay_drift is always the omitted workspace pay (Σ r*o) regardless of frozen.
+    # reconstruction_gap distinguishes eras: 0 → FLW-only invoice (org truly missing);
+    # ≈ org_pay_drift → the invoice already billed org (org not actually missing).
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=frozen_amount,
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    _completed_work_with_visits(invoice, opportunity, amount=100, org_amount=20, agreed_in_window=1)
+
+    drift = compute_invoice_drift(invoice)
+    assert drift.reconstructed_flw_amount == Decimal(100)
+    assert drift.org_pay_drift == Decimal(20)
+    assert drift.late_delivery_units == 0
+    assert drift.overbilled_units == 0
+    assert drift.reconstruction_gap == frozen_amount - Decimal(100)
+    # Neither era counts as drift: residual is either 0 (FLW-era) or == org_pay_drift (org-era).
+    assert not invoice_has_drift(drift)
+
+
+def test_unexplained_residual_is_flagged(opportunity):
+    # No org pay, 1 clean delivery → reconstructed_flw = 100, but frozen is 150. The 50 residual is
+    # not explained by either era (org_pay_drift is 0), so the invoice must surface as an anomaly.
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(150),
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    _completed_work_with_visits(invoice, opportunity, amount=100, org_amount=0, agreed_in_window=1)
+
+    drift = compute_invoice_drift(invoice)
+    assert drift.late_delivery_units == 0
+    assert drift.overbilled_units == 0
+    assert drift.org_pay_drift == Decimal(0)
+    assert drift.reconstruction_gap == Decimal(50)
+    assert invoice_has_drift(drift)
+
+
+def test_visits_approved_between_end_date_and_generation_are_billed_not_late(opportunity):
+    # Period ends Jan 31 (END) but the invoice was generated Feb 28 (GENERATED_ON). The one delivery was
+    # approved+agreed Feb 15 — after end_date but before generation — so it WAS billed. The reconstruction
+    # must count it (cutoff = generation date), yielding no late-delivery drift and a clean reconciliation.
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(100),
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=GENERATED_ON,
+    )
+    _completed_work_with_visits(invoice, opportunity, amount=100, org_amount=0, agreed_late=1)
+
+    drift = compute_invoice_drift(invoice)
+    assert drift.works[0].reconstructed_deliveries_count == 1  # counted via generation-date cutoff
+    assert drift.works[0].desired_deliveries_count == 1
+    assert drift.late_delivery_units == 0
+    assert drift.reconstruction_gap == Decimal(0)
+
+
+def test_overbilling_negative_drift_with_clean_reconciliation(opportunity):
+    # Invoice honestly billed 2 units (frozen 200): 1 agreed + 1 approved-but-never-agreed, both
+    # in-window. Old logic counts 2 (reconstruction reproduces the 200 → residual 0); current logic
+    # owes only the agreed 1 → 1 unit over-billed = negative drift, with clean reconciliation.
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(200),
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    _completed_work_with_visits(
+        invoice, opportunity, amount=100, org_amount=0, agreed_in_window=1, approved_only_in_window=1
+    )
+
+    drift = compute_invoice_drift(invoice)
+    assert drift.works[0].reconstructed_deliveries_count == 2
+    assert drift.works[0].desired_deliveries_count == 1
+    assert drift.reconstructed_flw_amount == Decimal(200)
+    assert drift.reconstruction_gap == Decimal(0)
+    assert drift.overbilled_units == 1
+    assert drift.overbilled_drift == Decimal(100)
+    assert drift.late_delivery_units == 0

--- a/commcare_connect/opportunity/tests/test_invoice_drift.py
+++ b/commcare_connect/opportunity/tests/test_invoice_drift.py
@@ -186,13 +186,14 @@ def test_no_drift(opportunity):
     )
     _completed_work_with_visits(invoice, opportunity, amount=100, org_amount=0, agreed_in_window=1)
 
-    drift = compute_invoice_drift(invoice)
+    drift = compute_invoice_drift(invoice, base_url="https://staging.example.com/")
     assert drift.reconstructed_flw_amount == Decimal(100)
     assert drift.reconstruction_gap == Decimal(0)
     assert drift.late_delivery_units == 0
     assert drift.overbilled_units == 0
     assert drift.org_pay_drift == Decimal(0)
     assert drift.works[0].desired_deliveries_count == 1
+    assert drift.invoice_url.startswith("https://staging.example.com")
 
 
 def test_late_delivery_drift_is_per_work(opportunity):
@@ -211,6 +212,7 @@ def test_late_delivery_drift_is_per_work(opportunity):
     assert drift.works[0].reconstructed_deliveries_count == 1
     assert drift.works[0].desired_deliveries_count == 2
     assert drift.works[0].late_delivery_units == 1
+    assert drift.works[0].late_approved_visit_count == 1
     assert drift.late_delivery_units == 1
     assert drift.late_delivery_drift == Decimal(100)
     assert drift.overbilled_units == 0
@@ -236,6 +238,7 @@ def test_overbilling_when_billed_visit_never_agreed(opportunity):
     assert drift.overbilled_units == 1
     assert drift.overbilled_drift == Decimal(100)
     assert drift.late_delivery_units == 0
+    assert drift.works[0].late_approved_visit_count == 0
 
 
 @pytest.mark.parametrize("frozen_amount", [Decimal(100), Decimal(120)])

--- a/commcare_connect/opportunity/tests/test_invoice_drift.py
+++ b/commcare_connect/opportunity/tests/test_invoice_drift.py
@@ -4,7 +4,10 @@ from decimal import Decimal
 import pytest
 
 from commcare_connect.opportunity.management.commands.report_invoice_drift import (
+    _late_approved_visit_count,
+    _null_status_date_approved_visit_count,
     compute_invoice_drift,
+    gap_is_unexplained,
     invoice_has_drift,
     iter_invoice_drift,
     reconstruct_billed_count,
@@ -98,6 +101,23 @@ def test_reconstruct_counts_only_visits_approved_by_end_date(opportunity):
 
     # Only the January visit is within the invoice window.
     assert reconstruct_billed_count(cw, END) == 1
+
+
+def test_null_status_date_visits_are_counted_as_billed_and_surfaced(opportunity):
+    """Some visits have a NULL status_modified_date because the approval timestamp was never recorded (a
+    known data-quality gap, not tied to age). We assume such visits were billed and COUNT them in the
+    reconstruction (excluding them manufactured phantom late drift); their presence is also surfaced via
+    _null_status_date_approved_visit_count so a bad assumption shows up against reconstruction_gap."""
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    pu = PaymentUnitFactory(opportunity=opportunity, amount=100, org_amount=0)
+    du = DeliverUnitFactory(payment_unit=pu, optional=False)
+    cw = CompletedWorkFactory(opportunity_access=access, payment_unit=pu)
+
+    _approved_visit(cw, du, on=None)
+
+    assert reconstruct_billed_count(cw, END) == 1  # unknown date → assumed billed, counted
+    assert _late_approved_visit_count(cw, END) == 0  # a NULL-date visit is never "late" either
+    assert _null_status_date_approved_visit_count(cw) == 1  # and its presence is surfaced
 
 
 def test_reconstruct_excludes_rejected_visits(opportunity):
@@ -194,6 +214,63 @@ def test_no_drift(opportunity):
     assert drift.org_pay_drift == Decimal(0)
     assert drift.works[0].desired_deliveries_count == 1
     assert drift.invoice_url.startswith("https://staging.example.com")
+
+
+def test_null_visit_that_was_billed_leaves_no_drift(opportunity):
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(100),  # the null-date visit WAS billed
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    pu = PaymentUnitFactory(opportunity=opportunity, amount=100, org_amount=0)
+    du = DeliverUnitFactory(payment_unit=pu, optional=False)
+    cw = CompletedWorkFactory(opportunity_access=access, payment_unit=pu)
+    cw.invoice = invoice
+    cw.save()
+    _approved_visit(cw, du, on=None, agree=True)
+
+    drift = compute_invoice_drift(invoice)
+    work = drift.works[0]
+    assert work.desired_deliveries_count == 1
+    assert work.reconstructed_deliveries_count == 1  # null assumed billed → counted
+    assert work.late_delivery_units == 0
+    assert work.legacy_null_status_date_visits == 1
+    assert drift.reconstruction_gap == Decimal(0)  # reconstruction reproduces frozen
+    assert drift.legacy_null_status_date_visits == 1
+
+
+def test_gap_catches_null_visit_that_was_not_billed(opportunity):
+    """When the "null was billed" assumption is wrong (the null visit was a genuine unbilled miss), folding
+    over-counts the reconstruction so no unit drift shows — but reconstruction_gap goes negative and
+    flags the invoice for review, with legacy_null_status_date_visits giving the reason."""
+    invoice = PaymentInvoiceFactory(
+        opportunity=opportunity,
+        amount=Decimal(100),  # only the one dated visit was billed; the null visit was NOT
+        service_delivery=True,
+        status=InvoiceStatus.PAID,
+        end_date=END,
+        date=END,
+    )
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    pu = PaymentUnitFactory(opportunity=opportunity, amount=100, org_amount=0)
+    du = DeliverUnitFactory(payment_unit=pu, optional=False)
+    cw = CompletedWorkFactory(opportunity_access=access, payment_unit=pu)
+    cw.invoice = invoice
+    cw.save()
+    _approved_visit(cw, du, on=IN_WINDOW, agree=True)  # billed
+    _approved_visit(cw, du, on=None, agree=True)  # unbilled null → over-counted by the fold
+
+    drift = compute_invoice_drift(invoice)
+    work = drift.works[0]
+    assert work.reconstructed_deliveries_count == 2  # both folded in
+    assert work.late_delivery_units == 0  # unit drift hidden by the fold...
+    assert drift.reconstruction_gap == Decimal(-100)  # ...but the gap catches it
+    assert gap_is_unexplained(drift) is True
+    assert drift.legacy_null_status_date_visits == 1
 
 
 def test_late_delivery_drift_is_per_work(opportunity):

--- a/commcare_connect/opportunity/tests/test_invoice_drift.py
+++ b/commcare_connect/opportunity/tests/test_invoice_drift.py
@@ -4,15 +4,18 @@ from decimal import Decimal
 import pytest
 
 from commcare_connect.opportunity.management.commands.report_invoice_drift import (
+    reconstruct_billed_count,
     service_delivery_invoices,
 )
-from commcare_connect.opportunity.models import InvoiceStatus
+from commcare_connect.opportunity.models import InvoiceStatus, UserVisit, VisitReviewStatus, VisitValidationStatus
 from commcare_connect.opportunity.tests.factories import (
     CompletedWorkFactory,
+    DeliverUnitFactory,
     OpportunityAccessFactory,
     OpportunityFactory,
     PaymentInvoiceFactory,
     PaymentUnitFactory,
+    UserVisitFactory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -55,3 +58,74 @@ def test_query_excludes_test_opportunities_by_default(opportunity):
 
     assert [i.id for i in service_delivery_invoices()] == [real_invoice.id]
     assert test_invoice.id in {i.id for i in service_delivery_invoices(exclude_test=False)}
+
+
+def _approved_visit(cw, deliver_unit, *, on, agree=False):
+    """Create an approved visit and force status/status_modified_date/review_status (bypasses __setattr__).
+
+    agree=True → review_status=agree (counts under the current agreement-gated logic / approved_count);
+    agree=False → review_status=pending (counts only under the pre-agreement reconstruction).
+    """
+    visit = UserVisitFactory(
+        opportunity=cw.opportunity_access.opportunity,
+        opportunity_access=cw.opportunity_access,
+        completed_work=cw,
+        deliver_unit=deliver_unit,
+    )
+    UserVisit.objects.filter(pk=visit.pk).update(
+        status=VisitValidationStatus.approved,
+        status_modified_date=on,
+        review_status=VisitReviewStatus.agree if agree else VisitReviewStatus.pending,
+    )
+    return visit
+
+
+def test_reconstruct_counts_only_visits_approved_by_end_date(opportunity):
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    pu = PaymentUnitFactory(opportunity=opportunity, amount=100, org_amount=0)
+    du = DeliverUnitFactory(payment_unit=pu, optional=False)
+    cw = CompletedWorkFactory(opportunity_access=access, payment_unit=pu)
+
+    _approved_visit(cw, du, on=datetime.datetime(2026, 1, 15, tzinfo=datetime.UTC))
+    _approved_visit(cw, du, on=datetime.datetime(2026, 2, 15, tzinfo=datetime.UTC))
+
+    # Only the January visit is within the invoice window.
+    assert reconstruct_billed_count(cw, END) == 1
+
+
+def test_reconstruct_excludes_rejected_visits(opportunity):
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    pu = PaymentUnitFactory(opportunity=opportunity, amount=100, org_amount=0)
+    du = DeliverUnitFactory(payment_unit=pu, optional=False)
+    cw = CompletedWorkFactory(opportunity_access=access, payment_unit=pu)
+
+    visit = _approved_visit(cw, du, on=datetime.datetime(2026, 1, 15, tzinfo=datetime.UTC))
+    # Post-invoice rejection overwrites status + status_modified_date.
+    UserVisit.objects.filter(pk=visit.pk).update(
+        status=VisitValidationStatus.rejected,
+        status_modified_date=datetime.datetime(2026, 2, 15, tzinfo=datetime.UTC),
+    )
+
+    assert reconstruct_billed_count(cw, END) == 0
+
+
+def test_reconstruct_child_constraint_uses_pre_agreement_basis(opportunity):
+    """A child work approved-but-not-agreed still counts (legacy basis), unlike live approved_count."""
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    parent_pu = PaymentUnitFactory(opportunity=opportunity, amount=100, org_amount=0)
+    child_pu = PaymentUnitFactory(opportunity=opportunity, amount=0, org_amount=0)
+    child_pu.parent_payment_unit = parent_pu
+    child_pu.save()
+    parent_du = DeliverUnitFactory(payment_unit=parent_pu, optional=False)
+    child_du = DeliverUnitFactory(payment_unit=child_pu, optional=False)
+
+    parent_cw = CompletedWorkFactory(opportunity_access=access, payment_unit=parent_pu, entity_id="e1")
+    child_cw = CompletedWorkFactory(opportunity_access=access, payment_unit=child_pu, entity_id="e1")
+
+    _approved_visit(parent_cw, parent_du, on=datetime.datetime(2026, 1, 15, tzinfo=datetime.UTC))
+    child_visit = _approved_visit(child_cw, child_du, on=datetime.datetime(2026, 1, 15, tzinfo=datetime.UTC))
+    # Child visit is approved but was never PM-agreed → excluded by live approved_count, kept by reconstruction.
+    UserVisit.objects.filter(pk=child_visit.pk).update(review_status=VisitReviewStatus.pending)
+
+    assert parent_cw.approved_count == 0  # live, agreement-gated logic drops it
+    assert reconstruct_billed_count(parent_cw, END) == 1  # legacy basis keeps it, parent constrained by child


### PR DESCRIPTION
## Product Description

Internal, **read-only** reporting command for one time use - no UI and no data changes. It quantifies billing "drift" on legacy automated service-delivery invoices to inform the [CCCT-2525](https://dimagi.atlassian.net/browse/CCCT-2525) backfill decision.

### Summary of the problem

This report is meant to help identify whether any past invoices may have been generated with incorrect amounts. It is read-only and does not make any changes or corrections.

What is the issue?
The system allows duplicate deliveries to be recorded for the same completed work, and the payable amount is calculated based on the total number of deliveries.
For example, if a worker is paid 100 per delivery and the same delivery is recorded twice, the calculated amount for that completed work becomes 200.
Once a completed work has been invoiced, it is never billed again. However, duplicate deliveries can still be submitted afterwards. Since the work has already been invoiced, these additional deliveries are not paid.
This report helps identify invoices and completed works where duplicate deliveries may have affected the amount that was originally invoiced, so they can be reviewed and consider for correction if needed.
Noting that a this can also go vice versa - a duplicate delivery is being paid in the invoice but it was never agreed by PM. So invoice is overbilled. This is also being checked in the report

## Technical Summary

- Ticket: [CCCT-2524](https://dimagi.atlassian.net/browse/CCCT-2524)
- **Start here → [`report_invoice_drift.md`](https://github.com/dimagi/commcare-connect/blob/ay/invoice-drift-report/commcare_connect/opportunity/management/commands/report_invoice_drift.md)** — full logic, the two drift kinds, the `reconstruction_gap` confidence check, and the decision this informs.
- `manage.py report_invoice_drift` reconstructs the (pre-[CCCT-2505](https://dimagi.atlassian.net/browse/CCCT-2505)) billed count per invoice, compares it to today's agreement-gated count, and decomposes the difference into late-delivery / over-billing / org-pay drift. Writes two CSVs + a summary.
- 7 commits in build order (query → reconstruct → decompose → output → enrich → null-date edge case → docs); each is self-contained and green on its own.

Can be run from a management command (requires merging) or its equivalent on django shell.

## Safety Assurance

### Safety story

Read-only: no writes, no migrations — only SELECTs, run manually via a management command or through shell. Inherently safe to existing data.

### Automated test coverage

21 tests in `test_invoice_drift.py` covering invoice selection, count reconstruction, each drift type, the `reconstruction_gap`, and the null-approval-date edge case.

### QA Plan

None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2524]: https://dimagi.atlassian.net/browse/CCCT-2524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCCT-2525]: https://dimagi.atlassian.net/browse/CCCT-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCCT-2505]: https://dimagi.atlassian.net/browse/CCCT-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ