### PR TITLE
Validate Payment Unit Budget

### DIFF
--- a/commcare_connect/opportunity/api/serializers/automation.py
+++ b/commcare_connect/opportunity/api/serializers/automation.py
@@ -83,7 +83,16 @@ class PaymentUnitListCreateSerializer(serializers.Serializer):
                     }
                 )
             seen_du_ids.update(item_dus)
+        self._validate_budget_covers_claimants(data["payment_units"])
         return data
+
+    def _validate_budget_covers_claimants(self, payment_units):
+        opportunity = self.context["opportunity"]
+        proposed_units = [
+            PaymentUnit(max_total=pu["max_total"], amount=pu["amount"], org_amount=pu.get("org_amount") or 0)
+            for pu in payment_units
+        ]
+        opportunity.validate_budget_for_payment_units([*proposed_units, *opportunity.paymentunit_set.all()])
 
     @transaction.atomic
     def create(self, validated_data):

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1378,33 +1378,15 @@ class PaymentUnitForm(forms.ModelForm):
         """
         Reject the create/edit if the budget can't give every existing claimant the full limit.
         """
-        opportunity = self.opportunity
-        claimant_count = OpportunityClaim.objects.filter(opportunity_access__opportunity=opportunity).count()
-        if not claimant_count or not opportunity.total_budget:
-            return
-
         max_total = cleaned_data.get("max_total")
         amount = cleaned_data.get("amount")
         if max_total is None or amount is None:
             return
-        org_amount = cleaned_data.get("org_amount") or 0
 
-        other_units = opportunity.paymentunit_set.exclude(pk=self.instance.pk)
-        budget_per_user = max_total * (amount + org_amount) + Opportunity.budget_per_user_for_units(other_units)
+        proposed_unit = PaymentUnit(max_total=max_total, amount=amount, org_amount=cleaned_data.get("org_amount") or 0)
+        other_units = self.opportunity.paymentunit_set.exclude(pk=self.instance.pk)
 
-        required_budget = budget_per_user * claimant_count
-        if opportunity.total_budget < required_budget:
-            raise ValidationError(
-                _(
-                    "The opportunity budget cannot give the full limit to all %(claimants)d workers "
-                    "who have already claimed. Increase it to at least %(required)d %(currency)s before saving."
-                )
-                % {
-                    "claimants": claimant_count,
-                    "required": required_budget,
-                    "currency": opportunity.currency_code or "",
-                }
-            )
+        self.opportunity.validate_budget_for_payment_units([proposed_unit, *other_units])
 
 
 class SendMessageMobileUsersForm(forms.Form):

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1397,9 +1397,13 @@ class PaymentUnitForm(forms.ModelForm):
             raise ValidationError(
                 _(
                     "The opportunity budget cannot give the full limit to all %(claimants)d workers "
-                    "who have already claimed. Increase it to at least %(required)d before saving."
+                    "who have already claimed. Increase it to at least %(required)d %(currency)s before saving."
                 )
-                % {"claimants": claimant_count, "required": required_budget}
+                % {
+                    "claimants": claimant_count,
+                    "required": required_budget,
+                    "currency": opportunity.currency_code or "",
+                }
             )
 
 

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1370,7 +1370,37 @@ class PaymentUnitForm(forms.ModelForm):
         if start_date and end_date and end_date < start_date:
             raise ValidationError({"end_date": "End date cannot be earlier than start date."})
 
+        self._validate_budget_covers_claimants(cleaned_data)
+
         return cleaned_data
+
+    def _validate_budget_covers_claimants(self, cleaned_data):
+        """
+        Reject the create/edit if the budget can't give every existing claimant the full limit.
+        """
+        opportunity = self.opportunity
+        claimant_count = OpportunityClaim.objects.filter(opportunity_access__opportunity=opportunity).count()
+        if not claimant_count or not opportunity.total_budget:
+            return
+
+        max_total = cleaned_data.get("max_total")
+        amount = cleaned_data.get("amount")
+        if max_total is None or amount is None:
+            return
+        org_amount = cleaned_data.get("org_amount") or 0
+
+        other_units = opportunity.paymentunit_set.exclude(pk=self.instance.pk)
+        budget_per_user = max_total * (amount + org_amount) + Opportunity.budget_per_user_for_units(other_units)
+
+        required_budget = budget_per_user * claimant_count
+        if opportunity.total_budget < required_budget:
+            raise ValidationError(
+                _(
+                    "The opportunity budget cannot give the full limit to all %(claimants)d workers "
+                    "who have already claimed. Increase it to at least %(required)d before saving."
+                )
+                % {"claimants": claimant_count, "required": required_budget}
+            )
 
 
 class SendMessageMobileUsersForm(forms.Form):

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pghistory
+from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import IntegrityError, models, transaction
 from django.db.models import Count, F, Q, Sum
@@ -191,6 +192,34 @@ class Opportunity(BaseModel):
     def budget_per_user_for_units(payment_units):
         """Total budget consumed per user (worker + org pay) across the given payment units."""
         return sum(pu.max_total * (pu.amount + pu.org_amount) for pu in payment_units)
+
+    def validate_budget_for_payment_units(self, payment_units):
+        """Validate that ``total_budget`` can give every existing claimant the full per-user
+        limit for ``payment_units``, raising ``ValidationError`` if it can't.
+
+        ``payment_units`` is the complete set of units that would exist after the proposed
+        change (each exposing ``max_total``/``amount``/``org_amount``; unsaved instances are
+        fine).
+        """
+        if not self.total_budget:
+            return
+        claimant_count = OpportunityClaim.objects.filter(opportunity_access__opportunity=self).count()
+        if not claimant_count:
+            return
+
+        required_budget = self.budget_per_user_for_units(payment_units) * claimant_count
+        if self.total_budget < required_budget:
+            raise ValidationError(
+                gettext_lazy(
+                    "The opportunity budget cannot give the full limit to all %(claimants)d workers "
+                    "who have already claimed. Increase it to at least %(required)d %(currency)s."
+                )
+                % {
+                    "claimants": claimant_count,
+                    "required": required_budget,
+                    "currency": self.currency_code or "",
+                }
+            )
 
     @property
     def number_of_users(self):

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -187,15 +187,16 @@ class Opportunity(BaseModel):
             opportunity_access__opportunity=self, status=CompletedWorkStatus.approved
         ).count()
 
+    @staticmethod
+    def budget_per_user_for_units(payment_units):
+        """Total budget consumed per user (worker + org pay) across the given payment units."""
+        return sum(pu.max_total * (pu.amount + pu.org_amount) for pu in payment_units)
+
     @property
     def number_of_users(self):
         if not self.total_budget:
             return 0
-        budget_per_user = 0
-        payment_units = self.paymentunit_set.all()
-        for pu in payment_units:
-            budget_per_user += pu.max_total * (pu.amount + pu.org_amount)
-        return self.total_budget / budget_per_user
+        return self.total_budget / self.budget_per_user_for_units(self.paymentunit_set.all())
 
     @property
     def allotted_visits(self):

--- a/commcare_connect/opportunity/tests/test_automation_api.py
+++ b/commcare_connect/opportunity/tests/test_automation_api.py
@@ -10,6 +10,7 @@ from commcare_connect.opportunity.tests.factories import (
     DeliverUnitFactory,
     DeliveryTypeFactory,
     HQApiKeyFactory,
+    OpportunityClaimFactory,
     OpportunityFactory,
     PaymentUnitFactory,
 )
@@ -215,6 +216,47 @@ class TestPaymentUnits:
             format="json",
         )
         assert response.status_code == 400
+
+    def test_payment_units_rejected_when_budget_cannot_cover_claimants(
+        self, api_client, program_manager_org_user_admin, managed_opp_with_deliver_units
+    ):
+        """Adding payment units the budget can't fund for existing claimants is rejected."""
+        opportunity, du1, du2 = managed_opp_with_deliver_units
+        opportunity.total_budget = 1500
+        opportunity.save()
+        # 3 workers have already claimed; a single 100 * (5 + 0) unit needs 500 * 3 = 1500 (ok),
+        # but the request below adds a second unit, doubling the per-user cost beyond the budget.
+        OpportunityClaimFactory.create_batch(
+            3, opportunity_access__opportunity=opportunity, opportunity_access__accepted=True
+        )
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/opportunities/{opportunity.opportunity_id}/payment_units/",
+            {
+                "payment_units": [
+                    {
+                        "name": "Visit A",
+                        "amount": 5,
+                        "org_amount": 0,
+                        "max_total": 100,
+                        "max_daily": 10,
+                        "required_deliver_units": [du1.id],
+                    },
+                    {
+                        "name": "Visit B",
+                        "amount": 5,
+                        "org_amount": 0,
+                        "max_total": 100,
+                        "max_daily": 10,
+                        "required_deliver_units": [du2.id],
+                    },
+                ]
+            },
+            format="json",
+        )
+        assert response.status_code == 400
+        assert "budget cannot give the full limit" in str(response.data)
+        assert not PaymentUnit.objects.filter(opportunity=opportunity).exists()
 
     def test_payment_units_cross_tenant_rejected(self, api_client, managed_opp_with_deliver_units):
         """Admin of a different program manager org cannot add payment units to someone else's opportunity."""

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -20,6 +20,7 @@ from commcare_connect.opportunity.forms import (
     OpportunityInitForm,
     OpportunityInitUpdateForm,
     OpportunityUserInviteForm,
+    PaymentUnitForm,
 )
 from commcare_connect.opportunity.models import (
     AssignedTaskStatus,
@@ -32,8 +33,10 @@ from commcare_connect.opportunity.tests.factories import (
     AssignedTaskFactory,
     CommCareAppFactory,
     CompletedWorkFactory,
+    DeliverUnitFactory,
     ExchangeRateFactory,
     OpportunityAccessFactory,
+    OpportunityClaimFactory,
     OpportunityFactory,
     PaymentInvoiceFactory,
     PaymentUnitFactory,
@@ -1102,3 +1105,65 @@ class TestEditTaskTypeForm:
         saved = form.save()
         assert saved.slug == "original-slug"
         assert saved.case_property == "original_prop"
+
+
+@pytest.mark.django_db
+class TestPaymentUnitFormBudgetValidation:
+    """The per-user delivery limit is allocated from a shared budget pool per payment unit.
+
+    Adding or enlarging a payment unit lowers the derived ``number_of_users``; if it drops
+    below the count of workers who have already claimed, some workers silently receive a
+    reduced limit (or none). ``PaymentUnitForm`` must reject such changes.
+    """
+
+    def _make_claimants(self, opportunity, count):
+        for _ in range(count):
+            OpportunityClaimFactory(opportunity_access__opportunity=opportunity, opportunity_access__accepted=True)
+
+    def _form(self, opportunity, data, instance=None):
+        deliver_unit = DeliverUnitFactory(app=opportunity.deliver_app, payment_unit=None)
+        return PaymentUnitForm(
+            data={
+                "name": "Bonus",
+                "description": "Bonus payment unit",
+                "max_daily": 10,
+                "org_amount": 0,
+                "required_deliver_units": [str(deliver_unit.id)],
+                **data,
+            },
+            deliver_units=[deliver_unit],
+            payment_units=[],
+            org_slug=opportunity.organization.slug,
+            opportunity=opportunity,
+            instance=instance,
+        )
+
+    @pytest.mark.parametrize(
+        "num_existing, total_budget, num_claimants, edit_existing, new_max_total, expect_valid",
+        [
+            # Budget covers 3 users with only the existing unit; adding a second unit needs double.
+            pytest.param(1, 1500, 3, False, 100, False, id="reject_new_over_budget"),
+            pytest.param(1, 3000, 3, False, 100, True, id="accept_new_within_budget"),
+            # Budget that would fail with claimants, proving the no-claimants early return fires.
+            pytest.param(1, 1500, 0, False, 100, True, id="skip_when_no_claimants"),
+            # Doubling an existing unit's max_total pushes number_of_users below the 3 claimants.
+            pytest.param(2, 3000, 3, True, 200, False, id="reject_enlarge_over_budget"),
+        ],
+    )
+    def test_budget_validation(
+        self, opportunity, num_existing, total_budget, num_claimants, edit_existing, new_max_total, expect_valid
+    ):
+        units = [
+            PaymentUnitFactory(opportunity=opportunity, max_total=100, amount=5, org_amount=0)
+            for _ in range(num_existing)
+        ]
+        opportunity.total_budget = total_budget
+        opportunity.save()
+        self._make_claimants(opportunity, num_claimants)
+
+        instance = units[0] if edit_existing else None
+        form = self._form(opportunity, {"max_total": new_max_total, "amount": 5}, instance=instance)
+
+        assert form.is_valid() == expect_valid
+        if not expect_valid:
+            assert any("budget cannot give the full limit" in e for e in form.non_field_errors())

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -1116,10 +1116,6 @@ class TestPaymentUnitFormBudgetValidation:
     reduced limit (or none). ``PaymentUnitForm`` must reject such changes.
     """
 
-    def _make_claimants(self, opportunity, count):
-        for _ in range(count):
-            OpportunityClaimFactory(opportunity_access__opportunity=opportunity, opportunity_access__accepted=True)
-
     def _form(self, opportunity, data, instance=None):
         deliver_unit = DeliverUnitFactory(app=opportunity.deliver_app, payment_unit=None)
         return PaymentUnitForm(
@@ -1127,6 +1123,7 @@ class TestPaymentUnitFormBudgetValidation:
                 "name": "Bonus",
                 "description": "Bonus payment unit",
                 "max_daily": 10,
+                "amount": 5,
                 "org_amount": 0,
                 "required_deliver_units": [str(deliver_unit.id)],
                 **data,
@@ -1153,16 +1150,17 @@ class TestPaymentUnitFormBudgetValidation:
     def test_budget_validation(
         self, opportunity, num_existing, total_budget, num_claimants, edit_existing, new_max_total, expect_valid
     ):
-        units = [
-            PaymentUnitFactory(opportunity=opportunity, max_total=100, amount=5, org_amount=0)
-            for _ in range(num_existing)
-        ]
+        units = PaymentUnitFactory.create_batch(
+            num_existing, opportunity=opportunity, max_total=100, amount=5, org_amount=0
+        )
         opportunity.total_budget = total_budget
         opportunity.save()
-        self._make_claimants(opportunity, num_claimants)
+        OpportunityClaimFactory.create_batch(
+            num_claimants, opportunity_access__opportunity=opportunity, opportunity_access__accepted=True
+        )
 
         instance = units[0] if edit_existing else None
-        form = self._form(opportunity, {"max_total": new_max_total, "amount": 5}, instance=instance)
+        form = self._form(opportunity, {"max_total": new_max_total}, instance=instance)
 
         assert form.is_valid() == expect_valid
         if not expect_valid:


### PR DESCRIPTION
## Product Description

Payment Units draw each worker's delivery limit from a shared opportunity budget. Previously, an admin could add or enlarge a Payment Unit (or create Payment Units via the automation API) in a way that left the budget unable to fund the full limit for every worker who had *already* claimed — silently reducing some workers' limits. This change validates that the opportunity's total budget can still cover all existing claimants at the full limit, and blocks the change otherwise.

- **Automation API:** rejects the request with `400` and the specific message, e.g. _"The opportunity budget cannot give the full limit to all 3 workers who have already claimed. Increase it to at least 3000 USD."_
- **Web form:** the invalid submission is blocked. Note: until the [companion form re-render PR](https://github.com/dimagi/commcare-connect/pull/1380) merges, the web form surfaces this as a generic "Invalid Data" message on the Payment Units list page rather than the specific message inline (see Technical Summary).

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-741)
This is a release path 1 feature — Improvements to existing features & quick wins.

The rule lives in one place — `Opportunity.validate_budget_for_payment_units`, which takes the complete effective set of units and raises `ValidationError` — so the web form and the DRF serializer share identical logic and message. Each caller only differs in how it assembles that set: the form uses the proposed/edited unit plus the other existing units, while the batch API uses all proposed units plus all existing ones. The method raises Django's core `ValidationError` rather than returning a message so both entry points work unchanged: the form's `clean()` surfaces it, and DRF's `run_validation` converts it to a `400` (verified to produce output identical to `serializers.ValidationError` for a string message).

One sequencing consequence: the specific, user-facing message on the **web form** depends on the [companion PR](https://github.com/dimagi/commcare-connect/pull/1380) that re-renders the form on error instead of redirecting. Until that merges, the web form still redirects to the list with a generic "Invalid Data" toast; the automation API returns the specific message regardless, since it doesn't go through that view.

## Safety Assurance

### Safety story

The change is fail-closed validation at the write boundary — it only blocks invalid saves and adds no data migrations. It early-returns when the opportunity has no budget or no existing claimants, so opportunities that don't meet those preconditions are entirely unaffected. Fully reversible by reverting the branch.

### Automated test coverage

Tests cover the model rule through both entry points: the form path (reject an over-budget add, accept one within budget, skip when there are no claimants, and reject enlarging an existing unit beyond budget) and the automation API (reject when the budget can't cover existing claimants with nothing persisted, and accept when it can).

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
