### PR TITLE
Allow Viewers to Access Visit Media

### DIFF
--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -1012,19 +1012,20 @@ class TestFetchAttachmentView:
         assert response.status_code == 404
         storage_handler_getitem_mock.assert_not_called()
 
-    @mock.patch.object(StorageHandler, "__getitem__")
-    def test_user_can_fetch(self, storage_handler_getitem_mock, org_user_member, organization, client):
+    def test_viewer_can_fetch(self, organization, client):
+        viewer = MembershipFactory(organization=organization, role="viewer").user
         visit = UserVisitFactory(opportunity__organization=organization)
-        blob_meta = BlobMetaFactory(parent_id=visit.xform_id)
+        blob_meta = BlobMetaFactory(parent_id=visit.xform_id, content_type="image/jpeg")
+        storages["default"].save(blob_meta.blob_id, ContentFile(b"imagebytes"))
 
         url = reverse(
             "opportunity:fetch_attachment", args=(organization.slug, visit.opportunity.id, blob_meta.blob_id)
         )
-        client.force_login(org_user_member)
+        client.force_login(viewer)
 
         response = client.get(url)
         assert response.status_code == 200
-        storage_handler_getitem_mock.assert_called_once()
+        assert b"".join(response.streaming_content) == b"imagebytes"
 
     def test_user_cannot_fetch_managed_opp(self, org_user_member, organization, client):
         opp = OpportunityFactory()
@@ -2777,7 +2778,8 @@ class TestDeleteTasks:
 
 
 @pytest.mark.django_db
-def test_fetch_audio_attachment_returns_file(client, organization, org_user_member, opportunity):
+def test_fetch_audio_attachment_returns_file(client, organization, opportunity):
+    viewer = MembershipFactory(organization=organization, role="viewer").user
     visit = UserVisitFactory.create(opportunity=opportunity)
     audio = AudioAttachmentFactory.create(user_visit=visit, content_type="audio/mp4")
     storages["default"].save(str(audio.blob_id), ContentFile(b"audiobytes"))
@@ -2786,7 +2788,7 @@ def test_fetch_audio_attachment_returns_file(client, organization, org_user_memb
         "opportunity:fetch_audio_attachment",
         args=(organization.slug, opportunity.id, audio.pk),
     )
-    client.force_login(org_user_member)
+    client.force_login(viewer)
     response = client.get(url)
 
     assert response.status_code == 200

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1137,7 +1137,7 @@ def reject_visits(request, org_slug=None, opp_id=None):
     return HttpResponse(status=200, headers={"HX-Trigger": "reload_table"})
 
 
-@org_member_required
+@org_viewer_required
 @opportunity_required
 def fetch_attachment(request, org_slug, opp_id, blob_id):
     blob_meta = get_object_or_404(BlobMeta, blob_id=blob_id)
@@ -1157,7 +1157,7 @@ def fetch_attachment(request, org_slug, opp_id, blob_id):
     return FileResponse(attachment, filename=blob_meta.name, content_type=blob_meta.content_type)
 
 
-@org_member_required
+@org_viewer_required
 @opportunity_required
 def fetch_audio_attachment(request, org_slug, opp_id, pk):
     audio = get_object_or_404(AudioAttachment, pk=pk, user_visit__opportunity=request.opportunity)


### PR DESCRIPTION
## Product Description

Organization users with **view-only (viewer)** access can now see images and play audio attachments when viewing a worker visit. Previously, a viewer could open the visit detail page but every embedded image rendered as a broken/blank placeholder and audio failed to load, because the attachment requests were rejected.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-794)

This is a release path 1 feature — Improvements to existing features & quick wins.

The visit detail view (`user_visit_details`) is gated with `@org_viewer_required`, but the `fetch_attachment` and `fetch_audio_attachment` endpoints that its template embeds were gated with the stricter `@org_member_required`. Viewers could load the page but each `<img>`/audio request returned a 404, so no media rendered. The fix aligns both attachment endpoints with the access level of the page that embeds them (`@org_viewer_required`); the existing per-opportunity ownership checks inside those views are unchanged.

## Safety Assurance

### Safety story

Low-risk, read-only change: it only relaxes a role gate on two GET endpoints that stream existing attachments, and the endpoints still enforce that the requested blob belongs to a visit in the requested opportunity. No data is written or migrated, and the change is trivially reversible by restoring the previous decorator.

### Automated test coverage

The attachment-fetch test was adapted for the `viewer` rolesto confirm this role is able to receive the file. An equivalent viewer-access test was added for the audio attachment endpoint.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
