### PR TITLE
Remove Task ID column from Assigned Task list table

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1842,7 +1842,6 @@ _task_select_td_extra = {
 
 class AssignedTaskListTable(OpportunityContextTable):
     select = select_column(td_extra=_task_select_td_extra)
-    assigned_task_id = tables.Column(verbose_name=gettext_lazy("Task ID"), accessor="pk")
     connect_worker = tables.Column(verbose_name=gettext_lazy("Connect Worker"), accessor="opportunity_access__user")
     status = TaskStatusColumn(verbose_name=gettext_lazy("Status"), accessor="status")
     task_type = tables.Column(verbose_name=gettext_lazy("Task Type"), accessor="task_type__name")
@@ -1865,7 +1864,6 @@ class AssignedTaskListTable(OpportunityContextTable):
         fields = ()
         sequence = (
             "select",
-            "assigned_task_id",
             "connect_worker",
             "status",
             "task_type",
@@ -1877,13 +1875,6 @@ class AssignedTaskListTable(OpportunityContextTable):
         order_by = ("-assigned_date",)
         row_attrs = {"class": "group"}
         empty_text = gettext_lazy("No tasks have been assigned yet.")
-
-    def render_assigned_task_id(self, value):
-        # TODO: CCCT-2184 - Link to Connect Worker page filtered to task view
-        return format_html(
-            '<a href="#" class="text-brand-indigo hover:underline"><span class="text-sm font-medium">#{}</span></a>',
-            value,
-        )
 
     def render_connect_worker(self, value):
         return format_html(


### PR DESCRIPTION
## Product Description

Removes the "Task ID" column from the Assigned Task list table — it linked nowhere (placeholder `#` link) and exposed an internal PK to users.

**Screenshot before** 

<img width="3154" height="1251" alt="image" src="https://github.com/user-attachments/assets/477446ac-bfe5-4076-a655-1092646333e9" />

**Screenshot after** 

<img width="3154" height="1251" alt="image" src="https://github.com/user-attachments/assets/d4b1882a-0f9e-4da6-a4a2-499f0ef913db" />

## Technical Summary

[CCCT-2572](https://dimagi.atlassian.net/browse/CCCT-2572)

Drops the `assigned_task_id` column and its renderer from `AssignedTaskListTable` in `commcare_connect/opportunity/tables.py`.

## Safety Assurance

### Safety story

Purely a display change — removes an unused/non-functional column. No data or backend logic affected.

### Automated test coverage

N/A — table column rendering, no existing test targeted this column.

### QA Plan
None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CCCT-2572]: https://dimagi.atlassian.net/browse/CCCT-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ