### PR TITLE
Assigned Task edit permsiion

### DIFF
--- a/commcare_connect/opportunity/filters.py
+++ b/commcare_connect/opportunity/filters.py
@@ -393,8 +393,16 @@ class AssignedTaskFilterSet(django_filters.FilterSet):
             "task_status",
             "task_type",
             "is_active",
-            Row(Column("date_assigned_after"), Column("date_assigned_before")),
-            Row(Column("due_date_after"), Column("due_date_before")),
+            Row(
+                Column("date_assigned_after", css_class="flex-1"),
+                Column("date_assigned_before", css_class="flex-1"),
+                css_class="flex gap-2",
+            ),
+            Row(
+                Column("due_date_after", css_class="flex-1"),
+                Column("due_date_before", css_class="flex-1"),
+                css_class="flex gap-2",
+            ),
         )
 
     def _get_task_type_choices(self):

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1850,7 +1850,8 @@ class AssignedTaskListTable(OpportunityContextTable):
     due_date = DMYTColumn(verbose_name=gettext_lazy("Due Date"), accessor="due_date")
     assigned_by = tables.Column(
         verbose_name=gettext_lazy("Assigned By"),
-        accessor="assigned_by__name",
+        accessor="assigned_by__display_name",
+        orderable=False,
         empty_values=(None,),
         default=gettext_lazy("Deleted user"),
     )
@@ -1878,6 +1879,11 @@ class AssignedTaskListTable(OpportunityContextTable):
         row_attrs = {"class": "group"}
         empty_text = gettext_lazy("No tasks have been assigned yet.")
 
+    def __init__(self, *args, can_edit_tasks=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not can_edit_tasks:
+            self.columns.hide("action")
+
     def render_assigned_task_id(self, value):
         # TODO: CCCT-2184 - Link to Connect Worker page filtered to task view
         return format_html(
@@ -1903,7 +1909,8 @@ class WorkerCompletedTaskTable(tables.Table):
     task_type = tables.Column(verbose_name=_("Task Type"), accessor="task_type", orderable=False)
     assigned_by = tables.Column(
         verbose_name=_("Assigned By"),
-        accessor="assigned_by__name",
+        accessor="assigned_by__display_name",
+        orderable=False,
         empty_values=(None,),
         default=gettext_lazy("Deleted user"),
     )

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2346,7 +2346,7 @@ class TestTaskTypesConfig:
         response = client.get(self._edit_url(opp, task_type))
         assert response.status_code == HTTPStatus.NOT_FOUND
 
-    def test_edit_task_type_managed_opp_requires_pm_role(
+    def test_edit_task_type_managed_opp_delivery_org_admin_can_edit(
         self, client, organization, org_user_admin, program_manager_org
     ):
         program = ProgramFactory(organization=program_manager_org)
@@ -2355,7 +2355,7 @@ class TestTaskTypesConfig:
         url = reverse("opportunity:edit_task_type", args=(organization.slug, managed_opp.opportunity_id, task_type.pk))
         client.force_login(org_user_admin)
         response = client.get(url)
-        assert response.status_code == HTTPStatus.NOT_FOUND
+        assert response.status_code == HTTPStatus.OK
 
     def test_edit_task_type_scoped_to_opportunity_app(self, client, program_manager_org_user_admin, opp):
         other_task_type = TaskTypeFactory()  # different app
@@ -2467,6 +2467,15 @@ class TestEditAssignedTask:
         assert f'hx-get="{edit_url}"' in content, f'Edit button hx-get not found. Looking for: hx-get="{edit_url}"'
         assert 'hx-target="#edit-assigned-task-form"' in content
 
+    def test_list_page_hides_edit_button_for_viewer(self, client, opp, assigned_task):
+        viewer = MembershipFactory(organization=opp.organization, role="viewer").user
+        client.force_login(viewer)
+        url = reverse("opportunity:assigned_task_list", args=(opp.organization.slug, opp.opportunity_id))
+        response = client.get(url)
+        content = response.content.decode()
+        edit_url = self._edit_url(opp, assigned_task)
+        assert f'hx-get="{edit_url}"' not in content
+
     def test_get_returns_form(self, client, program_manager_org_user_admin, opp, assigned_task):
         client.force_login(program_manager_org_user_admin)
         response = client.get(self._edit_url(opp, assigned_task))
@@ -2511,7 +2520,7 @@ class TestEditAssignedTask:
         response = client.get(self._edit_url(opp, assigned_task))
         assert response.status_code == HTTPStatus.NOT_FOUND
 
-    def test_managed_opp_requires_pm_role(self, client, organization, org_user_admin, program_manager_org):
+    def test_managed_opp_delivery_org_admin_can_edit(self, client, organization, org_user_admin, program_manager_org):
         program = ProgramFactory(organization=program_manager_org)
         managed_opp = OpportunityFactory(program=program, organization=organization)
         access = OpportunityAccessFactory(opportunity=managed_opp)
@@ -2526,6 +2535,18 @@ class TestEditAssignedTask:
         )
         client.force_login(org_user_admin)
         response = client.get(url)
+        assert response.status_code == HTTPStatus.OK
+
+    def test_viewer_cannot_edit(self, client, opp, user):
+        viewer = MembershipFactory(organization=opp.organization, role="viewer").user
+        access = OpportunityAccessFactory(opportunity=opp, user=user)
+        task = AssignedTaskFactory(
+            opportunity_access=access,
+            task_type=TaskTypeFactory(app=opp.deliver_app),
+            status=AssignedTaskStatus.ASSIGNED,
+        )
+        client.force_login(viewer)
+        response = client.get(self._edit_url(opp, task))
         assert response.status_code == HTTPStatus.NOT_FOUND
 
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -202,8 +202,10 @@ from commcare_connect.opportunity.visit_import import (
 )
 from commcare_connect.organization.decorators import (
     OrganizationProgramManagerMixin,
+    OrganizationUserAdminRoleMixin,
     OrganizationUserMemberRoleMixin,
     OrganizationUserMixin,
+    _request_user_is_admin,
     _request_user_is_member,
     managed_opportunity_pm_required,
     opportunity_required,
@@ -1349,7 +1351,7 @@ class TaskTypesConfig(ManagedOpportunityPMRequiredMixin, OrganizationUserMemberR
         return self.render_to_response(self.get_context_data(form=form))
 
 
-class EditTaskType(ManagedOpportunityPMRequiredMixin, OrganizationUserMemberRoleMixin, UpdateView):
+class EditTaskType(OrganizationUserAdminRoleMixin, OpportunityObjectMixin, UpdateView):
     template_name = "opportunity/edit_task_type_form.html"
     form_class = EditTaskTypeForm
     model = TaskType
@@ -2624,7 +2626,7 @@ def user_task_details(request, org_slug, opp_id, pk):
             completed_task=completed_task,
             images=images,
             hq_link=hq_link,
-            can_manage_tasks=_can_manage_tasks(request, request.opportunity),
+            can_edit_tasks=_request_user_is_admin(request),
         ),
     )
 
@@ -3516,6 +3518,7 @@ class AssignedTaskListView(OpportunityObjectMixin, OrganizationUserMixin, Filter
     def get_table_kwargs(self):
         kwargs = super().get_table_kwargs()
         kwargs["opp_id"] = self.get_opportunity().opportunity_id
+        kwargs["can_edit_tasks"] = _request_user_is_admin(self.request)
         return kwargs
 
     def get_table_data(self):
@@ -3563,7 +3566,7 @@ class AssignedTaskListView(OpportunityObjectMixin, OrganizationUserMixin, Filter
         return context
 
 
-class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMemberRoleMixin, UpdateView):
+class EditAssignedTask(OrganizationUserAdminRoleMixin, OpportunityObjectMixin, UpdateView):
     template_name = "opportunity/edit_assigned_task_form.html"
     form_class = EditAssignedTaskForm
     model = AssignedTask

--- a/commcare_connect/organization/decorators.py
+++ b/commcare_connect/organization/decorators.py
@@ -155,3 +155,11 @@ class OrganizationUserMemberRoleMixin:
     @method_decorator(org_member_required)
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
+
+
+class OrganizationUserAdminRoleMixin:
+    """Mixin version of org_admin_required decorator"""
+
+    @method_decorator(org_admin_required)
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)

--- a/commcare_connect/templates/opportunity/user_task_details.html
+++ b/commcare_connect/templates/opportunity/user_task_details.html
@@ -25,7 +25,7 @@
       <div class="text-sm text-brand-blue-light">{% translate "Assigned By" %}</div>
       <div class="text-sm font-normal text-brand-deep-purple">
         {% if completed_task.assigned_by %}
-          {{ completed_task.assigned_by.name }}
+          {{ completed_task.assigned_by.display_name }}
         {% else %}
           {% translate "Deleted user" %}
         {% endif %}

--- a/commcare_connect/templates/opportunity/user_task_details.html
+++ b/commcare_connect/templates/opportunity/user_task_details.html
@@ -44,7 +44,7 @@
       <div class="text-sm font-normal text-brand-deep-purple">{{ completed_task.completed_at }}</div>
     </div>
   </div>
-  {% if can_manage_tasks and completed_task.status == "assigned" %}
+  {% if can_edit_tasks and completed_task.status == "assigned" %}
     <div class="flex justify-end">
       <button type="button"
               class="button button-md outline-style"

--- a/commcare_connect/users/models.py
+++ b/commcare_connect/users/models.py
@@ -66,6 +66,10 @@ class User(AbstractUser):
     def display_name_with_username(self):
         return f"{self.name} ({self.username})"
 
+    @property
+    def display_name(self):
+        return self.name or self.email
+
     class Meta:
         constraints = [UniqueConstraint(fields=["email"], name="unique_user_email", condition=Q(email__isnull=False))]
         permissions = [


### PR DESCRIPTION
## Product Description

<table>
<tr>
<td align="center">
<img width="400" alt="Member View" src="https://github.com/user-attachments/assets/815027c2-9566-456c-bc78-b6afcde797ae" /><br/>
<sub><b>Viewer View</b></sub>
</td>
<td align="center">
<img width="400" alt="Admin View" src="https://github.com/user-attachments/assets/85d75da2-7f6f-405a-8fa0-afdbc961cb1c" /><br/>
<sub><b>Admin View</b></sub>
</td>
</tr>
</table>

## Technical Summary

[CCCT-2571](https://dimagi.atlassian.net/browse/CCCT-2571)
[CCCT-2570](https://dimagi.atlassian.net/browse/CCCT-2570)

- Edit access on assigned tasks now checks opportunity membership instead of requiring a PM or admin role, including for managed opportunities edited by a delivery org member.
- Added a `display_name` property on `User` (name or email) so the assigned-by column and detail page don't show blank for users without a name. Sorting on that column is disabled since it isn't a real DB field.

## Safety Assurance

### Safety story

Tested locally across viewer, member, and admin roles on both regular and managed opportunities to confirm edit access matches membership rather than role.

### Automated test coverage

Added tests covering viewer-cannot-edit, member-can-edit (including managed-opp delivery org members), and edit button visibility on the list and detail pages; all passing.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2571]: https://dimagi.atlassian.net/browse/CCCT-2571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCCT-2570]: https://dimagi.atlassian.net/browse/CCCT-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ