### PR TITLE
Fix assigned task edit permissions and button visibility

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1859,6 +1859,13 @@ class AssignedTaskListTable(OpportunityContextTable):
         template_name="opportunity/assigned_task_edit_button.html",
     )
 
+    def __init__(self, *args, can_edit_tasks=False, can_delete_tasks=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not can_edit_tasks:
+            self.columns.hide("action")
+        if not can_delete_tasks:
+            self.columns.hide("select")
+
     class Meta:
         model = AssignedTask
         fields = ()

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -2512,7 +2512,9 @@ class TestEditAssignedTask:
         response = client.get(self._edit_url(opp, assigned_task))
         assert response.status_code == HTTPStatus.NOT_FOUND
 
-    def test_managed_opp_requires_pm_role(self, client, organization, org_user_admin, program_manager_org):
+    def test_managed_opp_allows_nm_and_pm_org_members(
+        self, client, organization, org_user_admin, program_manager_org, program_manager_org_user_admin
+    ):
         program = ProgramFactory(organization=program_manager_org)
         managed_opp = OpportunityFactory(program=program, organization=organization)
         access = OpportunityAccessFactory(opportunity=managed_opp)
@@ -2521,13 +2523,22 @@ class TestEditAssignedTask:
             task_type=TaskTypeFactory(app=managed_opp.deliver_app),
             status=AssignedTaskStatus.ASSIGNED,
         )
-        url = reverse(
+
+        # NM org member (the opportunity's own org) can edit.
+        nm_url = reverse(
             "opportunity:edit_assigned_task",
             args=(organization.slug, managed_opp.opportunity_id, task.pk),
         )
         client.force_login(org_user_admin)
-        response = client.get(url)
-        assert response.status_code == HTTPStatus.NOT_FOUND
+        assert client.get(nm_url).status_code == HTTPStatus.OK
+
+        # PM org member (the program's managing org) can also edit.
+        pm_url = reverse(
+            "opportunity:edit_assigned_task",
+            args=(program_manager_org.slug, managed_opp.opportunity_id, task.pk),
+        )
+        client.force_login(program_manager_org_user_admin)
+        assert client.get(pm_url).status_code == HTTPStatus.OK
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2194,7 +2194,12 @@ class UserVisitVerificationView(WorkerPageView):
 
 
 def _can_manage_tasks(request, opportunity):
+    """Permission to create, edit, or delete tasks."""
     return _request_user_is_member(request) and request.is_opportunity_pm
+
+
+def _can_edit_tasks(request):
+    return _request_user_is_member(request) or request.is_opportunity_pm
 
 
 def _task_redirect_url(request, org_slug, opp_id):
@@ -2624,7 +2629,7 @@ def user_task_details(request, org_slug, opp_id, pk):
             completed_task=completed_task,
             images=images,
             hq_link=hq_link,
-            can_manage_tasks=_can_manage_tasks(request, request.opportunity),
+            can_edit_tasks=_can_edit_tasks(request),
         ),
     )
 
@@ -3516,6 +3521,8 @@ class AssignedTaskListView(OpportunityObjectMixin, OrganizationUserMixin, Filter
     def get_table_kwargs(self):
         kwargs = super().get_table_kwargs()
         kwargs["opp_id"] = self.get_opportunity().opportunity_id
+        kwargs["can_edit_tasks"] = _can_edit_tasks(self.request)
+        kwargs["can_delete_tasks"] = _can_manage_tasks(self.request, self.get_opportunity())
         return kwargs
 
     def get_table_data(self):
@@ -3563,7 +3570,7 @@ class AssignedTaskListView(OpportunityObjectMixin, OrganizationUserMixin, Filter
         return context
 
 
-class EditAssignedTask(ManagedOpportunityPMRequiredMixin, OrganizationUserMemberRoleMixin, UpdateView):
+class EditAssignedTask(LoginRequiredMixin, OpportunityObjectMixin, OrganizationUserMemberRoleMixin, UpdateView):
     template_name = "opportunity/edit_assigned_task_form.html"
     form_class = EditAssignedTaskForm
     model = AssignedTask

--- a/commcare_connect/templates/opportunity/user_task_details.html
+++ b/commcare_connect/templates/opportunity/user_task_details.html
@@ -44,7 +44,7 @@
       <div class="text-sm font-normal text-brand-deep-purple">{{ completed_task.completed_at }}</div>
     </div>
   </div>
-  {% if can_manage_tasks and completed_task.status == "assigned" %}
+  {% if can_edit_tasks and completed_task.status == "assigned" %}
     <div class="flex justify-end">
       <button type="button"
               class="button button-md outline-style"

--- a/commcare_connect/templates/opportunity/user_tasks.html
+++ b/commcare_connect/templates/opportunity/user_tasks.html
@@ -173,9 +173,9 @@
     </div>
     {% if can_manage_tasks %}
       {% include 'tasks/new_task_modal.html' with modal_name="showCreateTaskModal" form=create_task_form %}
-      {% include 'opportunity/edit_assigned_task_modal.html' %}
-      {% include 'components/confirm_modal.html' %}
     {% endif %}
+    {% include 'components/confirm_modal.html' %}
+    {% include 'opportunity/edit_assigned_task_modal.html' %}
   </div>
 {% endblock %}
 {% block inline_javascript %}


### PR DESCRIPTION
## Technical Summary

[CCCT-2571](https://dimagi.atlassian.net/browse/CCCT-2571)

- Split the single "manage tasks" check into two: editing a task's now allows any org member on either side of the opportunity (the owning org or the managing PM org), while creating and deleting tasks stays PM-only.
- The assigned task table's column visibility logic had the edit-button and bulk-delete-checkbox conditions swapped, so a user's actual permissions didn't reliably match what the UI showed them.

## Safety Assurance

### Safety Story
This primarily includes changes to the edit button and the create/delete permissions. I verified these changes locally across the different user roles, and they behaved as expected.

### Automated test coverage
Updated the tests

### QA Plan

No QA ticket needed

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2571]: https://dimagi.atlassian.net/browse/CCCT-2571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ