### PR TITLE
Remove case sensitivity from Work Area upload csv file

### DIFF
--- a/commcare_connect/microplanning/tasks.py
+++ b/commcare_connect/microplanning/tasks.py
@@ -53,6 +53,7 @@ class WorkAreaCSVImporter:
     def _validate_all_rows(self, f):
         f.seek(0)
         reader = csv.DictReader(f)
+        self._normalize_headers(reader)
         if not self._validate_headers(reader):
             return False
 
@@ -66,6 +67,7 @@ class WorkAreaCSVImporter:
     def _stream_and_insert(self, f):
         f.seek(0)
         reader = csv.DictReader(f)
+        self._normalize_headers(reader)
         batch = []
         batch_size = 5000
 
@@ -112,6 +114,10 @@ class WorkAreaCSVImporter:
         if self.errors:
             return {"errors": self.errors}
         return {"created": self.created_count}
+
+    def _normalize_headers(self, reader):
+        canonical_by_lower = {header.lower(): header for header in self.HEADERS.values()}
+        reader.fieldnames = [canonical_by_lower.get((h or "").lower(), h) for h in (reader.fieldnames or [])]
 
     def _validate_headers(self, reader):
         headers = set(reader.fieldnames or [])

--- a/commcare_connect/microplanning/tests/test_tasks.py
+++ b/commcare_connect/microplanning/tests/test_tasks.py
@@ -170,6 +170,36 @@ class TestWorkAreaCSVImporter:
 
         assert result["created"] == 1
 
+    def test_case_insensitive_headers(self, opportunity):
+        headers = [
+            "area slug",
+            "WARD",
+            "Centroid",
+            "boundary",
+            "Building count",
+            "expected VISIT count",
+            "target population",
+            "lga",
+            "STATE",
+        ]
+        row = [
+            "area-case",
+            "ward",
+            self.CENTROID,
+            self.POLYGON,
+            5,
+            "6",
+            "100",
+            "LGA1",
+            "State1",
+        ]
+
+        csv_data = self.build_csv([row], headers=headers)
+        result = WorkAreaCSVImporter(opportunity.id, csv_data).run()
+
+        assert result["created"] == 1
+        assert WorkArea.objects.filter(slug="area-case", target_population=100).exists()
+
     def test_missing_extra_properties(self, opportunity):
         row = [
             "area-1",


### PR DESCRIPTION
## Product Description

Work Area CSV uploads were rejected if a column header's casing didn't exactly match the expected name (for example "Target population" instead of "Target Population"), even though the data itself was fine. Header casing no longer matters.

## Technical Summary

[CCCT-2592](https://dimagi.atlassian.net/browse/CCCT-2592)

- Uploaded headers are normalized to the canonical casing (case-insensitive lookup) before columns are validated and rows are read, in both the validation pass and the streaming insert pass.
- The downloadable template still uses canonical casing, so nothing changes there.

## Safety Assurance

### Safety story

The change only touches header matching, not row data, so unrecognized or missing headers still fail validation the same way as before. Tested locally with mixed, upper, and lower-case header variants.

### Automated test coverage

Added `test_case_insensitive_headers` covering mixed/lower/upper-case header variants; the full `test_tasks.py` suite (14 tests) passes.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2592]: https://dimagi.atlassian.net/browse/CCCT-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ