### PR TITLE
Capture an HQ sync error in sentry

### DIFF
--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -6,7 +6,6 @@ from functools import partial
 from http import HTTPStatus
 
 import pghistory
-import sentry_sdk
 from celery.result import AsyncResult
 from crispy_forms.utils import render_crispy_form
 from django.conf import settings
@@ -889,7 +888,6 @@ def save_assignment(request, org_slug, opp_id):
         bulk_create_or_update_cases_by_work_areas(all_work_areas, request.opportunity)
     except CommCareHQAPIException:
         transaction.set_rollback(True)
-        sentry_sdk.capture_exception()
         logger.exception("Failed to sync work area assignments to HQ for opportunity %s", request.opportunity.id)
         return JsonResponse(
             {

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -6,6 +6,7 @@ from functools import partial
 from http import HTTPStatus
 
 import pghistory
+import sentry_sdk
 from celery.result import AsyncResult
 from crispy_forms.utils import render_crispy_form
 from django.conf import settings
@@ -888,7 +889,16 @@ def save_assignment(request, org_slug, opp_id):
         bulk_create_or_update_cases_by_work_areas(all_work_areas, request.opportunity)
     except CommCareHQAPIException:
         transaction.set_rollback(True)
-        return JsonResponse({"error": _("Failed to sync with CommCare HQ. Please try again.")}, status=502)
+        sentry_sdk.capture_exception()
+        logger.exception("Failed to sync work area assignments to HQ for opportunity %s", request.opportunity.id)
+        return JsonResponse(
+            {
+                "error": _(
+                    "Failed to sync with CommCare HQ. Please try again, and if the issue persists, contact support."
+                )
+            },
+            status=502,
+        )
 
     notified_access_ids = {access.id for access in work_area_to_access.values()}
     for access_id in notified_access_ids:


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2588

Add 'Contact support' in the error message when sync with HQ fails.

## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Capture the error in sentry for tracking

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
No change apart from message change
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA
### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
