### PR TITLE
Reject delivery visits while a task is pending

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -530,7 +530,8 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
         if access.suspended:
             flags.append(["user_suspended", "This user is suspended from the opportunity."])
             user_visit.status = VisitValidationStatus.rejected
-            completed_work.status = CompletedWorkStatus.rejected
+            if completed_work is not None:
+                completed_work.status = CompletedWorkStatus.rejected
         if _has_blocking_pending_task(access, app):
             flags.append(["pending_task", "Worker has an incomplete assigned task."])
             user_visit.status = VisitValidationStatus.rejected

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -534,8 +534,9 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
         if _has_blocking_pending_task(access, app):
             flags.append(["pending_task", "Worker has an incomplete assigned task."])
             user_visit.status = VisitValidationStatus.rejected
-            completed_work.status = CompletedWorkStatus.rejected
-            completed_work_needs_save = True
+            if completed_work is not None:
+                completed_work.status = CompletedWorkStatus.rejected
+                completed_work_needs_save = True
         if flags:
             user_visit.flagged = True
             user_visit.flag_reason = {"flags": flags}

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -592,6 +592,8 @@ def _has_blocking_pending_task(access: OpportunityAccess, app: CommCareApp) -> b
         opportunity_access=access,
         status=AssignedTaskStatus.ASSIGNED,
         task_type__app=app,
+        task_type__archived__isnull=True,
+        task_type__is_active=True,
     ).exists()
 
 

--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -446,10 +446,11 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
     submissions for the same user + payment unit, then:
     1. Creates a UserVisit with initial status based on daily/total/claim limits
     2. Runs verification flag checks via clean_form_submission()
-    3. Auto-rejects flagged visits if automatic_visit_verification is enabled
-    4. Auto-approves if auto_approve_visits is enabled and no flags are raised
-    5. Updates or creates the associated CompletedWork record
-    6. Triggers incremental payment recalculation
+    3. Rejects the visit if the worker has a pending assigned task
+    4. Auto-rejects flagged visits if automatic_visit_verification is enabled
+    5. Auto-approves if auto_approve_visits is enabled and no flags are raised
+    6. Updates or creates the associated CompletedWork record
+    7. Triggers incremental payment recalculation
     """
     deliver_unit = get_or_create_deliver_unit(app, deliver_unit_block)
     try:
@@ -530,6 +531,11 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
             flags.append(["user_suspended", "This user is suspended from the opportunity."])
             user_visit.status = VisitValidationStatus.rejected
             completed_work.status = CompletedWorkStatus.rejected
+        if _has_blocking_pending_task(access, app):
+            flags.append(["pending_task", "Worker has an incomplete assigned task."])
+            user_visit.status = VisitValidationStatus.rejected
+            completed_work.status = CompletedWorkStatus.rejected
+            completed_work_needs_save = True
         if flags:
             user_visit.flagged = True
             user_visit.flag_reason = {"flags": flags}
@@ -578,6 +584,14 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
     completed_work_id = completed_work.id if completed_work is not None else None
     update_payment_accrued_for_user(access, incremental=True, completed_work_id=completed_work_id)
     transaction.on_commit(partial(download_user_visit_attachments.delay, user_visit.id))
+
+
+def _has_blocking_pending_task(access: OpportunityAccess, app: CommCareApp) -> bool:
+    return AssignedTask.objects.filter(
+        opportunity_access=access,
+        status=AssignedTaskStatus.ASSIGNED,
+        task_type__app=app,
+    ).exists()
 
 
 def get_or_create_deliver_unit(app, unit_data):

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -44,6 +44,7 @@ from commcare_connect.opportunity.models import (
 )
 from commcare_connect.opportunity.tasks import bulk_approve_completed_work
 from commcare_connect.opportunity.tests.factories import (
+    AssignedTaskFactory,
     CatchmentAreaFactory,
     CompletedModuleFactory,
     CompletedWorkFactory,
@@ -458,6 +459,45 @@ def test_automatic_visit_verification_preserves_existing_status(
     visit = trigger_visit(opportunity, user_with_connectid_link, api_client)
     assert visit.flagged
     assert visit.status == expected_status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "same_app, expected_status, expected_flagged",
+    [
+        # A task for the deliver app blocks delivery: the visit is rejected even though
+        # auto_approve_visits would otherwise approve it.
+        pytest.param(True, VisitValidationStatus.rejected, True, id="same_app_blocks"),
+        # A task for an unrelated app must not block this opportunity's delivery.
+        pytest.param(False, VisitValidationStatus.approved, False, id="other_app_allows"),
+    ],
+)
+def test_pending_task_delivery_gating(
+    user_with_connectid_link: User,
+    api_client: APIClient,
+    opportunity: Opportunity,
+    same_app,
+    expected_status,
+    expected_flagged,
+):
+    opportunity.auto_approve_visits = True
+    opportunity.save()
+    oauth_application = opportunity.hq_server.oauth_application
+    form_json = _create_opp_and_form_json(opportunity, user=user_with_connectid_link)
+    form_json["metadata"]["timeEnd"] = "2023-06-07T12:36:10.178000Z"
+    access = OpportunityAccess.objects.get(user=user_with_connectid_link, opportunity=opportunity)
+    # Without task_type__app the factory creates a task for an unrelated app.
+    task_kwargs = {"task_type__app": opportunity.deliver_app} if same_app else {}
+    AssignedTaskFactory(opportunity_access=access, **task_kwargs)
+
+    make_request(api_client, form_json, user_with_connectid_link, oauth_application=oauth_application)
+
+    visit = UserVisit.objects.get(user=user_with_connectid_link)
+    assert visit.status == expected_status
+    assert visit.flagged == expected_flagged
+    if same_app:
+        assert "pending_task" in {flag for flag, _ in visit.flag_reason["flags"]}
+        assert visit.completed_work.status == CompletedWorkStatus.rejected
 
 
 def test_auto_approve_payments_flagged_visit(

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -463,13 +463,17 @@ def test_automatic_visit_verification_preserves_existing_status(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "same_app, expected_status, expected_flagged",
+    "same_app, archived, active, expected_status, expected_flagged",
     [
         # A task for the deliver app blocks delivery: the visit is rejected even though
         # auto_approve_visits would otherwise approve it.
-        pytest.param(True, VisitValidationStatus.rejected, True, id="same_app_blocks"),
+        pytest.param(True, False, True, VisitValidationStatus.rejected, True, id="same_app_blocks"),
         # A task for an unrelated app must not block this opportunity's delivery.
-        pytest.param(False, VisitValidationStatus.approved, False, id="other_app_allows"),
+        pytest.param(False, False, True, VisitValidationStatus.approved, False, id="other_app_allows"),
+        # An archived task type must not block delivery even on the same app.
+        pytest.param(True, True, True, VisitValidationStatus.approved, False, id="archived_same_app_allows"),
+        # An inactive task type must not block delivery even on the same app.
+        pytest.param(True, False, False, VisitValidationStatus.approved, False, id="inactive_same_app_allows"),
     ],
 )
 def test_pending_task_delivery_gating(
@@ -477,6 +481,8 @@ def test_pending_task_delivery_gating(
     api_client: APIClient,
     opportunity: Opportunity,
     same_app,
+    archived,
+    active,
     expected_status,
     expected_flagged,
 ):
@@ -488,6 +494,9 @@ def test_pending_task_delivery_gating(
     access = OpportunityAccess.objects.get(user=user_with_connectid_link, opportunity=opportunity)
     # Without task_type__app the factory creates a task for an unrelated app.
     task_kwargs = {"task_type__app": opportunity.deliver_app} if same_app else {}
+    if archived:
+        task_kwargs["task_type__archived"] = now()
+    task_kwargs["task_type__is_active"] = active
     AssignedTaskFactory(opportunity_access=access, **task_kwargs)
 
     make_request(api_client, form_json, user_with_connectid_link, oauth_application=oauth_application)
@@ -495,7 +504,7 @@ def test_pending_task_delivery_gating(
     visit = UserVisit.objects.get(user=user_with_connectid_link)
     assert visit.status == expected_status
     assert visit.flagged == expected_flagged
-    if same_app:
+    if expected_flagged:
         assert "pending_task" in {flag for flag, _ in visit.flag_reason["flags"]}
         assert visit.completed_work.status == CompletedWorkStatus.rejected
 

--- a/commcare_connect/utils/flags.py
+++ b/commcare_connect/utils/flags.py
@@ -13,6 +13,7 @@ class Flags(Enum):
     DURATION = "duration"
     FORM_VALUE_NOT_FOUND = "form_value_not_found"
     USER_SUSPENDED = "user_suspended"
+    PENDING_TASK = "pending_task"
 
 
 class FlagDescription(Enum):
@@ -24,6 +25,7 @@ class FlagDescription(Enum):
     ATTACHMENT_MISSING = "Form was submitted without attachements."
     DURATION = "The form was completed too quickly."
     USER_SUSPENDED = "This user is suspended from the opportunity."
+    PENDING_TASK = "Worker has an incomplete assigned task."
 
     @staticmethod
     def FORM_VALUE_NOT_FOUND(form_json_rule: FormJsonValidationRules):
@@ -47,6 +49,7 @@ class FlagLabels(Enum):
     DURATION = "Duration"
     FORM_VALUE_NOT_FOUND = "Missing Form Value"
     USER_SUSPENDED = "User Suspended"
+    PENDING_TASK = "Pending Task"
 
     @classmethod
     def get_label(cls, flag):


### PR DESCRIPTION
## Product Description

Field workers can no longer have delivery visits silently approved while they still have an incomplete assigned task. The mobile app already blocks delivery with "Complete assigned tasks to continue delivering services," but until now the backend accepted and auto-approved any visit that reached it anyway (e.g. via an app bug or out-of-order form sync). Such a visit is now rejected and flagged as **Pending Task**, and its associated completed work is rejected so it is not paid or invoiced.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-760)

This is a release path 3 feature — Experiments & early stage iterations of product area.

## Safety Assurance

### Safety story

The change only tightens an existing decision path — it can move a visit that would otherwise be `approved`/`pending` to `rejected`, and never the reverse — so it cannot loosen validation or over-approve. It affects only visits submitted while a same-app task is `ASSIGNED`, a state the mobile app already prevents, so the expected production blast radius is small. No data migration is involved; the new `pending_task` flag is stored in the existing `flag_reason` JSON field.

### Automated test coverage

Tests cover the delivery gate end to end through the form receiver: a same-app pending task rejects and flags the visit (with the completed work rejected) despite `auto_approve_visits` being on, while a pending task for an unrelated app leaves delivery approved. Existing delivery, auto-approve, flagging, and suspension tests continue to pass unchanged.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
