### PR TITLE
Fall back to email when Assigned By user has a blank name

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -3,6 +3,8 @@ from urllib.parse import urlencode
 
 import django_tables2 as tables
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.db.models import CharField, Value
+from django.db.models.functions import Coalesce, NullIf
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.html import format_html
@@ -1849,7 +1851,7 @@ class AssignedTaskListTable(OpportunityContextTable):
     due_date = DMYTColumn(verbose_name=gettext_lazy("Due Date"), accessor="due_date")
     assigned_by = tables.Column(
         verbose_name=gettext_lazy("Assigned By"),
-        accessor="assigned_by__name",
+        accessor="assigned_by",
         empty_values=(None,),
         default=gettext_lazy("Deleted user"),
     )
@@ -1886,6 +1888,14 @@ class AssignedTaskListTable(OpportunityContextTable):
             value.username,
         )
 
+    def render_assigned_by(self, value):
+        return value.name or value.email
+
+    def order_assigned_by(self, queryset, is_descending):
+        expression = Coalesce(NullIf("assigned_by__name", Value("")), "assigned_by__email", output_field=CharField())
+        queryset = queryset.order_by(expression.desc() if is_descending else expression.asc())
+        return queryset, True
+
 
 class WorkerCompletedTaskTable(tables.Table):
     use_view_url = True
@@ -1894,7 +1904,7 @@ class WorkerCompletedTaskTable(tables.Table):
     task_type = tables.Column(verbose_name=_("Task Type"), accessor="task_type", orderable=False)
     assigned_by = tables.Column(
         verbose_name=_("Assigned By"),
-        accessor="assigned_by__name",
+        accessor="assigned_by",
         empty_values=(None,),
         default=gettext_lazy("Deleted user"),
     )
@@ -1936,6 +1946,14 @@ class WorkerCompletedTaskTable(tables.Table):
 
     def render_task_type(self, value):
         return format_html("{} ({})", value.name, value.slug)
+
+    def render_assigned_by(self, value):
+        return value.name or value.email
+
+    def order_assigned_by(self, queryset, is_descending):
+        expression = Coalesce(NullIf("assigned_by__name", Value("")), "assigned_by__email", output_field=CharField())
+        queryset = queryset.order_by(expression.desc() if is_descending else expression.asc())
+        return queryset, True
 
 
 class TaskTable(OpportunityContextTable):

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1842,11 +1842,9 @@ _task_select_td_extra = {
 }
 
 
-class AssignedTaskListTable(OpportunityContextTable):
+class BaseAssignedTaskTable(tables.Table):
     select = select_column(td_extra=_task_select_td_extra)
-    connect_worker = tables.Column(verbose_name=gettext_lazy("Connect Worker"), accessor="opportunity_access__user")
     status = TaskStatusColumn(verbose_name=gettext_lazy("Status"), accessor="status")
-    task_type = tables.Column(verbose_name=gettext_lazy("Task Type"), accessor="task_type__name")
     assigned_date = DMYTColumn(verbose_name=gettext_lazy("Assigned Date"), accessor="date_created")
     due_date = DMYTColumn(verbose_name=gettext_lazy("Due Date"), accessor="due_date")
     assigned_by = tables.Column(
@@ -1855,6 +1853,19 @@ class AssignedTaskListTable(OpportunityContextTable):
         empty_values=(None,),
         default=gettext_lazy("Deleted user"),
     )
+
+    def render_assigned_by(self, value):
+        return value.name or value.email
+
+    def order_assigned_by(self, queryset, is_descending):
+        expression = Coalesce(NullIf("assigned_by__name", Value("")), "assigned_by__email", output_field=CharField())
+        queryset = queryset.order_by(expression.desc() if is_descending else expression.asc())
+        return queryset, True
+
+
+class AssignedTaskListTable(BaseAssignedTaskTable, OpportunityContextTable):
+    connect_worker = tables.Column(verbose_name=gettext_lazy("Connect Worker"), accessor="opportunity_access__user")
+    task_type = tables.Column(verbose_name=gettext_lazy("Task Type"), accessor="task_type__name")
     action = tables.TemplateColumn(
         verbose_name="",
         orderable=False,
@@ -1888,29 +1899,11 @@ class AssignedTaskListTable(OpportunityContextTable):
             value.username,
         )
 
-    def render_assigned_by(self, value):
-        return value.name or value.email
 
-    def order_assigned_by(self, queryset, is_descending):
-        expression = Coalesce(NullIf("assigned_by__name", Value("")), "assigned_by__email", output_field=CharField())
-        queryset = queryset.order_by(expression.desc() if is_descending else expression.asc())
-        return queryset, True
-
-
-class WorkerCompletedTaskTable(tables.Table):
+class WorkerCompletedTaskTable(BaseAssignedTaskTable):
     use_view_url = True
 
-    select = select_column(td_extra=_task_select_td_extra)
     task_type = tables.Column(verbose_name=_("Task Type"), accessor="task_type", orderable=False)
-    assigned_by = tables.Column(
-        verbose_name=_("Assigned By"),
-        accessor="assigned_by",
-        empty_values=(None,),
-        default=gettext_lazy("Deleted user"),
-    )
-    assigned_date = DMYTColumn(verbose_name=_("Assigned Date"), accessor="date_created")
-    due_date = DMYTColumn(verbose_name=_("Due Date"))
-    status = TaskStatusColumn(verbose_name=_("Status"), accessor="status")
 
     class Meta:
         model = AssignedTask
@@ -1946,14 +1939,6 @@ class WorkerCompletedTaskTable(tables.Table):
 
     def render_task_type(self, value):
         return format_html("{} ({})", value.name, value.slug)
-
-    def render_assigned_by(self, value):
-        return value.name or value.email
-
-    def order_assigned_by(self, queryset, is_descending):
-        expression = Coalesce(NullIf("assigned_by__name", Value("")), "assigned_by__email", output_field=CharField())
-        queryset = queryset.order_by(expression.desc() if is_descending else expression.asc())
-        return queryset, True
 
 
 class TaskTable(OpportunityContextTable):


### PR DESCRIPTION
## Product Description
<img width="1800" height="1008" alt="Screenshot 2026-07-16 at 5 07 52 PM" src="https://github.com/user-attachments/assets/389f1822-4b52-4dc4-b821-add23258d229" />
<img width="1800" height="1000" alt="Screenshot 2026-07-16 at 5 07 36 PM" src="https://github.com/user-attachments/assets/65b3838c-2ffe-4049-a219-49f3b7d87a40" />



## Technical Summary

[CCCT-2570](https://dimagi.atlassian.net/browse/CCCT-2570)

- The column read the user's name field directly, so a blank name showed nothing instead of falling back to another identifier. This is the same bug already fixed for the audit report's Reviewer column.
- Sorting now runs through a Coalesce expression evaluated at query time, so ordering by this column still works when some names are blank.
- Extracted the shared columns and this render/sort logic into a `BaseAssignedTaskTable` mixin, so `WorkerCompletedTaskTable` gets the same fix instead of duplicating it.

## Safety Assurance

### Safety story

This only changes how existing task table columns render and sort. No models, migrations, or view querysets change.

### Automated test coverage

No new tests added.

### QA Plan

No QA ticket needed

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2570]: https://dimagi.atlassian.net/browse/CCCT-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
