### PR TITLE
CCCT-2637: Replace prod with eu-west-1 config

### DIFF
--- a/deploy/config/deploy.production.yml
+++ b/deploy/config/deploy.production.yml
@@ -1,7 +1,13 @@
 logging:
   options:
     awslogs-region: 'eu-west-1'
-    awslogs-group: 'commcare-connect-traefik'
+
+traefik:
+  options:
+    log-driver: awslogs
+    log-opt:
+      - awslogs-region=eu-west-1
+      - awslogs-group=commcare-connect-traefik
 
 servers:
   web:

--- a/deploy/config/deploy.production.yml
+++ b/deploy/config/deploy.production.yml
@@ -1,8 +1,12 @@
+logging:
+  options:
+    awslogs-region: 'eu-west-1'
+
 servers:
   web:
     hosts:
-      - i-0901d8af0c29c69cf
-      - i-0a766713cb0d2fe96
+      - i-0061917b7240cfaef
+      - i-0006273d9b40ce3e0
     options:
       # create by ansible
       env-file: '/home/connect/www/commcare-connect/docker.env'
@@ -16,7 +20,7 @@ servers:
 
   celery:
     hosts:
-      - i-0816b5db3a153135e
+      - i-0517c5593d6eb861e
     options:
       # create by ansible
       env-file: '/home/connect/www/commcare-connect/docker.env'

--- a/deploy/config/deploy.production.yml
+++ b/deploy/config/deploy.production.yml
@@ -1,6 +1,7 @@
 logging:
   options:
     awslogs-region: 'eu-west-1'
+    awslogs-group: 'commcare-connect-traefik'
 
 servers:
   web:

--- a/deploy/config/deploy.staging.yml
+++ b/deploy/config/deploy.staging.yml
@@ -1,3 +1,10 @@
+traefik:
+  options:
+    log-driver: awslogs
+    log-opt:
+      - awslogs-region=eu-west-1
+      - awslogs-group=commcare-connect
+
 servers:
   web:
     hosts:

--- a/deploy/config/deploy.staging.yml
+++ b/deploy/config/deploy.staging.yml
@@ -2,7 +2,7 @@ traefik:
   options:
     log-driver: awslogs
     log-opt:
-      - awslogs-region=eu-west-1
+      - awslogs-region=us-east-1
       - awslogs-group=commcare-connect
 
 servers:

--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -16,6 +16,7 @@ logging:
   driver: awslogs
   options:
     awslogs-region: 'us-east-1'
+    awslogs-group: 'commcare-connect'
 
 builder:
   multiarch: false

--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -16,7 +16,6 @@ logging:
   driver: awslogs
   options:
     awslogs-region: 'us-east-1'
-    awslogs-group: 'commcare-connect'
 
 builder:
   multiarch: false

--- a/deploy/production.inventory.yml
+++ b/deploy/production.inventory.yml
@@ -7,7 +7,7 @@ webservers:
     celery0:
       ansible_host: i-0517c5593d6eb861e
   vars:
-    secrets_file: 'Ansible Secrets - Production EU'
+    secrets_file: 'Ansible Secrets - Production'
     commcare_hq_url: 'https://www.commcarehq.org'
     deploy_environment: 'production'
     env_file: 'connect.docker.env.j2'

--- a/deploy/production.inventory.yml
+++ b/deploy/production.inventory.yml
@@ -1,16 +1,17 @@
 webservers:
   hosts:
     web0:
-      ansible_host: i-0901d8af0c29c69cf
+      ansible_host: i-0061917b7240cfaef
     web1:
-      ansible_host: i-0a766713cb0d2fe96
+      ansible_host: i-0006273d9b40ce3e0
     celery0:
-      ansible_host: i-0816b5db3a153135e
+      ansible_host: i-0517c5593d6eb861e
   vars:
-    secrets_file: 'Ansible Secrets - Production'
+    secrets_file: 'Ansible Secrets - Production EU'
     commcare_hq_url: 'https://www.commcarehq.org'
     deploy_environment: 'production'
     env_file: 'connect.docker.env.j2'
+    aws_region: 'eu-west-1'
 
 connectid:
   hosts:

--- a/deploy/roles/connect/defaults/main.yml
+++ b/deploy/roles/connect/defaults/main.yml
@@ -11,6 +11,7 @@ project_dir: '{{ base_dir }}/{{ project_name }}'
 docker_env_file: '{{ project_dir }}/docker.env'
 
 # Django settings
+# Default region - can be overridden per-inventory
 aws_region: us-east-1
 connectid_url: https://connectid.dimagi.com
 django_admin_url: admin/


### PR DESCRIPTION
Make production the eu-west-1 deployment. Staging stays in us-east-1, production moves to eu-west-1.

- production.inventory.yml + deploy.production.yml now target the eu-west-1 hosts, with aws_region/awslogs-region overrides. The connectid group and its us-east-1 secrets are kept as-is.
- Add a default awslogs-group and a per-inventory aws_region default.
