### PR TITLE
Select aws region based on deployment env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy
 
 env:
-  AWS_REGION: 'us-west-1'
   SENTRY_ORG: 'dimagi'
   SENTRY_PROJECT: 'commcare-connect'
 
@@ -58,7 +57,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::037129986032:role/github_deploy
           role-session-name: GithubDeploy
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ inputs.environment == 'production' && 'eu-west-1' || 'us-east-1' }}
 
       - id: slack
         name: Notify Deploy Start


### PR DESCRIPTION
## Technical Summary
Now that production runs in `eu-west-1` and staging `us-east-1` we need to distinguish the aws region specification in the github `deploy.yml` file, so this PR sets the region based on the env being deployed (similar to how the slack notifications channel is chosen). 

## Safety Assurance

### Safety story
Tested by deploying staging

### Automated test coverage
N.A

### QA Plan
N.A

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
