### PR TITLE
Update filtering Options on Progress Map and Assignment Mode

### DIFF
--- a/commcare_connect/microplanning/filters.py
+++ b/commcare_connect/microplanning/filters.py
@@ -4,9 +4,9 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from commcare_connect.microplanning.coverage_progress import CoverageDateFilter
-from commcare_connect.microplanning.models import WorkArea, WorkAreaStatus
+from commcare_connect.microplanning.models import ImplementationArea, WorkArea, WorkAreaGroup, WorkAreaStatus
 from commcare_connect.opportunity.filters import CSRFExemptForm
-from commcare_connect.opportunity.models import UserVisit
+from commcare_connect.opportunity.models import PaymentUnit, UserVisit
 from commcare_connect.users.models import User
 
 INPUT_CSS = (
@@ -89,6 +89,12 @@ class CoverageProgressFilterSet(django_filters.FilterSet):
 
 
 class WorkAreaMapFilterSet(django_filters.FilterSet):
+    unassigned_only = django_filters.BooleanFilter(
+        label=_("Show Only Unassigned"),
+        method="filter_unassigned_only",
+        widget=forms.CheckboxInput(attrs={"class": "simple-toggle"}),
+    )
+
     status = django_filters.MultipleChoiceFilter(
         label=_("Work Area Status"),
         choices=WorkAreaStatus.choices,
@@ -102,23 +108,37 @@ class WorkAreaMapFilterSet(django_filters.FilterSet):
         widget=forms.SelectMultiple(attrs={"data-tomselect": "1", "class": INPUT_CSS}),
     )
 
+    implementation_area = django_filters.ModelMultipleChoiceFilter(
+        label=_("Implementation Area"),
+        queryset=ImplementationArea.objects.none(),
+        widget=forms.SelectMultiple(attrs={"data-tomselect": "1", "class": INPUT_CSS}),
+    )
+
+    work_area_group = django_filters.ModelMultipleChoiceFilter(
+        label=_("Work Area Group"),
+        queryset=WorkAreaGroup.objects.none(),
+        widget=forms.SelectMultiple(attrs={"data-tomselect": "1", "class": INPUT_CSS}),
+    )
+
+    payment_unit = django_filters.ModelChoiceFilter(
+        label=_("Payment Unit"),
+        field_name="uservisit__deliver_unit__payment_unit",
+        queryset=PaymentUnit.objects.none(),
+        widget=forms.Select(attrs={"data-tomselect": "1", "class": INPUT_CSS}),
+    )
+
     start_date = django_filters.DateFilter(
-        label=_("Start Date"),
+        label=_("Visit Start Date"),
         field_name="uservisit__visit_date",
         lookup_expr="date__gte",
         widget=forms.DateInput(attrs={"type": "date", "class": INPUT_CSS}),
     )
 
     end_date = django_filters.DateFilter(
-        label=_("End Date"),
+        label=_("Visit End Date"),
         field_name="uservisit__visit_date",
         lookup_expr="date__lte",
         widget=forms.DateInput(attrs={"type": "date", "class": INPUT_CSS}),
-    )
-
-    unassigned_only = django_filters.BooleanFilter(
-        label=_("Show Only Unassigned"),
-        method="filter_unassigned_only",
     )
 
     class Meta:
@@ -140,6 +160,15 @@ class WorkAreaMapFilterSet(django_filters.FilterSet):
                 )
                 .distinct()
                 .order_by("name")
+            )
+            self.filters["implementation_area"].queryset = ImplementationArea.objects.filter(
+                opportunity=opportunity
+            ).order_by("name")
+            self.filters["work_area_group"].queryset = WorkAreaGroup.objects.filter(opportunity=opportunity).order_by(
+                "name"
+            )
+            self.filters["payment_unit"].queryset = PaymentUnit.objects.filter(opportunity=opportunity).order_by(
+                "name"
             )
 
         # Display "name (username)" instead of default __str__

--- a/commcare_connect/microplanning/filters.py
+++ b/commcare_connect/microplanning/filters.py
@@ -124,7 +124,7 @@ class WorkAreaMapFilterSet(django_filters.FilterSet):
         label=_("Payment Unit"),
         field_name="uservisit__deliver_unit__payment_unit",
         queryset=PaymentUnit.objects.none(),
-        widget=forms.Select(attrs={"data-tomselect": "1", "class": INPUT_CSS}),
+        widget=forms.Select(attrs={"class": INPUT_CSS}),
     )
 
     start_date = django_filters.DateFilter(

--- a/commcare_connect/microplanning/forms.py
+++ b/commcare_connect/microplanning/forms.py
@@ -101,16 +101,16 @@ class WorkAreaModelForm(forms.ModelForm):
 
 
 class AssignmentModeForm(forms.Form):
-    work_area_group = forms.ModelChoiceField(
+    work_area_group = forms.ModelMultipleChoiceField(
         queryset=WorkAreaGroup.objects.none(),
         required=False,
-        empty_label=_("— Select Group —"),
         label=_("Select Work Area Group"),
-        widget=forms.Select(
+        widget=forms.SelectMultiple(
             attrs={
                 "class": INPUT_CSS,
+                "data-tomselect": "1",
                 "x-ref": "groupSelect",
-                "@change": "selectGroup($event.target.value)",
+                "@change": "selectGroup(Array.from($event.target.selectedOptions).map(o => o.value))",
             }
         ),
     )

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -9,6 +9,7 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from django import forms
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.utils import OperationalError
@@ -19,6 +20,7 @@ from commcare_connect.flags.flag_names import MICROPLANNING
 from commcare_connect.flags.models import Flag
 from commcare_connect.microplanning import views as microplanning_views
 from commcare_connect.microplanning.filters import WorkAreaMapFilterSet
+from commcare_connect.microplanning.forms import AssignmentModeForm
 from commcare_connect.microplanning.models import (
     ImplementationArea,
     InaccessibilityRequestStatus,
@@ -40,7 +42,13 @@ from commcare_connect.microplanning.views import (
     get_metrics_for_microplanning,
 )
 from commcare_connect.opportunity.models import BlobMeta, VisitValidationStatus
-from commcare_connect.opportunity.tests.factories import OpportunityAccessFactory, OpportunityFactory, UserVisitFactory
+from commcare_connect.opportunity.tests.factories import (
+    DeliverUnitFactory,
+    OpportunityAccessFactory,
+    OpportunityFactory,
+    PaymentUnitFactory,
+    UserVisitFactory,
+)
 from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 
 
@@ -731,6 +739,44 @@ class TestWorkAreaMapFilterSet:
         fs = WorkAreaMapFilterSet({}, queryset=empty_qs)
         assert fs.filters["assignee"].queryset.count() == 0
 
+    def test_implementation_area_filter(self, opportunity, work_areas):
+        impl_area = ImplementationAreaFactory(opportunity=opportunity)
+        work_areas.wa_visited.implementation_area = impl_area
+        work_areas.wa_visited.save(update_fields=["implementation_area"])
+
+        result = self._filter_ids({"implementation_area": [impl_area.id]}, opportunity)
+        assert result == {work_areas.wa_visited.id}
+
+    def test_work_area_group_filter(self, opportunity, work_areas):
+        other_group = WorkAreaGroupFactory(opportunity=opportunity)
+        wa_other_group = WorkAreaFactory(opportunity=opportunity, work_area_group=other_group)
+
+        result = self._filter_ids({"work_area_group": [work_areas.group.id]}, opportunity)
+        assert result == {work_areas.wa_not_visited.id, work_areas.wa_visited.id}
+        assert wa_other_group.id not in result
+
+    def test_payment_unit_filter(self, opportunity, work_areas):
+        payment_unit = PaymentUnitFactory(opportunity=opportunity)
+        deliver_unit = DeliverUnitFactory(payment_unit=payment_unit)
+        UserVisitFactory(
+            opportunity=opportunity,
+            user=work_areas.access.user,
+            work_area=work_areas.wa_visited,
+            deliver_unit=deliver_unit,
+        )
+
+        result = self._filter_ids({"payment_unit": payment_unit.id}, opportunity)
+        assert result == {work_areas.wa_visited.id}
+
+    def test_unassigned_only_is_a_checkbox_with_no_unknown_option(self, opportunity):
+        fs = WorkAreaMapFilterSet({}, queryset=WorkArea.objects.none(), opportunity=opportunity)
+        widget = fs.form.fields["unassigned_only"].widget
+        assert isinstance(widget, forms.CheckboxInput)
+
+    def test_unassigned_only_still_filters_when_true(self, opportunity, work_areas):
+        result = self._filter_ids({"unassigned_only": "True"}, opportunity)
+        assert result == {work_areas.wa_unassigned.id}
+
 
 @pytest.mark.django_db
 class TestUserVisitVectorLayer:
@@ -1295,6 +1341,92 @@ class TestReviewInaccessibilityModal(BaseMicroplanningFlagTest):
 
 
 @pytest.mark.django_db
+class TestAssignmentModeContext:
+    @pytest.fixture(autouse=True)
+    def setup_flag(self, managed_opportunity):
+        flag, _ = Flag.objects.get_or_create(name=MICROPLANNING)
+        flag.opportunities.add(managed_opportunity)
+        flag.flush()
+
+    def url(self, org_slug, opp_id):
+        return reverse("microplanning:microplanning_home", args=(org_slug, opp_id))
+
+    def test_worker_list_url_points_to_work_area_assignments_tab(
+        self, client, settings, program_manager_org, program_manager_org_user_admin, managed_opportunity
+    ):
+        settings.MAPBOX_TOKEN = "test-mapbox-token"
+        client.force_login(program_manager_org_user_admin)
+
+        response = client.get(
+            self.url(program_manager_org.slug, str(managed_opportunity.opportunity_id)),
+            {"assignment_mode": "1"},
+        )
+
+        assert response.status_code == 200
+        expected_url = reverse(
+            "opportunity:worker_work_areas",
+            args=(program_manager_org.slug, managed_opportunity.opportunity_id),
+        )
+        assert response.context["worker_list_url"] == expected_url
+
+    def test_work_area_group_field_accepts_multiple_groups(self, managed_opportunity):
+        group_a = WorkAreaGroupFactory(opportunity=managed_opportunity)
+        group_b = WorkAreaGroupFactory(opportunity=managed_opportunity)
+
+        form = AssignmentModeForm(
+            data={"work_area_group": [group_a.id, group_b.id]},
+            opportunity=managed_opportunity,
+        )
+
+        assert form.is_valid()
+        assert set(form.cleaned_data["work_area_group"]) == {group_a, group_b}
+
+
+class TestGetWorkAreasForAssignment:
+    @pytest.fixture(autouse=True)
+    def setup_flag(self, managed_opportunity):
+        flag, _ = Flag.objects.get_or_create(name=MICROPLANNING)
+        flag.opportunities.add(managed_opportunity)
+        flag.flush()
+
+    def url(self, org_slug, opp_id):
+        return reverse(
+            "microplanning:get_work_areas_for_assignment",
+            kwargs={"org_slug": org_slug, "opp_id": opp_id},
+        )
+
+    def test_returns_union_of_multiple_groups(
+        self, client, program_manager_org, program_manager_org_user_admin, managed_opportunity
+    ):
+        group_a = WorkAreaGroupFactory(opportunity=managed_opportunity)
+        group_b = WorkAreaGroupFactory(opportunity=managed_opportunity)
+        other_group = WorkAreaGroupFactory(opportunity=managed_opportunity)
+        wa_a = WorkAreaFactory(opportunity=managed_opportunity, work_area_group=group_a)
+        wa_b = WorkAreaFactory(opportunity=managed_opportunity, work_area_group=group_b)
+        WorkAreaFactory(opportunity=managed_opportunity, work_area_group=other_group)
+        client.force_login(program_manager_org_user_admin)
+
+        response = client.get(
+            self.url(program_manager_org.slug, managed_opportunity.opportunity_id),
+            {"group_id": [group_a.id, group_b.id]},
+        )
+
+        assert response.status_code == 200
+        returned_ids = {wa["id"] for wa in response.json()["work_areas"]}
+        assert returned_ids == {wa_a.id, wa_b.id}
+
+    def test_no_group_ids_returns_empty(
+        self, client, program_manager_org, program_manager_org_user_admin, managed_opportunity
+    ):
+        WorkAreaFactory(opportunity=managed_opportunity)
+        client.force_login(program_manager_org_user_admin)
+
+        response = client.get(self.url(program_manager_org.slug, managed_opportunity.opportunity_id))
+
+        assert response.status_code == 200
+        assert response.json()["work_areas"] == []
+
+
 class TestSaveAssignment:
     @pytest.fixture(autouse=True)
     def setup_flag(self, managed_opportunity):

--- a/commcare_connect/microplanning/urls.py
+++ b/commcare_connect/microplanning/urls.py
@@ -66,7 +66,7 @@ urlpatterns = [
         name="act_on_inaccessibility_request",
     ),
     path(
-        "<slug:opp_id>/assignment/group_work_areas/<int:group_id>/",
+        "<slug:opp_id>/assignment/group_work_areas/",
         views.get_work_areas_for_assignment,
         name="get_work_areas_for_assignment",
     ),

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -347,8 +347,8 @@ def _get_assignment_mode_context(request, opportunity):
         ),
         "group_work_areas_url": reverse(
             "microplanning:get_work_areas_for_assignment",
-            args=[org_slug, opp_id, 0],
-        ).replace("/0/", "/__group_id__/"),
+            args=[org_slug, opp_id],
+        ),
         "flw_work_areas_url": reverse(
             "microplanning:get_flw_work_areas_for_assignment",
             args=[org_slug, opp_id, 0],
@@ -370,7 +370,7 @@ def _get_assignment_mode_context(request, opportunity):
             args=[org_slug, opp_id],
         ),
         "worker_list_url": reverse(
-            "opportunity:worker_list",
+            "opportunity:worker_work_areas",
             args=[org_slug, opp_id],
         ),
     }
@@ -924,11 +924,12 @@ class ModifyWorkAreaUpdateView(UpdateView):
 @org_program_manager_required
 @opportunity_required
 @waffle_flag(MICROPLANNING)
-def get_work_areas_for_assignment(request, org_slug, opp_id, group_id):
+def get_work_areas_for_assignment(request, org_slug, opp_id):
+    group_ids = request.GET.getlist("group_id")
     work_areas = list(
         WorkArea.objects.filter(
             opportunity=request.opportunity,
-            work_area_group_id=group_id,
+            work_area_group_id__in=group_ids,
         ).values("id", "building_count", "expected_visit_count", "status")
     )
     return JsonResponse({"work_areas": work_areas})

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -180,31 +180,16 @@
             </div>
             <div class="flex items-center justify-between py-2">
               <label for="show-visits-toggle" class="text-sm text-gray-700">{% translate "Show Visits" %}</label>
-              <button id="show-visits-toggle"
-                      type="button"
-                      role="switch"
-                      :aria-checked="showVisits"
-                      @click="showVisits = !showVisits"
-                      :class="showVisits ? 'bg-indigo-600' : 'bg-gray-200'"
-                      class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">
-                <span :class="showVisits ? 'translate-x-5' : 'translate-x-0'"
-                      class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"></span>
-              </button>
+              <input id="show-visits-toggle" type="checkbox" class="simple-toggle" x-model="showVisits">
             </div>
             <div class="flex items-center justify-between py-2">
               <label for="show-implementation-areas-toggle" class="text-sm text-gray-700">
                 {% translate "Show Implementation Areas" %}
               </label>
-              <button id="show-implementation-areas-toggle"
-                      type="button"
-                      role="switch"
-                      :aria-checked="showImplementationAreas"
-                      @click="showImplementationAreas = !showImplementationAreas"
-                      :class="showImplementationAreas ? 'bg-indigo-600' : 'bg-gray-200'"
-                      class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">
-                <span :class="showImplementationAreas ? 'translate-x-5' : 'translate-x-0'"
-                      class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"></span>
-              </button>
+              <input id="show-implementation-areas-toggle"
+                     type="checkbox"
+                     class="simple-toggle"
+                     x-model="showImplementationAreas">
             </div>
             <form x-ref="filterForm" @change.debounce.1000ms="applyFilters()">
               {% for field in filter_form %}

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -208,11 +208,23 @@
             </div>
             <form x-ref="filterForm" @change.debounce.1000ms="applyFilters()">
               {% for field in filter_form %}
-                <div class="mb-3">
-                  <label for="{{ field.id_for_label }}"
-                         class="block text-sm font-medium text-gray-700 mb-1">{{ field.label }}</label>
-                  {{ field }}
-                </div>
+                {% if field.name == "unassigned_only" %}
+                  <div class="mb-3 flex items-center justify-between py-2">
+                    <label for="{{ field.id_for_label }}"
+                           class="text-sm font-medium text-gray-700">
+                      {{ field.label }}
+                      <i class="fa-solid fa-circle-info text-gray-400"
+                         x-tooltip.raw="{% translate 'Shows only Work Areas that have not been assigned to a Connect Worker.' %}"></i>
+                    </label>
+                    {{ field }}
+                  </div>
+                {% else %}
+                  <div class="mb-3">
+                    <label for="{{ field.id_for_label }}"
+                           class="block text-sm font-medium text-gray-700 mb-1">{{ field.label }}</label>
+                    {{ field }}
+                  </div>
+                {% endif %}
               {% endfor %}
             </form>
           </aside>

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -16,7 +16,7 @@
             selectedWorkAreas: new Set(),
             groupWorkAreaIds: new Set(),
             flwFilterWorkAreaIds: new Set(),
-            selectedGroupId: null,
+            selectedGroupIds: [],
             selectedFlwFilterId: null,
             selectedAssigneeId: null,
             flwSummaryAssigneeId: null,
@@ -252,12 +252,12 @@
 
                 // Clear group dropdown if the map click breaks the group selection:
                 // either deselecting a WA inside the group, or selecting one outside it
-                if (this.selectedGroupId) {
+                if (this.selectedGroupIds.length) {
                     const isGroupWa = this.groupWorkAreaIds.has(id);
                     if ((isDeselecting && isGroupWa) || (!isDeselecting && !isGroupWa)) {
                         this.groupWorkAreaIds.clear();
-                        this.selectedGroupId = null;
-                        if (this.$refs.groupSelect) this.$refs.groupSelect.value = '';
+                        this.selectedGroupIds = [];
+                        if (this.$refs.groupSelect?.tomselect) this.$refs.groupSelect.tomselect.clear();
                     }
                 }
 
@@ -265,12 +265,13 @@
                 this.updateFlwSummary();
             },
 
-            selectGroup(groupId) {
-                this.selectedGroupId = groupId || null;
+            selectGroup(groupIds) {
+                this.selectedGroupIds = groupIds || [];
+                const query = this.selectedGroupIds.map((id) => `group_id=${encodeURIComponent(id)}`).join('&');
                 return this.replaceFilterSelection({
                     trackingSet: this.groupWorkAreaIds,
-                    selectionId: groupId,
-                    url: '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId),
+                    selectionId: this.selectedGroupIds,
+                    url: query ? `{{ group_work_areas_url|escapejs }}?${query}` : '',
                     errorMsg: "{% translate 'Failed to load group work areas' %}",
                 });
             },
@@ -293,7 +294,8 @@
                 }
                 trackingSet.clear();
 
-                if (!selectionId) {
+                const hasSelection = Array.isArray(selectionId) ? selectionId.length > 0 : !!selectionId;
+                if (!hasSelection) {
                     this.updateFlwSummary();
                     return;
                 }
@@ -324,8 +326,8 @@
                 this.selectedWorkAreas.clear();
                 this.groupWorkAreaIds.clear();
                 this.flwFilterWorkAreaIds.clear();
-                if (this.$refs.groupSelect) this.$refs.groupSelect.value = '';
-                this.selectedGroupId = null;
+                if (this.$refs.groupSelect?.tomselect) this.$refs.groupSelect.tomselect.clear();
+                this.selectedGroupIds = [];
                 this.selectedFlwFilterId = null;
                 this.updateFlwSummary();
             },

--- a/tailwind/tailwind.css
+++ b/tailwind/tailwind.css
@@ -501,7 +501,7 @@
   }
 
   .simple-toggle:checked {
-    @apply bg-green-600;
+    @apply bg-indigo-600;
   }
 
   .simple-toggle:checked::before {


### PR DESCRIPTION
## Product Description

Program managers can now filter Progress Map work areas by assignment status, Implementation Area, Work Area Group, and Payment Unit, and can assign work to multiple Work Area Groups in one action instead of one at a time. The Show Visits and Show Implementation Areas toggles were also restyled to match the rest of the filter panel.

https://dimagi.slack.com/archives/C09H7D1V1NK/p1784552995334919

## Technical Summary

https://dimagi.atlassian.net/browse/CCCT-2586

- Group assignment now posts a list of group ids as query params instead of one id in the URL path, so `get_work_areas_for_assignment` filters with `work_area_group_id__in`.
- Show Visits and Show Implementation Areas toggles moved off the hand-rolled Alpine button markup onto the shared `.simple-toggle` checkbox class already used elsewhere in the app.
- The `unassigned_only` toggle reuses that same `.simple-toggle` widget, whose checked-state color changed from green to indigo so all three toggles match.

## Safety Assurance

### Safety story

The new filters and the multi-group assignment path are additive to the existing filter set and assignment queryset, so with nothing selected the map and assignment flow behave the same as before. Tested locally on the microplanning map, including assigning multiple groups at once and each new filter individually.

### Automated test coverage

Added tests for the new filters and the multi-group assignment endpoint; full suite passes.

### QA Plan

No QA ticket needed, tested manually on local and on staging.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2609]: https://dimagi.atlassian.net/browse/CCCT-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ