### PR TITLE
Add optional Work Area Group Name column to CSV import

### DIFF
--- a/commcare_connect/microplanning/tasks.py
+++ b/commcare_connect/microplanning/tasks.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from django.contrib.gis.geos import GEOSException, GEOSGeometry
 from django.core.cache import cache
 from django.core.files.storage import default_storage
+from django.db import transaction
 from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
 
@@ -16,7 +17,7 @@ from config import celery_app
 
 from .clustering import WorkAreaGrouper
 from .const import DEFAULT_BUILDING_COUNT
-from .models import SRID, WorkArea
+from .models import SRID, WorkArea, WorkAreaGroup
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,10 @@ class WorkAreaCSVImporter:
         "state": "State",
     }
 
+    # Optional column, not part of HEADERS: only "Work Area Group Name" is exempt from
+    # the required-columns check, since a sheet is allowed to omit it entirely.
+    GROUP_NAME_HEADER = "Work Area Group Name"
+
     def __init__(self, opp_id, csv_source):
         self.opp_id = opp_id
         self.csv_source = csv_source
@@ -49,6 +54,9 @@ class WorkAreaCSVImporter:
         self.seen_slugs = set()
         self.created_count = 0
         self.existing_slugs = set()
+        self.has_group_names = False
+        # Ward to use if a given group name doesn't exist yet: the ward of its first-seen row.
+        self.group_wards = {}
 
     def _validate_all_rows(self, f):
         f.seek(0)
@@ -58,18 +66,34 @@ class WorkAreaCSVImporter:
             return False
 
         self.existing_slugs.update(WorkArea.objects.filter(opportunity_id=self.opp_id).values_list("slug", flat=True))
+        total_rows = 0
+        rows_with_group = 0
         for line_num, row in enumerate(reader, start=2):
             self._process_row(line_num, row)
+            total_rows += 1
+            group_name = self.get_group_name(row)
+            if group_name:
+                rows_with_group += 1
+                self.group_wards.setdefault(group_name, self.get_ward(row))
+
+        self.has_group_names = total_rows > 0 and rows_with_group == total_rows
+        if 0 < rows_with_group < total_rows:
+            self._add_error(
+                1,
+                _("Work Area Group Name is required for all Work Areas, or must be omitted for all."),
+            )
 
         self.existing_slugs.clear()
         return len(self.errors) == 0
 
+    @transaction.atomic
     def _stream_and_insert(self, f):
         f.seek(0)
         reader = csv.DictReader(f)
         self._normalize_headers(reader)
         batch = []
         batch_size = 5000
+        group_cache = self._resolve_work_area_groups() if self.has_group_names else {}
 
         for row in reader:
             buildings, visits = self.get_building_and_visit(row)
@@ -84,6 +108,7 @@ class WorkAreaCSVImporter:
                     building_count=buildings,
                     expected_visit_count=visits,
                     target_population=self.get_target_population(row),
+                    work_area_group=group_cache.get(self.get_group_name(row)),
                     case_properties={
                         "lga": extra_props.get("lga"),
                         "state": extra_props.get("state"),
@@ -99,6 +124,24 @@ class WorkAreaCSVImporter:
         if batch:
             WorkArea.objects.bulk_create(batch)
             self.created_count += len(batch)
+
+        if group_cache:
+            for work_area_group in group_cache.values():
+                work_area_group.update_centroid(commit=False)
+            WorkAreaGroup.objects.bulk_update(group_cache.values(), ["centroid"])
+
+    def _resolve_work_area_groups(self):
+        group_cache = {
+            group.name: group
+            for group in WorkAreaGroup.objects.filter(opportunity_id=self.opp_id, name__in=self.group_wards)
+        }
+        missing = [name for name in self.group_wards if name not in group_cache]
+        if missing:
+            created = WorkAreaGroup.objects.bulk_create(
+                [WorkAreaGroup(opportunity_id=self.opp_id, name=name, ward=self.group_wards[name]) for name in missing]
+            )
+            group_cache.update({group.name: group for group in created})
+        return group_cache
 
     def run(self):
         # --- First pass: validation only ---
@@ -116,7 +159,8 @@ class WorkAreaCSVImporter:
         return {"created": self.created_count}
 
     def _normalize_headers(self, reader):
-        canonical_by_lower = {header.lower(): header for header in self.HEADERS.values()}
+        canonical_headers = [*self.HEADERS.values(), self.GROUP_NAME_HEADER]
+        canonical_by_lower = {header.lower(): header for header in canonical_headers}
         reader.fieldnames = [canonical_by_lower.get((h or "").lower(), h) for h in (reader.fieldnames or [])]
 
     def _validate_headers(self, reader):
@@ -161,6 +205,10 @@ class WorkAreaCSVImporter:
     def get_slug(self, row):
         slug = (row.get(self.HEADERS.get("slug")) or "").strip()
         return strip_tags(slug)
+
+    def get_group_name(self, row):
+        group_name = (row.get(self.GROUP_NAME_HEADER) or "").strip()
+        return strip_tags(group_name)
 
     def _get_int(self, row, key):
         raw = row.get(self.HEADERS.get(key))
@@ -276,7 +324,7 @@ def import_work_areas_task(self, opp_id, file_name):
 class WorkAreaCSVExporter:
     HEADERS = {
         **WorkAreaCSVImporter.HEADERS,
-        "group_name": "Work Area Group Name",
+        "group_name": WorkAreaCSVImporter.GROUP_NAME_HEADER,
     }
 
     FIELD_MAP = {

--- a/commcare_connect/microplanning/tests/test_tasks.py
+++ b/commcare_connect/microplanning/tests/test_tasks.py
@@ -261,6 +261,7 @@ class TestWorkAreaCSVImporter:
         assert result["created"] == 2
         assert not WorkAreaGroup.objects.filter(opportunity=opportunity).exists()
         assert WorkArea.objects.get(slug="area-1").work_area_group is None
+        assert WorkArea.objects.get(slug="area-2").work_area_group is None
 
     def test_import_errors_when_only_some_rows_have_a_group(self, opportunity):
         rows = [

--- a/commcare_connect/microplanning/tests/test_tasks.py
+++ b/commcare_connect/microplanning/tests/test_tasks.py
@@ -7,14 +7,14 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 
 from commcare_connect.microplanning.const import DEFAULT_BUILDING_COUNT
-from commcare_connect.microplanning.models import WorkArea
+from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup
 from commcare_connect.microplanning.tasks import (
     WorkAreaCSVImporter,
     cluster_work_areas_task,
     import_work_areas_task,
     send_work_area_assignment_notification,
 )
-from commcare_connect.microplanning.tests.factories import WorkAreaFactory
+from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 from commcare_connect.opportunity.tests.factories import OpportunityAccessFactory
 
 
@@ -215,6 +215,74 @@ class TestWorkAreaCSVImporter:
         error_keys = " ".join(result["errors"].keys()).lower()
         expected_error = "Missing values for properties: lga, state"
         assert expected_error.lower() in error_keys
+
+    def build_row(self, slug, group_name=None):
+        row = [
+            slug,
+            "ward",
+            self.CENTROID,
+            self.POLYGON,
+            5,
+            "6",
+            "100",
+            "LGA1",
+            "State1",
+        ]
+        if group_name is not None:
+            row.append(group_name)
+        return row
+
+    def build_csv_with_groups(self, rows):
+        headers = self.HEADERS + [WorkAreaCSVImporter.GROUP_NAME_HEADER]
+        return self.build_csv(rows, headers=headers)
+
+    def test_import_assigns_work_area_groups_when_all_rows_have_one(self, opportunity):
+        rows = [
+            self.build_row("area-1", "group-a"),
+            self.build_row("area-2", "group-a"),
+            self.build_row("area-3", "group-b"),
+        ]
+        result = WorkAreaCSVImporter(opportunity.id, self.build_csv_with_groups(rows)).run()
+
+        assert result["created"] == 3
+        groups = {g.name: g for g in WorkAreaGroup.objects.filter(opportunity=opportunity)}
+        assert set(groups) == {"group-a", "group-b"}
+        assert WorkArea.objects.get(slug="area-1").work_area_group == groups["group-a"]
+        assert WorkArea.objects.get(slug="area-2").work_area_group == groups["group-a"]
+        assert WorkArea.objects.get(slug="area-3").work_area_group == groups["group-b"]
+        # centroid should be computed for the newly created groups
+        assert groups["group-a"].centroid is not None
+        assert groups["group-b"].centroid is not None
+
+    def test_import_without_group_column_leaves_work_areas_ungrouped(self, opportunity):
+        rows = [self.build_row("area-1"), self.build_row("area-2")]
+        result = WorkAreaCSVImporter(opportunity.id, self.build_csv(rows)).run()
+
+        assert result["created"] == 2
+        assert not WorkAreaGroup.objects.filter(opportunity=opportunity).exists()
+        assert WorkArea.objects.get(slug="area-1").work_area_group is None
+
+    def test_import_errors_when_only_some_rows_have_a_group(self, opportunity):
+        rows = [
+            self.build_row("area-1", "group-a"),
+            self.build_row("area-2", ""),
+        ]
+        result = WorkAreaCSVImporter(opportunity.id, self.build_csv_with_groups(rows)).run()
+
+        assert "errors" in result
+        error_keys = " ".join(result["errors"].keys()).lower()
+        assert "work area group name" in error_keys
+        assert WorkArea.objects.count() == 0
+        assert not WorkAreaGroup.objects.filter(opportunity=opportunity).exists()
+
+    def test_import_reuses_existing_work_area_group_with_same_name(self, opportunity):
+        existing_group = WorkAreaGroupFactory(opportunity=opportunity, name="group-a", ward="other-ward")
+        rows = [self.build_row("area-1", "group-a")]
+        result = WorkAreaCSVImporter(opportunity.id, self.build_csv_with_groups(rows)).run()
+
+        assert result["created"] == 1
+        assert WorkAreaGroup.objects.filter(opportunity=opportunity, name="group-a").count() == 1
+        assert WorkArea.objects.get(slug="area-1").work_area_group == existing_group
 
 
 @pytest.mark.django_db

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -105,6 +105,17 @@ class TestWorkAreaUpload(BaseMicroplanningFlagTest):
         assert response.status_code == 404
         assert mock_delay.call_count == 0
 
+    def test_download_template_row_matches_headers(self, client, org_user_admin, opportunity):
+        url = self.get_url(opportunity.organization.slug, opportunity.opportunity_id)
+        client.force_login(org_user_admin)
+
+        response = client.get(url)
+
+        rows = list(csv_mod.reader(io.StringIO(response.content.decode())))
+        header_row, sample_row = rows[0], rows[1]
+        assert header_row[-1] == "Work Area Group Name"
+        assert len(sample_row) == len(header_row)
+
 
 @pytest.mark.django_db
 class TestMicroplanningHomeView(BaseMicroplanningFlagTest):

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -349,7 +349,7 @@ class WorkAreaImport(View):
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="work_area_template.csv"'
         writer = csv.writer(response)
-        writer.writerow(WorkAreaCSVImporter.HEADERS.values())
+        writer.writerow([*WorkAreaCSVImporter.HEADERS.values(), WorkAreaCSVImporter.GROUP_NAME_HEADER])
         writer.writerow(
             [
                 "Work-Area-1",
@@ -359,9 +359,9 @@ class WorkAreaImport(View):
                 10,
                 12,
                 7,
-                2,
                 "LGA1",
                 "State1",
+                "Work-Area-Group-1",
             ]
         )
         return response

--- a/commcare_connect/templates/microplanning/import_work_area_modal.html
+++ b/commcare_connect/templates/microplanning/import_work_area_modal.html
@@ -49,7 +49,7 @@
             <p class="mt-3 text-sm text-gray-500 text-center">{% translate "Please fix the rows listed above and re-upload." %}</p>
           </div>
         {% elif result_data.created %}
-          <div class="mt-4 border-t border-gray-100 pt-4 text-green-600 text-center">
+          <div class="mt-4 border-t border-gray-100 pt-4 text-green-600">
             <i class="fa-solid fa-circle-check"></i> {% translate "Successfully created" %} {{ result_data.created }} {% translate "work area(s)" %}
           </div>
         {% endif %}

--- a/commcare_connect/templates/microplanning/import_work_area_modal.html
+++ b/commcare_connect/templates/microplanning/import_work_area_modal.html
@@ -96,6 +96,9 @@
                   <li>{% translate "Expected Visit Count – positive integer" %}</li>
                   <li>{% translate "LGA – name of the LGA the work area is in" %}</li>
                   <li>{% translate "State – name of the state the work area is in" %}</li>
+                  <li>
+                    {% translate "Work Area Group Name (optional): Enter a group name for every row to assign work areas directly and skip automatic clustering. Leave this column blank for every row to use automatic clustering. Do not mix blank and non-blank values." %}
+                  </li>
                 </ul>
               </div>
             </div>

--- a/commcare_connect/templates/microplanning/import_work_area_modal.html
+++ b/commcare_connect/templates/microplanning/import_work_area_modal.html
@@ -97,7 +97,7 @@
                   <li>{% translate "LGA – name of the LGA the work area is in" %}</li>
                   <li>{% translate "State – name of the state the work area is in" %}</li>
                   <li>
-                    {% translate "Work Area Group Name (optional): Enter a group name for every row to assign work areas directly and skip automatic clustering. Leave this column blank for every row to use automatic clustering. Do not mix blank and non-blank values." %}
+                    {% translate "Work Area Group Name (optional): Enter a group name for every row to assign work areas directly and skip automatic clustering. Leave this column blank for every row to use automatic clustering. Do not mix blank and filled values." %}
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
## Product Description

Work Area CSV uploads now accept an optional "Work Area Group Name" column, letting users assign pre-defined groups directly instead of relying on automatic clustering afterward.

## Technical Summary

[CCCT-2646](https://dimagi.atlassian.net/browse/CCCT-2646)

- The group column is all-or-none: every row must have a group name, or none can. A partial mix aborts the import with a single error.
- When groups are assigned this way, the existing clustering endpoint already blocks re-clustering (it errors out if groups already exist for the opportunity), so no extra logic was needed to skip clustering.
- The import batches group creation and centroid updates, one query per unique group set instead of one per row, to keep large imports fast.

## Safety Assurance

### Safety story

Tested manually on local: uploaded CSVs through the actual upload view and Celery task, then checked the database and map rendering for correct group assignment and centroids.

### Automated test coverage

Added importer and view tests covering grouped imports, ungrouped imports, the mixed-column error, and group reuse. All passing.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2646]: https://dimagi.atlassian.net/browse/CCCT-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ