### PR TITLE
Work Area Group Selection Mode in Microplanning Map

### DIFF
--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -138,8 +138,8 @@
           <span id="toast-message"></span>
         </div>
         {% if assignment_mode %}
-          <div x-show="hoveringWorkArea"
-               x-effect="if (hoveringWorkArea) { clearTimeout(hintTimeout); hintTimeout = setTimeout(() => hoveringWorkArea = false, 3000) }"
+          <div x-show="isHoveringWorkArea"
+               x-effect="if (isHoveringWorkArea) { clearTimeout(hintTimeout); hintTimeout = setTimeout(() => isHoveringWorkArea = false, 3000) }"
                x-cloak
                class="absolute top-4 right-2 z-40 pointer-events-none px-2 py-2 rounded-md shadow-lg border border-white/10 text-sm text-white bg-black/50">
             {% translate "Click to select group · Shift+click to select single area" %}

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -137,6 +137,14 @@
           <i id="toast-icon" class="text-lg"></i>
           <span id="toast-message"></span>
         </div>
+        {% if assignment_mode %}
+          <div x-show="hoveringWorkArea"
+               x-effect="if (hoveringWorkArea) { clearTimeout(hintTimeout); hintTimeout = setTimeout(() => hoveringWorkArea = false, 3000) }"
+               x-cloak
+               class="absolute top-4 right-2 z-40 pointer-events-none px-2 py-2 rounded-md shadow-lg border border-white/10 text-sm text-white bg-black/50">
+            {% translate "Click to select group · Shift+click to select single area" %}
+          </div>
+        {% endif %}
         <div id="map" class="w-full h-full"></div>
       </div>
       <!-- Sidebars (stacked) -->

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -266,6 +266,41 @@
                 this.updateFlwSummary();
             },
 
+            // Selects/deselects an entire Work Area Group with one click.
+            async toggleGroupSelection(groupId, fallbackId, fallbackProperties) {
+                if (groupId == null) {
+                    this.toggleWorkAreaSelection(fallbackId, fallbackProperties);
+                    return;
+                }
+
+                let workAreas;
+                try {
+                    const url = '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId);
+                    const resp = await fetch(url);
+                    const data = await resp.json();
+                    workAreas = data.work_areas;
+                } catch (e) {
+                    this.showToast("{% translate 'Failed to load group work areas' %}", true);
+                    return;
+                }
+
+                // Any member already selected (even after a shift+click removed one) counts
+                // as "this group is selected" - a plain click anywhere in it deselects the
+                // whole group rather than just filling in the missing member.
+                const hasAnySelected = workAreas.some(wa => this.selectedWorkAreas.has(wa.id));
+
+                for (const wa of workAreas) {
+                    this.workAreaProperties.set(wa.id, wa);
+                    if (hasAnySelected) {
+                        this.selectedWorkAreas.delete(wa.id);
+                    } else {
+                        this.selectedWorkAreas.add(wa.id);
+                    }
+                    this.setWorkAreaState(wa.id, { assignment_selected: !hasAnySelected });
+                }
+                this.updateFlwSummary();
+            },
+
             selectGroup(groupId) {
                 this.selectedGroupId = groupId || null;
                 return this.replaceFilterSelection({
@@ -686,6 +721,10 @@
                 // navigation ui on left of the map
                 MapboxUtils.addNavigation(this.map, 'top-left');
 
+                // Mapbox binds shift+drag to box-zoom by default, which intercepts the
+                // mousedown/click sequence before our shift+click work-area handler sees it.
+                this.map.boxZoom.disable();
+
                 await new Promise(resolve => this.map.once('load', resolve));
 
                 // Workareas are served using django-vectortiles,
@@ -945,9 +984,14 @@
                     if (!feature || feature.id == null) return;
                     const id = feature.id;
 
-                    // In assignment mode, toggle multi-select instead of single-select
+                    // In assignment mode: plain click selects/deselects the whole Work Area
+                    // Group by default; shift+click targets just this one work area.
                     if (this.assignmentMode) {
-                        this.toggleWorkAreaSelection(id, feature.properties);
+                        if (e.originalEvent.shiftKey) {
+                            this.toggleWorkAreaSelection(id, feature.properties);
+                        } else {
+                            this.toggleGroupSelection(feature.properties.group_id, id, feature.properties);
+                        }
                         return;
                     }
 

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -32,6 +32,7 @@
             showOnlyUnassigned: false,
             assignees: [],
             workAreaProperties: new Map(),
+            groupWorkAreasCache: new Map(),
             assignmentQueue: [],
             excludedWorkAreaIds: new Set(),
 
@@ -239,47 +240,68 @@
 
             // --- Assignment mode methods ---
 
-            toggleWorkAreaSelection(id, properties) {
-                const isDeselecting = this.selectedWorkAreas.has(id);
-                if (isDeselecting) {
+            // Adds/removes a single work area from the assignment selection. Both single-WA
+            // and whole-group selection go through this one place so the group filter
+            // dropdown's own tracked selection can't drift from the actual selection: if this
+            // change breaks coherence with the dropdown-selected group (deselecting one of its
+            // members, or selecting one outside it), the dropdown's tracking is cleared too.
+            setWorkAreaSelected(id, selected) {
+                if (selected) {
+                    this.selectedWorkAreas.add(id);
+                } else {
                     this.selectedWorkAreas.delete(id);
                     this.flwFilterWorkAreaIds.delete(id);
-                } else {
-                    this.selectedWorkAreas.add(id);
-                    if (properties) {
-                        this.workAreaProperties.set(id, properties);
-                    }
                 }
 
-                // Clear group dropdown if the map click breaks the group selection:
-                // either deselecting a WA inside the group, or selecting one outside it
                 if (this.selectedGroupId) {
                     const isGroupWa = this.groupWorkAreaIds.has(id);
-                    if ((isDeselecting && isGroupWa) || (!isDeselecting && !isGroupWa)) {
+                    if ((!selected && isGroupWa) || (selected && !isGroupWa)) {
                         this.groupWorkAreaIds.clear();
                         this.selectedGroupId = null;
                         if (this.$refs.groupSelect) this.$refs.groupSelect.value = '';
                     }
                 }
 
-                this.setWorkAreaState(id, { assignment_selected: this.selectedWorkAreas.has(id) });
+                this.setWorkAreaState(id, { assignment_selected: selected });
+            },
+
+            toggleWorkAreaSelection(id, properties) {
+                const isSelecting = !this.selectedWorkAreas.has(id);
+                if (isSelecting && properties) {
+                    this.workAreaProperties.set(id, properties);
+                }
+                this.setWorkAreaSelected(id, isSelecting);
                 this.updateFlwSummary();
             },
 
-            // Selects/deselects an entire Work Area Group with one click.
-            async toggleGroupSelection(groupId, fallbackId, fallbackProperties) {
-                if (groupId == null) {
-                    this.toggleWorkAreaSelection(fallbackId, fallbackProperties);
-                    return;
+            // Fetches (and caches) a group's work areas. Concurrent or repeat calls for the
+            // same group share one in-flight/cached request instead of re-fetching, since
+            // group membership doesn't change during a session.
+            async fetchGroupWorkAreas(groupId) {
+                if (!this.groupWorkAreasCache.has(groupId)) {
+                    const url = '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId);
+                    const promise = fetch(url)
+                        .then(resp => {
+                            if (!resp.ok) throw new Error(`Failed to load group work areas (status ${resp.status})`);
+                            return resp.json();
+                        })
+                        .then(data => data.work_areas)
+                        .catch(e => {
+                            this.groupWorkAreasCache.delete(groupId);
+                            throw e;
+                        });
+                    this.groupWorkAreasCache.set(groupId, promise);
                 }
+                return this.groupWorkAreasCache.get(groupId);
+            },
 
+            // Selects/deselects an entire Work Area Group with one click.
+            async toggleGroupSelection(groupId) {
                 let workAreas;
                 try {
-                    const url = '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId);
-                    const resp = await fetch(url);
-                    const data = await resp.json();
-                    workAreas = data.work_areas;
+                    workAreas = await this.fetchGroupWorkAreas(groupId);
                 } catch (e) {
+                    console.error(e);
                     this.showToast("{% translate 'Failed to load group work areas' %}", true);
                     return;
                 }
@@ -291,12 +313,7 @@
 
                 for (const wa of workAreas) {
                     this.workAreaProperties.set(wa.id, wa);
-                    if (hasAnySelected) {
-                        this.selectedWorkAreas.delete(wa.id);
-                    } else {
-                        this.selectedWorkAreas.add(wa.id);
-                    }
-                    this.setWorkAreaState(wa.id, { assignment_selected: !hasAnySelected });
+                    this.setWorkAreaSelected(wa.id, !hasAnySelected);
                 }
                 this.updateFlwSummary();
             },
@@ -985,12 +1002,13 @@
                     const id = feature.id;
 
                     // In assignment mode: plain click selects/deselects the whole Work Area
-                    // Group by default; shift+click targets just this one work area.
+                    // Group by default; shift+click (or a work area with no group) targets
+                    // just this one work area.
                     if (this.assignmentMode) {
-                        if (e.originalEvent.shiftKey) {
+                        if (e.originalEvent.shiftKey || feature.properties.group_id == null) {
                             this.toggleWorkAreaSelection(id, feature.properties);
                         } else {
-                            this.toggleGroupSelection(feature.properties.group_id, id, feature.properties);
+                            this.toggleGroupSelection(feature.properties.group_id);
                         }
                         return;
                     }

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -5,7 +5,7 @@
             map: null,
             selectedFeature: null,
             highlightedWorkAreaId: null,
-            hoveringWorkArea: false,
+            isHoveringWorkArea: false,
             hintTimeout: null,
             showWorkAreaEditModal: false,
             showReviewInaccessibilityModal: false,
@@ -743,7 +743,10 @@
 
                 // Mapbox binds shift+drag to box-zoom by default, which intercepts the
                 // mousedown/click sequence before our shift+click work-area handler sees it.
-                this.map.boxZoom.disable();
+                // Only assignment mode uses shift+click, so only disable it there.
+                if (this.assignmentMode) {
+                    this.map.boxZoom.disable();
+                }
 
                 await new Promise(resolve => this.map.once('load', resolve));
 
@@ -1045,7 +1048,7 @@
                 let hoveredId = null;
                 this.map.on('mousemove', 'workareas-fill', (e) => {
                     this.map.getCanvasContainer().style.cursor = 'pointer';
-                    this.hoveringWorkArea = true;
+                    this.isHoveringWorkArea = true;
                     const feature = e.features?.[0];
                     if (!feature || feature.id == null) return;
                     const newId = feature.id;
@@ -1059,7 +1062,7 @@
 
                 this.map.on('mouseleave', 'workareas-fill', () => {
                     this.map.getCanvasContainer().style.cursor = '';
-                    this.hoveringWorkArea = false;
+                    this.isHoveringWorkArea = false;
                     if (hoveredId !== null) {
                         this.setWorkAreaState(hoveredId, { hovered: false });
                         hoveredId = null;

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -5,6 +5,8 @@
             map: null,
             selectedFeature: null,
             highlightedWorkAreaId: null,
+            hoveringWorkArea: false,
+            hintTimeout: null,
             showWorkAreaEditModal: false,
             showReviewInaccessibilityModal: false,
             showVisits: false,
@@ -978,6 +980,7 @@
                 let hoveredId = null;
                 this.map.on('mousemove', 'workareas-fill', (e) => {
                     this.map.getCanvasContainer().style.cursor = 'pointer';
+                    this.hoveringWorkArea = true;
                     const feature = e.features?.[0];
                     if (!feature || feature.id == null) return;
                     const newId = feature.id;
@@ -991,6 +994,7 @@
 
                 this.map.on('mouseleave', 'workareas-fill', () => {
                     this.map.getCanvasContainer().style.cursor = '';
+                    this.hoveringWorkArea = false;
                     if (hoveredId !== null) {
                         this.setWorkAreaState(hoveredId, { hovered: false });
                         hoveredId = null;

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -297,6 +297,10 @@
                 return this.groupWorkAreasCache.get(groupId);
             },
 
+            invalidateGroupWorkAreasCache() {
+                this.groupWorkAreasCache.clear();
+            },
+
             // Selects/deselects an entire Work Area Group with one click.
             async toggleGroupSelection(groupId) {
                 let workAreas;
@@ -564,6 +568,7 @@
                     this.showConfirmModal = false;
                     if (resp.ok) {
                         this.showToast("{% translate 'Assignment saved successfully!' %}");
+                        this.invalidateGroupWorkAreasCache();
                         this.assignmentQueue = [];
                         this.clearSelection();
                         if (this.$refs.assigneeSelect) this.$refs.assigneeSelect.value = '';
@@ -612,6 +617,7 @@
                                 props.assignee_name = null;
                             }
                         }
+                        if (unassignedIds.length > 0) this.invalidateGroupWorkAreasCache();
                         this.showUnassignModal = false;
                         // Clear the selection, then re-select any failed areas so they stay highlighted
                         // on the map for the user to inspect and retry.
@@ -715,6 +721,7 @@
                         this.setWorkAreaState(id, { status: 'EXCLUDED' });
                         this.excludedWorkAreaIds.add(id);
                     }
+                    if (excluded.length > 0) this.invalidateGroupWorkAreasCache();
                     this.showExcludeModal = false;
                     this.clearSelection();
                     if (excluded.length > 0 && skipped === 0) {

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -306,14 +306,17 @@
                     return;
                 }
 
-                // Any member already selected (even after a shift+click removed one) counts
-                // as "this group is selected" - a plain click anywhere in it deselects the
-                // whole group rather than just filling in the missing member.
-                const hasAnySelected = workAreas.some(wa => this.selectedWorkAreas.has(wa.id));
+                // A majority of the group already selected (e.g. all but one, after a
+                // shift+click removed a member) counts as "this group is selected" - a plain
+                // click deselects the rest. A minority selected (e.g. a couple of WAs picked
+                // one at a time via shift+click, starting from none) counts as "not selected" -
+                // a plain click fills in the rest instead of wiping out what's there.
+                const selectedCount = workAreas.filter(wa => this.selectedWorkAreas.has(wa.id)).length;
+                const isMajoritySelected = selectedCount > workAreas.length / 2;
 
                 for (const wa of workAreas) {
                     this.workAreaProperties.set(wa.id, wa);
-                    this.setWorkAreaSelected(wa.id, !hasAnySelected);
+                    this.setWorkAreaSelected(wa.id, !isMajoritySelected);
                 }
                 this.updateFlwSummary();
             },

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -278,6 +278,8 @@
             // same group share one in-flight/cached request instead of re-fetching, since
             // group membership doesn't change during a session.
             async fetchGroupWorkAreas(groupId) {
+                // Normalize to string for consistency from different callers
+                groupId = String(groupId);
                 if (!this.groupWorkAreasCache.has(groupId)) {
                     const url = '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId);
                     const promise = fetch(url)
@@ -326,7 +328,7 @@
                 return this.replaceFilterSelection({
                     trackingSet: this.groupWorkAreaIds,
                     selectionId: groupId,
-                    url: '{{ group_work_areas_url|escapejs }}'.replace('__group_id__', groupId),
+                    fetchWorkAreas: () => this.fetchGroupWorkAreas(groupId),
                     errorMsg: "{% translate 'Failed to load group work areas' %}",
                 });
             },
@@ -336,13 +338,18 @@
                 return this.replaceFilterSelection({
                     trackingSet: this.flwFilterWorkAreaIds,
                     selectionId: assigneeId,
-                    url: '{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId),
+                    fetchWorkAreas: () => fetch('{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId))
+                        .then(resp => {
+                            if (!resp.ok) throw new Error(`Failed to load FLW work areas (status ${resp.status})`);
+                            return resp.json();
+                        })
+                        .then(data => data.work_areas),
                     errorMsg: "{% translate 'Failed to load FLW work areas' %}",
                 });
             },
 
             // Replaces the selection contributed by one filter (a group or an FLW).
-            async replaceFilterSelection({ trackingSet, selectionId, url, errorMsg }) {
+            async replaceFilterSelection({ trackingSet, selectionId, fetchWorkAreas, errorMsg }) {
                 for (const id of trackingSet) {
                     this.selectedWorkAreas.delete(id);
                     this.setWorkAreaState(id, { assignment_selected: false });
@@ -359,9 +366,8 @@
                 // count the FLW's own existing areas as "new" and inflate the total.
                 this.flwSummaryLoading = true;
                 try {
-                    const resp = await fetch(url);
-                    const data = await resp.json();
-                    for (const wa of data.work_areas) {
+                    const workAreas = await fetchWorkAreas();
+                    for (const wa of workAreas) {
                         this.selectedWorkAreas.add(wa.id);
                         trackingSet.add(wa.id);
                         this.workAreaProperties.set(wa.id, wa);


### PR DESCRIPTION
## Product Description

<img width="936" height="367" alt="Screenshot 2026-07-23 at 3 36 21 PM" src="https://github.com/user-attachments/assets/5096b614-8cf7-4ee0-9fda-6d16a2038de1" />

In Assignment Mode on the microplanning map, work area selection now defaults to selecting a whole Work Area Group (WAG) instead of a single work area:

- Click a work area → selects/deselects its entire WAG (all member work areas at once). Clicking another WAG adds it to the selection — previous selections are kept, not replaced.
- Shift+click a work area → selects/deselects just that single work area, without touching the rest of its group. This preserves the original click-to-select-one-area behavior as an explicit option.
- Clicking a work area inside an already-selected WAG deselects the whole group; shift+clicking one WA out of a selected WAG removes just that one, leaving the rest selected.
- A hint ("Click to select group · Shift+click to select single area") appears briefly on hover to make the new interaction discoverable.
- The existing "Select Work Area Group" and assignee filter dropdowns are unchanged — they still work exactly as before, independently of map clicks.
- View Mode is unaffected — this change is scoped to Assignment Mode only, confirmed with product since WAGs there are already visually distinguishable by color and the sidebar shows group info on click.


## Technical Summary

https://dimagi.atlassian.net/browse/CCCT-2647

- Click handling (map_handler.html): the assignment-mode click handler now branches on shiftKey — plain click calls toggleGroupSelection(groupId), shift+click (or a work area with no group) calls the existing toggleWorkAreaSelection(id, properties).
- Group selection (toggleGroupSelection/fetchGroupWorkAreas): fetches a group's work area ids from the existing group_work_areas_url endpoint (the same one the filter dropdown already uses), cached per group_id so repeat/rapid clicks on the same group share one request instead of re-fetching or racing. Toggle direction is based on whether a majority of the group is currently selected (deselect all) vs. not (select all) — a straight "any selected" check misfired when building up a partial selection via shift+click from empty, since it couldn't distinguish that from "shift+click removed one member from a full group."
- Shared selection primitive (setWorkAreaSelected(id, selected)): both single-WA and whole-group selection now go through one method that mutates selectedWorkAreas and keeps the group filter dropdown's own tracked selection (selectedGroupId/groupWorkAreaIds) in sync — previously only the single-WA path did this, so a map click that diverged from a dropdown-selected group could leave the dropdown's selection stale and its work areas un-clearable.
- boxZoom: Mapbox's default shift+drag box-zoom handler was intercepting the shift+click sequence, so it's disabled (map.boxZoom.disable()), scoped to assignment mode only since that's the only place shift+click is used.
- Hover hint: a new isHoveringWorkArea boolean (naming matches the existing is*/show* convention) toggled by the map's mousemove/mouseleave handlers, with auto-dismiss after 3s handled declaratively via x-effect on the hint element in home.html.
- No changes to View Mode, the filter dropdowns' own selection logic, or backend endpoints — this is a client-side (Alpine/Mapbox) interaction change only.


## Safety Assurance

### Safety story

Tested locally, will be QAed

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

Full assignment-mode will be QAed for this feature along with regressions

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
