### PR TITLE
Program/opportunity role data model changes

### DIFF
--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -30,6 +30,7 @@ from commcare_connect.program.models import Program
 
 class OpportunityDataExportSerializer(serializers.ModelSerializer):
     organization = serializers.SlugRelatedField(read_only=True, slug_field="slug")
+    supervising_organization = serializers.SlugRelatedField(read_only=True, slug_field="slug")
     program = serializers.SerializerMethodField()
     visit_count = serializers.SerializerMethodField()
 
@@ -40,6 +41,7 @@ class OpportunityDataExportSerializer(serializers.ModelSerializer):
             "name",
             "date_created",
             "organization",
+            "supervising_organization",
             "end_date",
             "is_active",
             "program",
@@ -56,17 +58,19 @@ class OpportunityDataExportSerializer(serializers.ModelSerializer):
 class OrganizationDataExportSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization
-        fields = ["id", "slug", "name"]
+        fields = ["id", "slug", "name", "funder"]
 
 
 class ProgramDataExportSerializer(serializers.ModelSerializer):
     organization = serializers.SlugRelatedField(read_only=True, slug_field="slug")
+    funder = serializers.SlugRelatedField(read_only=True, slug_field="slug")
+    watchers = serializers.SlugRelatedField(read_only=True, slug_field="slug", many=True)
     delivery_type = serializers.SlugRelatedField(read_only=True, slug_field="slug")
     currency = serializers.CharField(source="currency_id", read_only=True)
 
     class Meta:
         model = Program
-        fields = ["id", "name", "delivery_type", "currency", "organization"]
+        fields = ["id", "name", "delivery_type", "currency", "organization", "funder", "watchers"]
 
 
 class OpportunityUserDataSerializer(serializers.Serializer):

--- a/commcare_connect/opportunity/migrations/0140_opportunity_supervising_organization.py
+++ b/commcare_connect/opportunity/migrations/0140_opportunity_supervising_organization.py
@@ -1,0 +1,56 @@
+import django.db.models.deletion
+from django.db import migrations, models
+from django.db.models import F, OuterRef, Subquery
+
+
+def backfill_supervising_organization(apps, schema_editor):
+    Opportunity = apps.get_model("opportunity", "Opportunity")
+    Program = apps.get_model("program", "Program")
+    # Program-linked (managed) opportunities inherit the program's owning organization.
+    Opportunity.objects.filter(program__isnull=False, supervising_organization__isnull=True).update(
+        supervising_organization_id=Subquery(
+            Program.objects.filter(pk=OuterRef("program_id")).values("organization_id")[:1]
+        )
+    )
+    # Any remaining opportunities (no program) supervise themselves.
+    Opportunity.objects.filter(supervising_organization__isnull=True).update(
+        supervising_organization_id=F("organization_id")
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("organization", "0010_organizationinvite_and_more"),
+        ("opportunity", "0139_uservisit_status_modified_date_and_review_status"),
+        ("program", "0015_rename_managedopportunity_program_to_program_old"),
+    ]
+
+    operations = [
+        # Step 1: add the column as nullable so it can be populated on existing rows.
+        migrations.AddField(
+            model_name="opportunity",
+            name="supervising_organization",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="supervised_opportunities",
+                to="organization.organization",
+            ),
+        ),
+        # Step 2: backfill from the program's owning organization.
+        migrations.RunPython(
+            backfill_supervising_organization,
+            migrations.RunPython.noop,
+            hints={"run_on_secondary": False},
+        ),
+        # Step 3: enforce non-null now that every row has a value.
+        migrations.AlterField(
+            model_name="opportunity",
+            name="supervising_organization",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="supervised_opportunities",
+                to="organization.organization",
+            ),
+        ),
+    ]

--- a/commcare_connect/opportunity/migrations/0140_opportunity_supervising_organization.py
+++ b/commcare_connect/opportunity/migrations/0140_opportunity_supervising_organization.py
@@ -1,20 +1,17 @@
 import django.db.models.deletion
 from django.db import migrations, models
-from django.db.models import F, OuterRef, Subquery
+from django.db.models import OuterRef, Subquery
 
 
 def backfill_supervising_organization(apps, schema_editor):
+    # Every opportunity is program-linked as of 0134_add_program_fk_to_opportunity, so the
+    # supervising organization is always the program's owning organization.
     Opportunity = apps.get_model("opportunity", "Opportunity")
     Program = apps.get_model("program", "Program")
-    # Program-linked (managed) opportunities inherit the program's owning organization.
-    Opportunity.objects.filter(program__isnull=False, supervising_organization__isnull=True).update(
+    Opportunity.objects.filter(supervising_organization__isnull=True).update(
         supervising_organization_id=Subquery(
             Program.objects.filter(pk=OuterRef("program_id")).values("organization_id")[:1]
         )
-    )
-    # Any remaining opportunities (no program) supervise themselves.
-    Opportunity.objects.filter(supervising_organization__isnull=True).update(
-        supervising_organization_id=F("organization_id")
     )
 
 

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -121,7 +121,21 @@ class Opportunity(BaseModel):
     delivery_type = models.ForeignKey(DeliveryType, null=True, blank=True, on_delete=models.DO_NOTHING)
     managed = models.BooleanField(default=False)
     program = models.ForeignKey("program.Program", on_delete=models.DO_NOTHING, null=True)
+    supervising_organization = models.ForeignKey(
+        Organization,
+        on_delete=models.PROTECT,
+        related_name="supervised_opportunities",
+    )
     hq_server = models.ForeignKey(HQServer, on_delete=models.DO_NOTHING, null=True)
+
+    def save(self, *args, **kwargs):
+        # Until the UI allows setting a supervising organization, default it to the program's
+        # owning organization (or the opportunity's own organization when there is no program).
+        if not self.supervising_organization_id:
+            self.supervising_organization_id = (
+                self.program.organization_id if self.program_id else self.organization_id
+            )
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return self.name

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -130,11 +130,9 @@ class Opportunity(BaseModel):
 
     def save(self, *args, **kwargs):
         # Until the UI allows setting a supervising organization, default it to the program's
-        # owning organization (or the opportunity's own organization when there is no program).
+        # owning organization.
         if not self.supervising_organization_id:
-            self.supervising_organization_id = (
-                self.program.organization_id if self.program_id else self.organization_id
-            )
+            self.supervising_organization_id = self.program.organization_id
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/commcare_connect/opportunity/tests/factories.py
+++ b/commcare_connect/opportunity/tests/factories.py
@@ -62,6 +62,7 @@ class OpportunityFactory(DjangoModelFactory):
     country = LazyFunction(lambda: Country.objects.get(code="USA"))
     hq_server = SubFactory(HQServerFactory)
     program = SubFactory("commcare_connect.program.tests.factories.ProgramFactory")
+    supervising_organization = LazyAttribute(lambda o: o.program.organization if o.program else o.organization)
 
     class Meta:
         model = "opportunity.Opportunity"

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -36,8 +36,9 @@ from commcare_connect.opportunity.tests.factories import (
 )
 from commcare_connect.opportunity.utils.invoice import generate_invoice_number
 from commcare_connect.opportunity.visit_import import update_payment_accrued
+from commcare_connect.program.tests.factories import ProgramFactory
 from commcare_connect.users.models import User
-from commcare_connect.users.tests.factories import MobileUserFactory
+from commcare_connect.users.tests.factories import MobileUserFactory, OrganizationFactory
 from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 
 
@@ -446,6 +447,38 @@ class TestAssignedTaskDeleteAndResetHQ:
             AssignedTask.bulk_delete([task_a.pk, task_b.pk], access.opportunity)
 
         mock_update.assert_called_once_with({access: {"properties": {"prop_a": "", "prop_b": ""}}})
+
+
+@pytest.mark.django_db
+class TestSupervisingOrganizationDefault:
+    """Until the UI allows setting it, new opportunities default their supervising organization."""
+
+    def test_defaults_to_program_organization(self):
+        program = ProgramFactory()
+        opp = Opportunity(organization=OrganizationFactory(), program=program, name="opp", description="desc")
+        opp.save()
+        opp.refresh_from_db()
+        assert opp.supervising_organization == program.organization
+
+    def test_defaults_to_own_organization_without_program(self):
+        org = OrganizationFactory()
+        opp = Opportunity(organization=org, program=None, name="opp", description="desc")
+        opp.save()
+        opp.refresh_from_db()
+        assert opp.supervising_organization == org
+
+    def test_does_not_override_explicit_supervisor(self):
+        supervisor = OrganizationFactory()
+        opp = Opportunity(
+            organization=OrganizationFactory(),
+            program=ProgramFactory(),
+            supervising_organization=supervisor,
+            name="opp",
+            description="desc",
+        )
+        opp.save()
+        opp.refresh_from_db()
+        assert opp.supervising_organization == supervisor
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -460,13 +460,6 @@ class TestSupervisingOrganizationDefault:
         opp.refresh_from_db()
         assert opp.supervising_organization == program.organization
 
-    def test_defaults_to_own_organization_without_program(self):
-        org = OrganizationFactory()
-        opp = Opportunity(organization=org, program=None, name="opp", description="desc")
-        opp.save()
-        opp.refresh_from_db()
-        assert opp.supervising_organization == org
-
     def test_does_not_override_explicit_supervisor(self):
         supervisor = OrganizationFactory()
         opp = Opportunity(

--- a/commcare_connect/organization/migrations/0011_organization_funder.py
+++ b/commcare_connect/organization/migrations/0011_organization_funder.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("organization", "0010_organizationinvite_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="organization",
+            name="funder",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/commcare_connect/organization/models.py
+++ b/commcare_connect/organization/models.py
@@ -30,6 +30,7 @@ class Organization(BaseModel):
         settings.AUTH_USER_MODEL, related_name="organizations", through="UserOrganizationMembership"
     )
     program_manager = models.BooleanField(default=False)
+    funder = models.BooleanField(default=False)
     llo_entity = models.ForeignKey(LLOEntity, on_delete=models.SET_NULL, null=True)
 
     def save(self, *args, **kwargs):

--- a/commcare_connect/program/migrations/0016_program_funder_program_watchers.py
+++ b/commcare_connect/program/migrations/0016_program_funder_program_watchers.py
@@ -1,0 +1,32 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("organization", "0011_organization_funder"),
+        ("program", "0015_rename_managedopportunity_program_to_program_old"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="program",
+            name="funder",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="funded_programs",
+                to="organization.organization",
+            ),
+        ),
+        migrations.AddField(
+            model_name="program",
+            name="watchers",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="watched_programs",
+                to="organization.organization",
+            ),
+        ),
+    ]

--- a/commcare_connect/program/models.py
+++ b/commcare_connect/program/models.py
@@ -20,6 +20,14 @@ class Program(BaseModel):
     start_date = models.DateField()
     end_date = models.DateField()
     organization = models.ForeignKey(Organization, on_delete=models.PROTECT)
+    funder = models.ForeignKey(
+        Organization,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="funded_programs",
+    )
+    watchers = models.ManyToManyField(Organization, related_name="watched_programs", blank=True)
 
     def save(self, *args, **kwargs):
         if not self.id:

--- a/commcare_connect/users/admin.py
+++ b/commcare_connect/users/admin.py
@@ -72,11 +72,11 @@ class UserOrganizationMembershipInline(admin.TabularInline):
 @admin.register(Organization)
 class OrganizationAdmin(admin.ModelAdmin):
     form = OrganizationCreationForm
-    list_display = ["name", "created_by", "program_manager"]
+    list_display = ["name", "created_by", "program_manager", "funder"]
     search_fields = ["name"]
     ordering = ["name"]
     inlines = [UserOrganizationMembershipInline]
-    list_filter = ["program_manager"]
+    list_filter = ["program_manager", "funder"]
 
 
 @admin.register(ConnectIDUserLink)


### PR DESCRIPTION
## Product Description
Only model changes in this PR.

- Added supervising_organization field on Opportunity model.
- Added funder (boolean field) on Organization Model
- Added funder (organization FK 1-1) on Program Model
- Added watchers (organization FK M-M) on Program Model.


## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2557)

## Safety Assurance
### Safety story
- Mostly model changes, tests exist for other changes that were made.

### Automated test coverage
- Automated Tests added.

### QA Plan
- No QA, backend only ticket. QA would test these changes once we have the UI tickets ready.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
