### PR TITLE
feat(prelogin): add EA Forum and KMC blog press tiles

### DIFF
--- a/commcare_connect/static/prelogin/styles.css
+++ b/commcare_connect/static/prelogin/styles.css
@@ -10214,12 +10214,12 @@ a.explore-card:hover {
   padding: clamp(60px, 6vw, 96px) 0;
 }
 .os-origins .wrap {
-  max-width: 1080px;
+  max-width: 1320px;
 }
 .os-origins-grid {
   display: grid;
-  grid-template-columns: 1.35fr 1fr;
-  gap: 48px;
+  grid-template-columns: 1.6fr 0.85fr 0.85fr;
+  gap: 32px;
   align-items: stretch;
 }
 .os-origins-story {
@@ -10252,9 +10252,10 @@ a.explore-card:hover {
   text-decoration-color: var(--indigo);
 }
 
-/* Devex press feature card */
+/* Press feature cards (Devex + further reading) */
 .os-press-card {
   display: flex;
+  position: relative;
 }
 .os-press-link {
   display: flex;
@@ -10313,6 +10314,22 @@ a.explore-card:hover {
 .os-press-link:hover .os-press-cta {
   color: var(--indigo-deep);
 }
+/* Temporary launch marker for the two press tiles added 2026-07 (EA Forum,
+   Dimagi KMC blog). Remove the `is-new` class from both once they've aged out. */
+.os-press-card.is-new::after {
+  content: 'NEW';
+  position: absolute;
+  top: -9px;
+  right: 12px;
+  background: var(--mango);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  z-index: 1;
+}
 
 /* Funders & investors row */
 .os-funders {
@@ -10363,7 +10380,39 @@ a.explore-card:hover {
   transform: translateY(-2px);
 }
 
+/* KMC portfolio page: "closing the post-discharge gap" further-reading band.
+   Reuses the .os-press-card component at its default (full) size. */
+.section.kmc-press-band {
+  background: var(--paper-warm);
+}
+.kmc-press-grid {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: 48px;
+  align-items: stretch;
+}
+.kmc-press-text {
+  align-self: center;
+}
+.kmc-press-text h2 {
+  font-size: var(--fs-h2);
+  font-weight: 300;
+  margin: 0 0 20px;
+}
+.kmc-press-text p {
+  color: var(--ink-3);
+  font-size: var(--fs-lede);
+  line-height: 1.6;
+  font-weight: 300;
+  max-width: 54ch;
+  margin: 0;
+}
+
 @media (max-width: 860px) {
+  .kmc-press-grid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
   .os-origins-grid {
     grid-template-columns: 1fr;
     gap: 32px;

--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -1430,6 +1430,27 @@
     </div>
   </div>
 
+  <div class="section kmc-press-band">
+    <div class="wrap">
+      <div class="kmc-press-grid">
+        <div class="kmc-press-text">
+          <span class="eyebrow">FURTHER READING</span>
+          <h2>Closing the <em>post-discharge gap</em>.</h2>
+          <p>80% of neonatal deaths happen after discharge, at home, without follow-up. Read how Connect Kangaroo Mother Care closes that gap for small and vulnerable newborns in their first 60 days.</p>
+        </div>
+        <aside class="os-press-card is-new" aria-label="Further reading: Dimagi blog post on closing the post-discharge gap">
+          <a class="os-press-link" href="https://dimagi.com/closing-post-discharge-gap-kangaroo-mother-care/" target="_blank" rel="noopener">
+            <span class="os-press-kicker">From the</span>
+            <span class="os-press-source">Dimagi Blog</span>
+            <p class="os-press-headline">&#x201C;Closing the Post-Discharge Gap with Connect Kangaroo Mother Care&#x201D;</p>
+            <span class="os-press-meta">Lilianna Bagnoli &middot; November 2025</span>
+            <span class="os-press-cta">Read the article &#x2197;</span>
+          </a>
+        </aside>
+      </div>
+    </div>
+  </div>
+
   <div class="stats-cool">
     <div class="wrap">
       <div class="sec-head">
@@ -3374,7 +3395,7 @@
     </div>
   </div>
 
-  <!-- ── THE ORIGINS OF CONNECT: founding story + Devex feature ── -->
+  <!-- ── THE ORIGINS OF CONNECT: founding story + press features ── -->
   <div class="section os-origins">
     <div class="wrap">
       <div class="os-origins-grid">
@@ -3390,6 +3411,16 @@
             <span class="os-press-source">Devex</span>
             <p class="os-press-headline">&#x201C;Could this app transform delivery of last-mile health services?&#x201D;</p>
             <span class="os-press-meta">Catherine Cheney &middot; January 2023</span>
+            <span class="os-press-cta">Read the article &#x2197;</span>
+          </a>
+        </aside>
+
+        <aside class="os-press-card is-new" aria-label="Further reading: EA Forum essay on locally-led organizations">
+          <a class="os-press-link" href="https://forum.effectivealtruism.org/posts/ZDXmNYyhbpHJxHtHf/the-overlooked-absorptive-capacity-of-locally-led-1" target="_blank" rel="noopener">
+            <span class="os-press-kicker">Posted on the</span>
+            <span class="os-press-source">EA Forum</span>
+            <p class="os-press-headline">&#x201C;The Overlooked Absorptive Capacity of Locally-Led Organizations&#x201D;</p>
+            <span class="os-press-meta">Neal Lesh &amp; Jonathan Jackson &middot; July 2026</span>
             <span class="os-press-cta">Read the article &#x2197;</span>
           </a>
         </aside>


### PR DESCRIPTION
## Product Description

Adds two new "further reading" links to the marketing site (connect.dimagi.com):

- A second press-style tile next to the existing Devex feature in the "Origins of Connect" section, linking to the co-founders' EA Forum essay, *"The Overlooked Absorptive Capacity of Locally-Led Organizations."*
- A new "Closing the post-discharge gap" tile on the Kangaroo Mother Care portfolio page (`/portfolio/kangaroo-mother-care`), linking to the Dimagi blog post on the same topic.

Both open in a new tab and carry a small "NEW" badge (temporary — remove once they've aged out).

## Technical Summary

Promotion of [dimagi-internal/connect-labs#987](https://github.com/dimagi-internal/connect-labs/pull/987), already reviewed, merged, and verified live on labs (labs is this site's staging environment/source of truth — see `docs/prelogin-marketing-site.md` there).

Pure `home.html` template + `styles.css` changes, no backend/JS logic touched:

- `.os-origins-grid` widened from a 2-column (text + 1 card) to a 3-column layout (text + 2 cards): `max-width` 1080px → 1320px, columns `1.35fr 1fr` → `1.6fr 0.85fr 0.85fr`.
- New `.kmc-press-band` section (reuses the existing `.os-press-card` component at its default size) inserted between "Inside a KMC visit" and "At a glance" on the KMC portfolio page.
- `.os-press-card.is-new` adds a small "NEW" ribbon via `::after`, used on both new tiles.

This PR applies only the scoped diff for these two tiles (not a full directory sync from labs) — `commcare_connect/prelogin/`, `contact.html`, `app.js`, and `contact-form.js` have other unrelated labs changes not yet promoted, and are intentionally left untouched here to keep this PR scoped to the press tiles.

## Safety Assurance

### Safety story

Content-only change to a public, unauthenticated marketing page — no data model, view, or auth logic touched. Already merged and verified rendering correctly on labs (connect-labs PR #987, including live template-engine render checks and a design review loop with the requester).

Independent 5-agent review (design, quality, security, smells, maintainability) was run against this diff on the labs side before merge. No security issues found. One dead-CSS block was identified and removed there; that fix is included in this promoted diff.

### Automated test coverage

`commcare_connect/prelogin/tests/test_views.py` covers route rendering (status codes, brand-text presence) but doesn't assert on this specific content; not re-run in this session (no local dev environment/DB set up for this repo here) since the change is additive HTML/CSS with no routing or logic impact. Recommend a reviewer run the existing prelogin test suite locally before merge as a sanity check.

### QA Plan

After merge/deploy, verify on connect.dimagi.com: home page shows both press tiles side-by-side in "The Origins of Connect" section, and `/portfolio/kangaroo-mother-care` shows the new "Closing the post-discharge gap" tile between "Inside a KMC visit" and "At a glance". Confirm both new links open in a new tab and layout holds at the existing 860px mobile breakpoint.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change