### PR TITLE
Use waffle's flag_is_active instead of custom is_flag_active

### DIFF
--- a/commcare_connect/flags/tests/test_flag_models.py
+++ b/commcare_connect/flags/tests/test_flag_models.py
@@ -1,5 +1,7 @@
 import pytest
 from django.core.cache import cache
+from django.test import RequestFactory
+from waffle import flag_is_active
 
 from commcare_connect.flags.models import Flag
 from commcare_connect.flags.tests.factories import FlagFactory
@@ -104,3 +106,44 @@ class TestFlagModel:
         active_flags = Flag.active_flags_for_user(user, include_role_flags=True)
         assert active_flags.count() == 2
         assert set(active_flags) == {staff_flag, everyone_flag}
+
+
+@pytest.mark.django_db
+class TestFlagIsActiveRequest:
+    def setup_method(self):
+        cache.clear()
+
+    @pytest.mark.parametrize("scope", ["opportunity", "program", "organization"])
+    def test_flag_active_for_request_scoped_to_object(self, organization, opportunity, scope):
+        flag = FlagFactory()
+        user = UserFactory()
+        MembershipFactory(user=user, organization=organization)
+
+        request = RequestFactory().get("/")
+        request.user = user
+        request.org = organization
+
+        if scope == "opportunity":
+            flag.opportunities.add(opportunity)
+            request.opportunity = opportunity
+        elif scope == "program":
+            program = ProgramFactory(organization=organization)
+            opportunity.program = program
+            opportunity.save(update_fields=["program"])
+            flag.programs.add(program)
+            request.opportunity = opportunity
+        elif scope == "organization":
+            flag.organizations.add(organization)
+
+        assert flag_is_active(request, flag.name) is True
+
+    def test_flag_not_scoped_to_request_context_is_inactive(self, organization, opportunity):
+        flag = FlagFactory()
+        flag.organizations.add(OrganizationFactory())
+
+        request = RequestFactory().get("/")
+        request.user = UserFactory()
+        request.org = organization
+        request.opportunity = opportunity
+
+        assert flag_is_active(request, flag.name) is False

--- a/commcare_connect/flags/utils.py
+++ b/commcare_connect/flags/utils.py
@@ -1,9 +1,0 @@
-from commcare_connect.flags.models import Flag
-from commcare_connect.opportunity.models import Opportunity
-from commcare_connect.organization.models import Organization
-from commcare_connect.program.models import Program
-
-
-def is_flag_active(flag_name, obj: Opportunity | Organization | Program):
-    flag, _ = Flag.objects.get_or_create(name=flag_name)
-    return flag.is_active_for(obj)

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -3048,20 +3048,22 @@ class TestOpportunityDeliveryStatsTiles:
 
         assert b"View Progress Map" in response.content
 
-    def test_audit_tile_shown_only_when_flag_scoped_to_opportunity(
-        self, client, organization, org_user_member, opportunity
-    ):
-        program = ProgramFactory(organization=organization)
-        opportunity.program = program
-        opportunity.save(update_fields=["program"])
-        Flag.objects.create(name=WEEKLY_PERFORMANCE_REPORT).programs.add(program)
+    @pytest.mark.parametrize("scope", ["opportunity", "program", "organization"])
+    def test_audit_tile_shown_when_flag_enabled(self, client, organization, org_user_member, opportunity, scope):
+        flag = Flag.objects.create(name=WEEKLY_PERFORMANCE_REPORT)
+        if scope == "opportunity":
+            flag.opportunities.add(opportunity)
+        elif scope == "program":
+            program = ProgramFactory(organization=organization)
+            opportunity.program = program
+            opportunity.save(update_fields=["program"])
+            flag.programs.add(program)
+        elif scope == "organization":
+            flag.organizations.add(organization)
 
         client.force_login(org_user_member)
         response = client.get(self._url(organization, opportunity))
-        assert b"Audit Opportunity" not in response.content
 
-        Flag.objects.get(name=WEEKLY_PERFORMANCE_REPORT).opportunities.add(opportunity)
-        response = client.get(self._url(organization, opportunity))
         assert b"Audit Opportunity" in response.content
 
     def test_tasks_tile_shown_only_with_switch_and_configured_task_type(

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -62,7 +62,6 @@ from waffle import flag_is_active, switch_is_active
 from commcare_connect.connect_id_client import fetch_users
 from commcare_connect.flags.flag_names import MICROPLANNING, WEEKLY_PERFORMANCE_REPORT
 from commcare_connect.flags.switch_names import WORKER_VISITS_TASKS
-from commcare_connect.flags.utils import is_flag_active
 from commcare_connect.form_receiver.serializers import XFormSerializer
 from commcare_connect.microplanning.models import WorkAreaInaccessibilityRequest
 from commcare_connect.opportunity.api.serializers.mobile import remove_opportunity_access_cache
@@ -2734,7 +2733,8 @@ class BaseWorkerListView(OrganizationUserMixin, OpportunityObjectMixin, View):
 
     def get(self, request, org_slug, opp_id):
         opportunity = self.get_opportunity()
-        if is_flag_active(MICROPLANNING, opportunity):
+        request.opportunity = opportunity
+        if flag_is_active(request, MICROPLANNING):
             self.tabs = self.tabs + [
                 {
                     "key": "work_areas",
@@ -2983,7 +2983,8 @@ class WorkerWorkAreaView(BaseWorkerListView):
     active_tab = "work_areas"
 
     def dispatch(self, request, *args, **kwargs):
-        if not is_flag_active(MICROPLANNING, self.get_opportunity()):
+        request.opportunity = self.get_opportunity()
+        if not flag_is_active(request, MICROPLANNING):
             raise Http404
         return super().dispatch(request, *args, **kwargs)
 
@@ -3296,7 +3297,7 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
                 "url": microplanning_url,
             }
         )
-    if is_flag_active(WEEKLY_PERFORMANCE_REPORT, request.opportunity):
+    if flag_is_active(request, WEEKLY_PERFORMANCE_REPORT):
         deliveries_panels.append(
             {
                 "icon": "fa-magnifying-glass",


### PR DESCRIPTION
## Product Description

No user-facing change.

## Technical Summary

[CCCT-2693](https://dimagi.atlassian.net/browse/CCCT-2693)

We had two feature flag helpers with different behaviour:

* `is_flag_active(name, obj)` only checked the object's direct M2M flag.
* `flag_is_active(request, name)` applied hierarchy (org → programme → opportunity) and Waffle rules.

This led to inconsistent flag evaluation depending on which helper was used. I removed `is_flag_active` and standardised all checks on `flag_is_active`, so every feature flag now follows the same evaluation path and cascade rules.


## Safety Assurance

### Safety story

Behavior is unchanged: `flag_is_active` resolves the same opportunity/program/organization scoping the old helper did. Verified locally against the updated test suite.

### Automated test coverage

Added parametrized tests covering flag scoping across opportunity, program, and organization, and updated existing view tests; all passing.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2693]: https://dimagi.atlassian.net/browse/CCCT-2693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ