### PR TITLE
Select/deselect a whole Work Area Group with one click

### DIFF
--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -1505,8 +1505,11 @@ class TestGetWorkAreasForAssignment:
         )
 
         assert response.status_code == 200
-        returned_ids = {wa["id"] for wa in response.json()["work_areas"]}
+        work_areas = response.json()["work_areas"]
+        returned_ids = {wa["id"] for wa in work_areas}
         assert returned_ids == {wa_a.id, wa_b.id}
+        group_id_by_wa_id = {wa["id"]: wa["group_id"] for wa in work_areas}
+        assert group_id_by_wa_id == {wa_a.id: group_a.id, wa_b.id: group_b.id}
 
     def test_no_group_ids_returns_empty(
         self, client, program_manager_org, program_manager_org_user_admin, managed_opportunity

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -952,7 +952,7 @@ def get_work_areas_for_assignment(request, org_slug, opp_id):
         WorkArea.objects.filter(
             opportunity=request.opportunity,
             work_area_group_id__in=group_ids,
-        ).values("id", "building_count", "expected_visit_count", "status")
+        ).values("id", "building_count", "expected_visit_count", "status", group_id=F("work_area_group_id"))
     )
     return JsonResponse({"work_areas": work_areas})
 

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -156,6 +156,14 @@
           <i id="toast-icon" class="text-lg"></i>
           <span id="toast-message"></span>
         </div>
+        {% if assignment_mode %}
+          <div x-show="isHoveringWorkArea"
+               x-effect="if (isHoveringWorkArea) { clearTimeout(hintTimeout); hintTimeout = setTimeout(() => isHoveringWorkArea = false, 3000) }"
+               x-cloak
+               class="absolute top-4 right-2 z-40 pointer-events-none px-2 py-2 rounded-md shadow-lg border border-white/10 text-sm text-white bg-black/50">
+            {% translate "Click to select group · Shift+click to select single area" %}
+          </div>
+        {% endif %}
         <div id="map" class="w-full h-full"></div>
       </div>
       <!-- Sidebars (stacked) -->

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -5,6 +5,8 @@
             map: null,
             selectedFeature: null,
             highlightedWorkAreaId: null,
+            isHoveringWorkArea: false,
+            hintTimeout: null,
             showWorkAreaEditModal: false,
             showReviewInaccessibilityModal: false,
             showVisits: false,
@@ -31,6 +33,7 @@
             showOnlyUnassigned: false,
             assignees: [],
             workAreaProperties: new Map(),
+            groupWorkAreasCache: new Map(),
             assignmentQueue: [],
             excludedWorkAreaIds: new Set(),
 
@@ -238,40 +241,143 @@
 
             // --- Assignment mode methods ---
 
-            toggleWorkAreaSelection(id, properties) {
-                const isDeselecting = this.selectedWorkAreas.has(id);
-                if (isDeselecting) {
+            // Adds/removes a single work area from the assignment selection. Both single-WA
+            // and whole-group selection go through this one place. With multi-select groups:
+            // selecting a WA that happens to complete its group (the last remaining member)
+            // syncs that group into the dropdown, same as a plain click would; deselecting a
+            // WA that belongs to a dropdown-tracked group breaks just that one group's
+            // coherence and removes only it, not every group currently selected.
+            setWorkAreaSelected(id, selected, groupId = null) {
+                groupId = groupId != null ? String(groupId) : null;
+
+                if (selected) {
+                    this.selectedWorkAreas.add(id);
+
+                    if (groupId && !this.selectedGroupIds.includes(groupId)) {
+                        // Already cached once this group's been seen before; otherwise this
+                        // is the same fetch a click on it would trigger anyway.
+                        this.fetchGroupWorkAreas(groupId).then(workAreas => {
+                            const isFullySelected = workAreas.length > 0
+                                && workAreas.every(wa => this.selectedWorkAreas.has(wa.id));
+                            if (isFullySelected) {
+                                this.syncGroupDropdown(groupId, true, workAreas);
+                            }
+                        });
+                    }
+                } else {
                     this.selectedWorkAreas.delete(id);
                     this.flwFilterWorkAreaIds.delete(id);
-                } else {
-                    this.selectedWorkAreas.add(id);
-                    if (properties) {
-                        this.workAreaProperties.set(id, properties);
+
+                    if (groupId && this.selectedGroupIds.includes(groupId) && this.groupWorkAreaIds.has(id)) {
+                        this.selectedGroupIds = this.selectedGroupIds.filter(gid => gid !== groupId);
+                        this.$refs.groupSelect?.tomselect?.removeItem(groupId, true);
+                        // Already cached (this group must have been fetched to be tracked),
+                        // so this resolves immediately without a new network request.
+                        this.fetchGroupWorkAreas(groupId).then(workAreas => {
+                            for (const wa of workAreas) this.groupWorkAreaIds.delete(wa.id);
+                        });
                     }
                 }
 
-                // Clear group dropdown if the map click breaks the group selection:
-                // either deselecting a WA inside the group, or selecting one outside it
-                if (this.selectedGroupIds.length) {
-                    const isGroupWa = this.groupWorkAreaIds.has(id);
-                    if ((isDeselecting && isGroupWa) || (!isDeselecting && !isGroupWa)) {
-                        this.groupWorkAreaIds.clear();
-                        this.selectedGroupIds = [];
-                        if (this.$refs.groupSelect?.tomselect) this.$refs.groupSelect.tomselect.clear();
-                    }
-                }
+                this.setWorkAreaState(id, { assignment_selected: selected });
+            },
 
-                this.setWorkAreaState(id, { assignment_selected: this.selectedWorkAreas.has(id) });
+            toggleWorkAreaSelection(id, properties) {
+                const isSelecting = !this.selectedWorkAreas.has(id);
+                if (isSelecting && properties) {
+                    this.workAreaProperties.set(id, properties);
+                }
+                this.setWorkAreaSelected(id, isSelecting, properties?.group_id);
                 this.updateFlwSummary();
+            },
+
+            // Fetches (and caches) a group's work areas. Concurrent or repeat calls for the
+            // same group share one in-flight/cached request instead of re-fetching, since
+            // group membership doesn't change during a session.
+            async fetchGroupWorkAreas(groupId) {
+                // Normalize to string for consistency from different callers
+                groupId = String(groupId);
+                if (!this.groupWorkAreasCache.has(groupId)) {
+                    // The endpoint takes repeatable ?group_id= query params (to support
+                    // fetching several groups in one call); a single id is just the 1-param case.
+                    const url = `{{ group_work_areas_url|escapejs }}?group_id=${encodeURIComponent(groupId)}`;
+                    const promise = fetch(url)
+                        .then(resp => {
+                            if (!resp.ok) throw new Error(`Failed to load group work areas (status ${resp.status})`);
+                            return resp.json();
+                        })
+                        .then(data => data.work_areas)
+                        .catch(e => {
+                            this.groupWorkAreasCache.delete(groupId);
+                            throw e;
+                        });
+                    this.groupWorkAreasCache.set(groupId, promise);
+                }
+                return this.groupWorkAreasCache.get(groupId);
+            },
+
+            invalidateGroupWorkAreasCache() {
+                this.groupWorkAreasCache.clear();
+            },
+
+            // Selects/deselects an entire Work Area Group with one click.
+            async toggleGroupSelection(groupId) {
+                groupId = String(groupId);
+
+                let workAreas;
+                try {
+                    workAreas = await this.fetchGroupWorkAreas(groupId);
+                } catch (e) {
+                    console.error(e);
+                    this.showToast("{% translate 'Failed to load group work areas' %}", true);
+                    return;
+                }
+
+                // A majority of the group already selected (e.g. all but one, after a
+                // shift+click removed a member) counts as "this group is selected" - a plain
+                // click deselects the rest. A minority selected (e.g. a couple of WAs picked
+                // one at a time via shift+click, starting from none) counts as "not selected" -
+                // a plain click fills in the rest instead of wiping out what's there.
+                const selectedCount = workAreas.filter(wa => this.selectedWorkAreas.has(wa.id)).length;
+                const isMajoritySelected = selectedCount > workAreas.length / 2;
+                const willSelect = !isMajoritySelected;
+
+                for (const wa of workAreas) {
+                    this.workAreaProperties.set(wa.id, wa);
+                    this.setWorkAreaSelected(wa.id, willSelect);
+                }
+                this.syncGroupDropdown(groupId, willSelect, workAreas);
+                this.updateFlwSummary();
+            },
+
+            // Keeps the group filter dropdown showing the same groups a map click just fully
+            // selected/deselected, so both stay visually in sync. Uses TomSelect's silent
+            // add/remove so this doesn't re-trigger the dropdown's own @change handler (which
+            // would otherwise re-run selectGroup() and re-fetch every currently-selected group).
+            syncGroupDropdown(groupId, selected, workAreas) {
+                if (selected) {
+                    for (const wa of workAreas) this.groupWorkAreaIds.add(wa.id);
+                    if (!this.selectedGroupIds.includes(groupId)) {
+                        this.selectedGroupIds = [...this.selectedGroupIds, groupId];
+                    }
+                    this.$refs.groupSelect?.tomselect?.addItem(groupId, true);
+                } else {
+                    for (const wa of workAreas) this.groupWorkAreaIds.delete(wa.id);
+                    this.selectedGroupIds = this.selectedGroupIds.filter(id => id !== groupId);
+                    this.$refs.groupSelect?.tomselect?.removeItem(groupId, true);
+                }
             },
 
             selectGroup(groupIds) {
                 this.selectedGroupIds = groupIds || [];
-                const query = this.selectedGroupIds.map((id) => `group_id=${encodeURIComponent(id)}`).join('&');
                 return this.replaceFilterSelection({
                     trackingSet: this.groupWorkAreaIds,
                     selectionId: this.selectedGroupIds,
-                    url: query ? `{{ group_work_areas_url|escapejs }}?${query}` : '',
+                    // Fetch each selected group through the same cached fetcher clicks use,
+                    // so a group picked here and also clicked on the map (or vice versa)
+                    // only ever fetches once, then merge the per-group results together.
+                    fetchWorkAreas: () => Promise.all(this.selectedGroupIds.map(id => this.fetchGroupWorkAreas(id)))
+                        .then(arrays => arrays.flat()),
                     errorMsg: "{% translate 'Failed to load group work areas' %}",
                 });
             },
@@ -281,13 +387,21 @@
                 return this.replaceFilterSelection({
                     trackingSet: this.flwFilterWorkAreaIds,
                     selectionId: assigneeId,
-                    url: '{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId),
+                    // Not cached: unlike group membership, an assignee's work areas change
+                    // during a session (that's the point of this workflow), so a stale
+                    // cached list here would hide assignments just made this session.
+                    fetchWorkAreas: () => fetch('{{ flw_work_areas_url|escapejs }}'.replace('__assignee_id__', assigneeId))
+                        .then(resp => {
+                            if (!resp.ok) throw new Error(`Failed to load FLW work areas (status ${resp.status})`);
+                            return resp.json();
+                        })
+                        .then(data => data.work_areas),
                     errorMsg: "{% translate 'Failed to load FLW work areas' %}",
                 });
             },
 
             // Replaces the selection contributed by one filter (a group or an FLW).
-            async replaceFilterSelection({ trackingSet, selectionId, url, errorMsg }) {
+            async replaceFilterSelection({ trackingSet, selectionId, fetchWorkAreas, errorMsg }) {
                 for (const id of trackingSet) {
                     this.selectedWorkAreas.delete(id);
                     this.setWorkAreaState(id, { assignment_selected: false });
@@ -305,9 +419,8 @@
                 // count the FLW's own existing areas as "new" and inflate the total.
                 this.flwSummaryLoading = true;
                 try {
-                    const resp = await fetch(url);
-                    const data = await resp.json();
-                    for (const wa of data.work_areas) {
+                    const workAreas = await fetchWorkAreas();
+                    for (const wa of workAreas) {
                         this.selectedWorkAreas.add(wa.id);
                         trackingSet.add(wa.id);
                         this.workAreaProperties.set(wa.id, wa);
@@ -504,6 +617,7 @@
                     this.showConfirmModal = false;
                     if (resp.ok) {
                         this.showToast("{% translate 'Assignment saved successfully!' %}");
+                        this.invalidateGroupWorkAreasCache();
                         this.assignmentQueue = [];
                         this.clearSelection();
                         if (this.$refs.assigneeSelect) this.$refs.assigneeSelect.value = '';
@@ -552,13 +666,13 @@
                                 props.assignee_name = null;
                             }
                         }
+                        if (unassignedIds.length > 0) this.invalidateGroupWorkAreasCache();
                         this.showUnassignModal = false;
                         // Clear the selection, then re-select any failed areas so they stay highlighted
                         // on the map for the user to inspect and retry.
                         this.clearSelection();
                         for (const id of failedIds) {
-                            this.selectedWorkAreas.add(id);
-                            this.setWorkAreaState(id, { assignment_selected: true });
+                            this.setWorkAreaSelected(id, true, this.workAreaProperties.get(id)?.group_id);
                         }
                         const msg = data.skipped || failedIds.length
                             ? "{% translate 'Unassigned' %} " + unassignedIds.length + " " + "{% translate 'work area(s).' %}"
@@ -655,6 +769,7 @@
                         this.setWorkAreaState(id, { status: 'EXCLUDED' });
                         this.excludedWorkAreaIds.add(id);
                     }
+                    if (excluded.length > 0) this.invalidateGroupWorkAreasCache();
                     this.showExcludeModal = false;
                     this.clearSelection();
                     if (excluded.length > 0 && skipped === 0) {
@@ -686,6 +801,13 @@
 
                 // navigation ui on left of the map
                 MapboxUtils.addNavigation(this.map, 'top-left');
+
+                // Mapbox binds shift+drag to box-zoom by default, which intercepts the
+                // mousedown/click sequence before our shift+click work-area handler sees it.
+                // Only assignment mode uses shift+click, so only disable it there.
+                if (this.assignmentMode) {
+                    this.map.boxZoom.disable();
+                }
 
                 await new Promise(resolve => this.map.once('load', resolve));
 
@@ -950,9 +1072,15 @@
                     if (!feature || feature.id == null) return;
                     const id = feature.id;
 
-                    // In assignment mode, toggle multi-select instead of single-select
+                    // In assignment mode: plain click selects/deselects the whole Work Area
+                    // Group by default; shift+click (or a work area with no group) targets
+                    // just this one work area.
                     if (this.assignmentMode) {
-                        this.toggleWorkAreaSelection(id, feature.properties);
+                        if (e.originalEvent.shiftKey || feature.properties.group_id == null) {
+                            this.toggleWorkAreaSelection(id, feature.properties);
+                        } else {
+                            this.toggleGroupSelection(feature.properties.group_id);
+                        }
                         return;
                     }
 
@@ -985,6 +1113,7 @@
                 let hoveredId = null;
                 this.map.on('mousemove', 'workareas-fill', (e) => {
                     this.map.getCanvasContainer().style.cursor = 'pointer';
+                    this.isHoveringWorkArea = true;
                     const feature = e.features?.[0];
                     if (!feature || feature.id == null) return;
                     const newId = feature.id;
@@ -998,6 +1127,7 @@
 
                 this.map.on('mouseleave', 'workareas-fill', () => {
                     this.map.getCanvasContainer().style.cursor = '';
+                    this.isHoveringWorkArea = false;
                     if (hoveredId !== null) {
                         this.setWorkAreaState(hoveredId, { hovered: false });
                         hoveredId = null;


### PR DESCRIPTION
## Product Description

<img width="936" height="367" alt="Screenshot 2026-07-23 at 3 36 21 PM" src="https://github.com/user-attachments/assets/5096b614-8cf7-4ee0-9fda-6d16a2038de1" />

In Assignment Mode on the microplanning map, work area selection now defaults to selecting a whole Work Area Group (WAG) instead of a single work area:

- Click a work area → selects/deselects its entire WAG (all member work areas at once). Clicking another WAG adds it to the selection — previous selections are kept, not replaced.
- Shift+click a work area → selects/deselects just that single work area, without touching the rest of its group. This preserves the original click-to-select-one-area behavior as an explicit option.
- Clicking a work area inside an already-selected WAG deselects the whole group; shift+clicking one WA out of a selected WAG removes just that one, leaving the rest selected.
- A hint ("Click to select group · Shift+click to select single area") appears briefly on hover to make the new interaction discoverable.
- The existing "Select Work Area Group" and assignee filter dropdowns are unchanged — they still work exactly as before, independently of map clicks.
- View Mode is unaffected — this change is scoped to Assignment Mode only, confirmed with product since WAGs there are already visually distinguishable by color and the sidebar shows group info on click.


## Technical Summary

https://dimagi.atlassian.net/browse/CCCT-2647

- Click handling (map_handler.html): the assignment-mode click handler now branches on shiftKey — plain click calls toggleGroupSelection(groupId), shift+click (or a work area with no group) calls the existing toggleWorkAreaSelection(id, properties).
- Group selection (toggleGroupSelection/fetchGroupWorkAreas): fetches a group's work area ids from the existing group_work_areas_url endpoint (the same one the filter dropdown already uses), cached per group_id so repeat/rapid clicks on the same group share one request instead of re-fetching or racing. Toggle direction is based on whether a majority of the group is currently selected (deselect all) vs. not (select all) — a straight "any selected" check misfired when building up a partial selection via shift+click from empty, since it couldn't distinguish that from "shift+click removed one member from a full group."
- Shared selection primitive (setWorkAreaSelected(id, selected)): both single-WA and whole-group selection now go through one method that mutates selectedWorkAreas and keeps the group filter dropdown's own tracked selection (selectedGroupId/groupWorkAreaIds) in sync — previously only the single-WA path did this, so a map click that diverged from a dropdown-selected group could leave the dropdown's selection stale and its work areas un-clearable.
- boxZoom: Mapbox's default shift+drag box-zoom handler was intercepting the shift+click sequence, so it's disabled (map.boxZoom.disable()), scoped to assignment mode only since that's the only place shift+click is used.
- Hover hint: a new isHoveringWorkArea boolean (naming matches the existing is*/show* convention) toggled by the map's mousemove/mouseleave handlers, with auto-dismiss after 3s handled declaratively via x-effect on the hint element in home.html.
- No changes to View Mode, the filter dropdowns' own selection logic, or backend endpoints — this is a client-side (Alpine/Mapbox) interaction change only.


## Safety Assurance

### Safety story

Tested locally, will be QAed

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

Full assignment-mode will be QAed for this feature along with regressions

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
