### PR TITLE
Add periodic task to clear expired OAuth tokens

### DIFF
--- a/commcare_connect/users/migrations/0028_create_clear_expired_oauth_tokens_periodic_task.py
+++ b/commcare_connect/users/migrations/0028_create_clear_expired_oauth_tokens_periodic_task.py
@@ -1,0 +1,42 @@
+from django.db import migrations
+from django_celery_beat.models import CrontabSchedule, PeriodicTask
+
+
+def create_periodic_task(apps, schema_editor):
+    schedule, _ = CrontabSchedule.objects.get_or_create(
+        minute="0",
+        hour="2",
+        day_of_week="sun",
+        day_of_month="*",
+        month_of_year="*",
+    )
+    PeriodicTask.objects.update_or_create(
+        name="clear_expired_oauth_tokens",
+        defaults={
+            "task": "commcare_connect.users.tasks.clear_expired_oauth_tokens",
+            "crontab": schedule,
+            "interval": None,
+        },
+    )
+
+
+def delete_periodic_task(apps, schema_editor):
+    PeriodicTask.objects.filter(
+        name="clear_expired_oauth_tokens",
+        task="commcare_connect.users.tasks.clear_expired_oauth_tokens",
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0027_remove_connectiduserlink_connect_user_and_more"),
+        ("django_celery_beat", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_periodic_task,
+            delete_periodic_task,
+            hints={"run_on_secondary": False},
+        )
+    ]

--- a/commcare_connect/users/tasks.py
+++ b/commcare_connect/users/tasks.py
@@ -14,4 +14,5 @@ def get_users_count():
 
 @celery_app.task()
 def clear_expired_oauth_tokens():
+    # https://django-oauth-toolkit.readthedocs.io/en/latest/management_commands.html
     call_command("cleartokens")

--- a/commcare_connect/users/tasks.py
+++ b/commcare_connect/users/tasks.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.management import call_command
 
 from config import celery_app
 
@@ -9,3 +10,8 @@ User = get_user_model()
 def get_users_count():
     """A pointless Celery task to demonstrate usage."""
     return User.objects.count()
+
+
+@celery_app.task()
+def clear_expired_oauth_tokens():
+    call_command("cleartokens")


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-2472

- Adds a Celery task that runs django-oauth-toolkit's built-in [`cleartokens`](https://django-oauth-toolkit.readthedocs.io/en/latest/management_commands.html)  management command to purge expired OAuth tokens.

Checked prod to see what this would actually clean up:

| Query | Count |
|---|---|
| Total `AccessToken` rows | 4,455,011 |
| Expired | 4,415,465 |
| Expired with no refresh token | 4,414,662 |

99% of access tokens in prod are already expired, and almost all of those have no refresh token attached, so `cleartokens` will remove them outright rather than leaving orphaned refresh tokens behind. No duplicate tokens were found, so there's no risk of the cleanup colliding with anything else.


## Safety Assurance

### Safety story

The task only calls django-oauth-toolkit's own [`cleartokens`](https://django-oauth-toolkit.readthedocs.io/en/latest/management_commands.html) command, which deletes expired token rows, so there's no new logic to get wrong. The migration is reversible and idempotent.


### Automated test coverage

No new tests added; the task is a thin wrapper around an already-tested library command.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
