### PR TITLE
Exclude org viewers for invoice review reminder

### DIFF
--- a/commcare_connect/organization/models.py
+++ b/commcare_connect/organization/models.py
@@ -40,12 +40,13 @@ class Organization(BaseModel):
     def __str__(self):
         return self.slug
 
-    def get_member_emails(self):
-        return list(
-            self.memberships.exclude(user__email__isnull=True)
-            .exclude(user__email="")
-            .values_list("user__email", flat=True)
-        )
+    def get_member_emails(self, exclude_viewer=False):
+        member_query = self.memberships.exclude(user__email__isnull=True).exclude(user__email="")
+
+        if exclude_viewer:
+            member_query = member_query.exclude(role=UserOrganizationMembership.Role.VIEWER)
+
+        return list(member_query.values_list("user__email", flat=True))
 
 
 class UserOrganizationMembership(models.Model):

--- a/commcare_connect/organization/tests/test_models.py
+++ b/commcare_connect/organization/tests/test_models.py
@@ -46,6 +46,23 @@ class TestOrganization:
         emails = organization.get_member_emails()
         assert sorted(emails) == sorted([org_user_admin.email, org_user_member.email])
 
+    @pytest.mark.parametrize(
+        "exclude_viewer,expect_viewer",
+        [(False, True), (True, False)],
+    )
+    def test_get_member_emails_viewer_exclusion(
+        self, organization, org_user_admin, org_user_member, exclude_viewer, expect_viewer
+    ):
+        viewer = UserFactory(email="viewer@example.com")
+        MembershipFactory(organization=organization, user=viewer, role=UserOrganizationMembership.Role.VIEWER)
+
+        emails = organization.get_member_emails(exclude_viewer=exclude_viewer)
+
+        expected = [org_user_admin.email, org_user_member.email]
+        if expect_viewer:
+            expected.append(viewer.email)
+        assert sorted(emails) == sorted(expected)
+
 
 @pytest.mark.django_db
 class TestUserOrganizationMembership:

--- a/commcare_connect/program/tasks.py
+++ b/commcare_connect/program/tasks.py
@@ -286,7 +286,7 @@ def send_pm_invoice_review_reminder():
 
 
 def _send_pm_invoice_review_reminder_email(pm_org, invoices):
-    recipient_emails = pm_org.get_member_emails()
+    recipient_emails = pm_org.get_member_emails(exclude_viewer=True)
     if not recipient_emails:
         return
 


### PR DESCRIPTION
## Product Description
Previously "viewer" members of an organization would receive the "Action Required: Program Invoices Awaiting Review" email, despite not being able to action them.

## Technical Summary
Viewer members are excluded from the recipient list query.

## Safety Assurance

### Safety story
It's a very simply query update and covered testing it locally using unit tests.

### Automated test coverage
Added a test to cover the change to the model method.

### QA Plan
No QA planned

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
