### PR TITLE
Increase timeout for send_message

### DIFF
--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -93,7 +93,7 @@ def get_user_otp(phone_number):
         raise
 
 
-def _make_request(method, path, params=None, json=None, timeout=5, auth=None) -> Response:
+def _make_request(method, path, params=None, json=None, timeout=10, auth=None) -> Response:
     if json and not method == "POST":
         raise ValueError("json can only be used with POST requests")
     if not auth:

--- a/commcare_connect/connect_id_client/main.py
+++ b/commcare_connect/connect_id_client/main.py
@@ -29,7 +29,7 @@ def fetch_demo_user_tokens() -> list[DemoUser]:
 
 def send_message(message: Message):
     """Send a push notification to a user."""
-    response = _make_request(POST, "/messaging/send/", json=message.asdict())
+    response = _make_request(POST, "/messaging/send/", json=message.asdict(), timeout=15)
     data = response.json()
     return MessagingResponse.build(**data)
 


### PR DESCRIPTION
## Technical Summary
Up the `send_message` request timeout to 15 seconds from the previous 5 seconds due to some timeout errors I saw in the celery logs. I don't see any errors on ConnectID side pertaining to this endpoint though, but I know Twilio has had some issues recently so I'm wondering if the holdup might be on their side. That said, I'm not sure if this is the right solution, but it's something we _can_ do.

## Safety Assurance

### Safety story
Simple change

### Automated test coverage
N.A

### QA Plan
N.A

### Labels & Review
- [x ] The set of people pinged as reviewers is appropriate for the level of risk of the change
