### PR TITLE
Allow Export of presigned references for attachments

### DIFF
--- a/commcare_connect/data_export/tests/test_views.py
+++ b/commcare_connect/data_export/tests/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 import pytest
 from django.contrib.auth.models import Permission
@@ -347,3 +348,47 @@ class TestImageView:
         url = reverse("data_export:image_export", kwargs={"opp_id": opportunity.id})
         response = api_client.get(url, {"blob_id": blob_meta.blob_id})
         assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestAttachmentSignedUrlView:
+    def _url(self, opportunity):
+        return reverse("data_export:attachment_signed_url", kwargs={"opp_id": opportunity.id})
+
+    def test_requires_export_scope(self, api_client, opportunity):
+        response = api_client.get(self._url(opportunity), {"blob_id": "any"})
+        assert response.status_code == 401
+
+    def test_non_member_returns_404(self, api_client, opportunity, user):
+        visit = UserVisitFactory(opportunity=opportunity)
+        blob_meta = BlobMetaFactory(parent_id=visit.xform_id)
+        _add_export_credentials(api_client, user)
+        response = api_client.get(self._url(opportunity), {"blob_id": blob_meta.blob_id})
+        assert response.status_code == 404
+
+    def test_foreign_org_blob_returns_404(self, api_client, opportunity, org_user_member):
+        foreign_visit = UserVisitFactory(opportunity__organization=OrgWithUsersFactory())
+        blob_meta = BlobMetaFactory(parent_id=foreign_visit.xform_id)
+        _add_export_credentials(api_client, org_user_member)
+        response = api_client.get(self._url(opportunity), {"blob_id": blob_meta.blob_id})
+        assert response.status_code == 404
+
+    def test_returns_501_when_no_s3_backend(self, api_client, opportunity, org_user_member):
+        visit = UserVisitFactory(opportunity=opportunity)
+        blob_meta = BlobMetaFactory(parent_id=visit.xform_id)
+        _add_export_credentials(api_client, org_user_member)
+        # The test environment uses FileSystemStorage, which cannot produce a portable URL.
+        response = api_client.get(self._url(opportunity), {"blob_id": blob_meta.blob_id})
+        assert response.status_code == 501
+
+    def test_returns_signed_url(self, api_client, opportunity, org_user_member):
+        visit = UserVisitFactory(opportunity=opportunity)
+        blob_meta = BlobMetaFactory(parent_id=visit.xform_id)
+        _add_export_credentials(api_client, org_user_member)
+        with (
+            mock.patch("commcare_connect.data_export.views._default_storage_supports_signed_urls", return_value=True),
+            mock.patch("commcare_connect.data_export.views._get_attachment_signed_url", return_value="https://signed"),
+        ):
+            response = api_client.get(self._url(opportunity), {"blob_id": blob_meta.blob_id})
+        assert response.status_code == 200
+        assert response.json() == {"attachment_signed_url": "https://signed"}

--- a/commcare_connect/data_export/tests/test_views.py
+++ b/commcare_connect/data_export/tests/test_views.py
@@ -2,6 +2,8 @@ import datetime
 
 import pytest
 from django.contrib.auth.models import Permission
+from django.core.files.base import ContentFile
+from django.core.files.storage import storages
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import now
@@ -9,7 +11,13 @@ from django.utils.timezone import now
 from commcare_connect.audit.tests.factories import AuditReportEntryFactory, AuditReportFactory
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 from commcare_connect.opportunity.models import LabsRecord
-from commcare_connect.opportunity.tests.factories import AssignedTaskFactory, OpportunityAccessFactory, TaskTypeFactory
+from commcare_connect.opportunity.tests.factories import (
+    AssignedTaskFactory,
+    BlobMetaFactory,
+    OpportunityAccessFactory,
+    TaskTypeFactory,
+    UserVisitFactory,
+)
 from commcare_connect.users.tests.factories import LLOEntityFactory, OrgWithUsersFactory
 
 
@@ -318,3 +326,24 @@ class TestLabsRecordDataViewAuthorization:
         assert response.status_code == 404
         record.refresh_from_db()
         assert record.experiment == "original", "Cross-org record must not be overwritten"
+
+
+@pytest.mark.django_db
+class TestImageView:
+    def test_returns_image_bytes(self, api_client, opportunity, org_user_member):
+        visit = UserVisitFactory(opportunity=opportunity)
+        blob_meta = BlobMetaFactory(parent_id=visit.xform_id, content_type="image/jpeg")
+        storages["default"].save(blob_meta.blob_id, ContentFile(b"imagebytes"))
+        _add_export_credentials(api_client, org_user_member)
+        url = reverse("data_export:image_export", kwargs={"opp_id": opportunity.id})
+        response = api_client.get(url, {"blob_id": blob_meta.blob_id})
+        assert response.status_code == 200
+        assert b"".join(response.streaming_content) == b"imagebytes"
+
+    def test_non_member_returns_404(self, api_client, opportunity, user):
+        visit = UserVisitFactory(opportunity=opportunity)
+        blob_meta = BlobMetaFactory(parent_id=visit.xform_id, content_type="image/jpeg")
+        _add_export_credentials(api_client, user)
+        url = reverse("data_export:image_export", kwargs={"opp_id": opportunity.id})
+        response = api_client.get(url, {"blob_id": blob_meta.blob_id})
+        assert response.status_code == 404

--- a/commcare_connect/data_export/tests/test_views.py
+++ b/commcare_connect/data_export/tests/test_views.py
@@ -392,3 +392,34 @@ class TestAttachmentSignedUrlView:
             response = api_client.get(self._url(opportunity), {"blob_id": blob_meta.blob_id})
         assert response.status_code == 200
         assert response.json() == {"attachment_signed_url": "https://signed"}
+
+
+class _FakeSignedStorage:
+    """Storage stand-in that records how ``url()`` is invoked.
+
+    Used because django-storages (the real S3 backend) is a production-only dependency and
+    is absent from the test environment. ``location`` is a class default; a per-instance
+    override models config a *resolved* storage carries, so this verifies the copy retains
+    it rather than falling back to bare class defaults.
+    """
+
+    location = "class-default"
+
+    def __init__(self):
+        self.querystring_auth = False
+
+    def url(self, name, expire, http_method):
+        return f"https://signed/{self.location}/{name}?auth={self.querystring_auth}&method={http_method}"
+
+
+def test_get_attachment_signed_url_preserves_resolved_storage_config():
+    from commcare_connect.data_export.views import _get_attachment_signed_url
+
+    storage = _FakeSignedStorage()
+    storage.location = "configured/prefix"  # instance-level config, e.g. a STORAGES OPTIONS override
+    with mock.patch("commcare_connect.data_export.views.storages", {"default": storage}):
+        url = _get_attachment_signed_url("blob123")
+    # The signed URL reflects the resolved instance's config (not the class default), opts
+    # querystring_auth in, and is scoped to GET; the original instance is left untouched.
+    assert url == "https://signed/configured/prefix/blob123?auth=True&method=GET"
+    assert storage.querystring_auth is False

--- a/commcare_connect/data_export/urls.py
+++ b/commcare_connect/data_export/urls.py
@@ -25,6 +25,11 @@ urlpatterns = [
         name="image_export",
     ),
     path(
+        "opportunity/<int:opp_id>/attachment_signed_url/",
+        views.AttachmentSignedUrlView.as_view(),
+        name="attachment_signed_url",
+    ),
+    path(
         "opportunity/<int:opp_id>/app_structure/",
         views.AppStructureView.as_view(),
         name="app_structure",

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import uuid
 from collections import defaultdict
@@ -512,9 +513,10 @@ def _get_attachment_signed_url(blob_id, expire=ATTACHMENT_SIGNED_URL_EXPIRY):
 
     Caller must guard with ``_default_storage_supports_signed_urls()`` first.
     """
-    # AWS_QUERYSTRING_AUTH is globally False, so build a signing-enabled storage of the
-    # same class (preserving its ``location`` prefix) and request a GET-only URL.
-    signed_storage = type(storages["default"])(querystring_auth=True)
+    # Create a storage handler which allows pre-authed url's, retaining the existing
+    # config of the default handler.
+    signed_storage = copy.copy(storages["default"])
+    signed_storage.querystring_auth = True
     return signed_storage.url(blob_id, expire=expire, http_method="GET")
 
 

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -490,6 +490,42 @@ class ImageView(OpportunityDataExportView):
         return FileResponse(attachment, filename=blob_meta.name, content_type=blob_meta.content_type)
 
 
+# Signed URLs are consumed by a follow-up request made immediately after issuance.
+ATTACHMENT_SIGNED_URL_EXPIRY = 60 * 10  # seconds (10 minutes)
+
+
+def _default_storage_supports_signed_urls():
+    """True when the default storage is S3-backed and can produce a portable signed URL.
+
+    django-storages is a production-only dependency, so it may be absent entirely; when it
+    is, there is no S3 backend and therefore no portable URL.
+    """
+    try:
+        from storages.backends.s3boto3 import S3Boto3Storage
+    except ImportError:
+        return False
+    return isinstance(storages["default"], S3Boto3Storage)
+
+
+def _get_attachment_signed_url(blob_id, expire=ATTACHMENT_SIGNED_URL_EXPIRY):
+    """Return a pre-signed GET URL for ``blob_id`` in the default (S3) storage.
+
+    Caller must guard with ``_default_storage_supports_signed_urls()`` first.
+    """
+    # AWS_QUERYSTRING_AUTH is globally False, so build a signing-enabled storage of the
+    # same class (preserving its ``location`` prefix) and request a GET-only URL.
+    signed_storage = type(storages["default"])(querystring_auth=True)
+    return signed_storage.url(blob_id, expire=expire, http_method="GET")
+
+
+class AttachmentSignedUrlView(OpportunityDataExportView):
+    def get(self, request, *args, **kwargs):
+        blob_meta = _get_scoped_blob_meta(request)
+        if not _default_storage_supports_signed_urls():
+            return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response({"attachment_signed_url": _get_attachment_signed_url(blob_meta.blob_id)})
+
+
 class AppStructureView(OpportunityDataExportView):
     def get(self, request, opp_id):
         app_type = request.query_params.get("app_type", APP_TYPE_BOTH)

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -166,6 +166,16 @@ def _get_opportunity_or_404(user, opp_id):
         raise NotFound()
 
 
+def _get_scoped_blob_meta(request):
+    """Resolve the ``blob_id`` query param to its BlobMeta, enforcing that the requesting
+    user has access to the opportunity that owns the blob."""
+    blob_id = request.query_params["blob_id"]
+    blob_meta = BlobMeta.objects.get(blob_id=blob_id)
+    form = UserVisit.objects.get(xform_id=blob_meta.parent_id)
+    _get_opportunity_or_404(request.user, form.opportunity_id)
+    return blob_meta
+
+
 def _get_program_or_404(user, program_id):
     try:
         return (
@@ -475,11 +485,8 @@ class LabsRecordDataView(BaseDataExportView, ListCreateAPIView):
 
 class ImageView(OpportunityDataExportView):
     def get(self, request, *args, **kwargs):
-        blob_id = request.query_params["blob_id"]
-        blob_meta = BlobMeta.objects.get(blob_id=blob_id)
-        form = UserVisit.objects.get(xform_id=blob_meta.parent_id)
-        _get_opportunity_or_404(request.user, form.opportunity_id)
-        attachment = storages["default"].open(blob_id)
+        blob_meta = _get_scoped_blob_meta(request)
+        attachment = storages["default"].open(blob_meta.blob_id)
         return FileResponse(attachment, filename=blob_meta.name, content_type=blob_meta.content_type)
 
 


### PR DESCRIPTION
## Product Description
Extends the export endpoints to support the creation of pre-authenticated URL's rather than byte responses.

## Technical Summary

[Functional and Tech Spec](https://docs.google.com/document/d/1xb_ncJKN8vMQOZVLN-bMNQE9u61hLirpn9I39MUN02o/edit?tab=t.0) - Includes overview of the reasoning for this model of approach.

This PR is split into two parts. The first commit cleanly refactors the current source of authorization for the `export/.../image` endpoint to ensure that the new endpoint uses the exact same authorization semantics. The second commit creates the new endpoint and response semantics. 

## Safety Assurance

### Safety story

Discussion of the use of pre-authed url's for programmatic access to bulk attachments is in the original specification. As they are still part of the `export` structure here and won't be accessed non-programmatically, providing a pre-signed url isn't a meaningful escalation of access or revocability compared to a direct download. 

Since this can't be tested locally due to the native reliance on S3, it was tested in Staging against test data submitted along the normal path. 

Testing confirmed:
* The existing image endpoints still work correctly
* The existing image endpoints still require authentication
* The existing image endpoints still only work for authorized users (fetches begin failing after removal from project)
* New endpoints work to create links to the attachments which do not require additional auth
* Pre-authed URL's expire after the correct time period (10 minutes)
* New endpoints require authentication
* New endpoints only work for authorized users (fetches begin failing after removal from project)

### Automated test coverage

New tests added to confirm the request semantics, but since the underlying feature is dependent on S3 (for pre-signed url availability) the ultimate fetch can't be tested live, same as the existing image byte fetch endpoint. 

### QA Plan

Since the export API's aren't part of the UX, QA shouldn't be necessary based on the limited scope of changes. 

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
