### PR TITLE
Add ability to update task case property if not assigned

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -2104,15 +2104,33 @@ class EditTaskTypeForm(forms.ModelForm):
 
     class Meta:
         model = TaskType
-        fields = ["name", "description"]
+        fields = ["name", "case_property", "description"]
         widgets = {"description": forms.Textarea(attrs={"rows": 2})}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance and self.instance.archived:
             self.fields["is_archived"].initial = True
+        if self._has_assigned_tasks():
+            self._lock_case_property()
         self.helper = FormHelper(self)
         self.helper.form_tag = False
+        self.helper.layout = Layout(
+            Field("name"),
+            Field("case_property"),
+            Field("description"),
+            Field("is_archived"),
+        )
+
+    def _has_assigned_tasks(self):
+        return bool(self.instance.pk) and AssignedTask.objects.filter(task_type=self.instance).exists()
+
+    def _lock_case_property(self):
+        field = self.fields["case_property"]
+        field.disabled = True
+        field.help_text = _(
+            "This cannot be changed because the task type has already been assigned to one or more workers."
+        )
 
     def save(self, commit=True):
         instance = super().save(commit=False)

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -1090,21 +1090,77 @@ class TestEditTaskTypeForm:
         saved = form.save()
         assert saved.archived == original_time
 
-    def test_excludes_non_editable_fields(self, opportunity):
-        task_type = TaskTypeFactory(app=opportunity.deliver_app, slug="original-slug", case_property="original_prop")
+    def test_updates_case_property(self, opportunity):
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property="wrong_prop")
         form = EditTaskTypeForm(
             data={
-                "name": "New Name",
-                "description": "New Desc",
-                "slug": "hacked-slug",
-                "case_property": "hacked_prop",
+                "name": task_type.name,
+                "description": task_type.description,
+                "case_property": "correct_prop",
             },
             instance=task_type,
         )
         assert form.is_valid(), form.errors
         saved = form.save()
-        assert saved.slug == "original-slug"
+        assert saved.case_property == "correct_prop"
+
+    @pytest.mark.parametrize("initial_case_property", ["original_prop", None])
+    def test_case_property_is_optional(self, opportunity, initial_case_property):
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property=initial_case_property)
+        form = EditTaskTypeForm(
+            data={"name": task_type.name, "description": task_type.description, "case_property": ""},
+            instance=task_type,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
+        assert not saved.case_property
+
+    @pytest.mark.parametrize("status", [AssignedTaskStatus.ASSIGNED, AssignedTaskStatus.COMPLETED])
+    def test_case_property_disabled_when_task_assigned(self, opportunity, status):
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property="original_prop")
+        AssignedTaskFactory(task_type=task_type, status=status)
+        form = EditTaskTypeForm(instance=task_type)
+        assert form.fields["case_property"].disabled is True
+        assert form.fields["case_property"].help_text
+
+    @pytest.mark.parametrize("status", [AssignedTaskStatus.ASSIGNED, AssignedTaskStatus.COMPLETED])
+    def test_case_property_change_ignored_when_task_assigned(self, opportunity, status):
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property="original_prop")
+        AssignedTaskFactory(task_type=task_type, status=status)
+        form = EditTaskTypeForm(
+            data={"name": "New Name", "description": "New Desc", "case_property": "hacked_prop"},
+            instance=task_type,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
         assert saved.case_property == "original_prop"
+        assert saved.name == "New Name"
+
+    def test_case_property_editable_without_assigned_tasks(self, opportunity):
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property="original_prop")
+        form = EditTaskTypeForm(instance=task_type)
+        assert form.fields["case_property"].disabled is False
+        assert not form.fields["case_property"].help_text
+
+    def test_case_property_editable_when_other_task_type_assigned(self, opportunity):
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, case_property="original_prop")
+        AssignedTaskFactory(task_type=TaskTypeFactory(app=opportunity.deliver_app))
+        form = EditTaskTypeForm(
+            data={"name": task_type.name, "description": task_type.description, "case_property": "correct_prop"},
+            instance=task_type,
+        )
+        assert form.is_valid(), form.errors
+        assert form.save().case_property == "correct_prop"
+
+    def test_excludes_slug(self, opportunity):
+        task_type = TaskTypeFactory(app=opportunity.deliver_app, slug="original-slug")
+        form = EditTaskTypeForm(
+            data={"name": "New Name", "description": "New Desc", "slug": "hacked-slug"},
+            instance=task_type,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
+        assert saved.slug == "original-slug"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Product Description
Add the ability to update a task type case property after the task type has been created. This is **_only_** possible if there exists no `AssignedTask` records with the given task type. 

When as task with task_type has not been assigned yet - is able to update case property: 
<img width="713" height="516" alt="image" src="https://github.com/user-attachments/assets/5b14d70e-0b48-4954-9001-a21f960e4d66" />

After a task with task_type has been assigned - is not able to update case property: 
<img width="713" height="516" alt="image" src="https://github.com/user-attachments/assets/3bb5c26b-dc69-4857-8d60-9fd7cf78f4fb" />

## Technical Summary
Ticket: https://dimagi.atlassian.net/browse/CI-848

We allow the editing of a task type case property when the task type is unused, but lock the case property editing when the task type is in use. The "locking" mechanism is an easy win to ensure the user can still correct the case_property in case a spelling mistake or so was during setup, without dealing with the complexities of hitting HQ to rectify the  change. This change is thus only effective during setup phase.  

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
A couple of unit tests have been added covering some scenarios.

### QA Plan
No QA planned.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
