### PR TITLE
Fix run_on_secondary hint for migration

### DIFF
--- a/commcare_connect/opportunity/migrations/0140_opportunity_supervising_organization.py
+++ b/commcare_connect/opportunity/migrations/0140_opportunity_supervising_organization.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
         migrations.RunPython(
             backfill_supervising_organization,
             migrations.RunPython.noop,
-            hints={"run_on_secondary": False},
+            hints={"run_on_secondary": True},
         ),
         # Step 3: enforce non-null now that every row has a value.
         migrations.AlterField(


### PR DESCRIPTION
## Product Description
No end user facing changes.

## Technical Summary
This fixes an issue that came up due to a data migration section not being run for the secondary database which caused a migration and the deploy to fail.

## Safety Assurance
### Safety story
- Tested Locally. Migrations are already working and applied for Production, they only fail for secondary due to missing hint.

### Automated test coverage
- None

### QA Plan
- None

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
