### PR TITLE
Invoice create/review form fixes

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1992,64 +1992,9 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
 
     @property
     def line_items(self):
-        if self.line_items_table:
-            table = HTML(
-                """
-                {% load django_tables2 %}
-                <div class="overflow-x-auto mb-4">
-                    {% render_table form.line_items_table %}
-                </div>
-                """
-            )
-        else:
-            table = HTML(
-                """
-                {% load i18n %}
-                <div x-show="lineItemsError"
-                  x-cloak
-                  role="alert"
-                  class="flex items-center justify-between p-4 mb-4 rounded-lg border-[0.5px]
-                         bg-message-error text-message-error-text border-message-error-border">
-                  <div class="flex items-center gap-2">
-                    <i class="fa-solid fa-circle-exclamation"></i>
-                    <span>
-                      {% translate "Could not load the deliveries for this period. Please try again, and contact support if the problem persists." %}
-                    </span>
-                  </div>
-                  <button type="button"
-                          class="button button-md outline-style ml-4"
-                          @click="fetchInvoiceLineItems()">
-                    {% translate "Retry" %}
-                  </button>
-                </div>
-                <div id="invoice-line-items-wrapper" class="space-y-1 text-sm text-gray-500 mb-4"></div>
-                <div x-show="lineItemsLoading"
-                    x-cloak
-                    role="status"
-                    class="flex items-center justify-center gap-2 py-6 text-gray-500">
-                    <i class="fa-solid fa-spinner fa-spin"></i>
-                    <span>{% translate "Loading deliveries for this period…" %}</span>
-                </div>
-                """
-            )
-
         return Fieldset(
             "Line Items",
-            table,
-            HTML(
-                """
-                <div id="download-line-items-wrapper" x-cloak x-show="showDownloadButton" class="my-4">
-                    <a type="button"
-                    class="button button-md outline-style"
-                    :href="downloadLineItemsUrl()"
-                    target="_blank"
-                    >
-                        <i class="fa-solid fa-download mr-2"></i>
-                        {% load i18n %}{% translate "Download All Items" %}
-                    </a>
-                </div>
-                """
-            ),
+            HTML('{% include "opportunity/partials/invoice_line_items_fieldset.html" %}'),
         )
 
 

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -13,8 +13,9 @@ from django.core.exceptions import ValidationError
 from django.db.models import Count, F, Q, Sum, TextChoices
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.html import format_html
-from django.utils.timezone import now
+from django.utils.timezone import localdate, now
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from waffle import switch_is_active
@@ -1645,7 +1646,9 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
         widgets = {
             "date": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
             "start_date": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
-            "end_date": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+            "end_date": forms.DateInput(
+                attrs={"type": "date", "max": timezone.localdate() - datetime.timedelta(days=1)}, format="%Y-%m-%d"
+            ),
             "title": forms.TextInput(attrs={"placeholder": _("e.g. October Services")}),
         }
         labels = {
@@ -1934,6 +1937,9 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
 
             if end_date < start_date:
                 raise ValidationError({"end_date": "End date cannot be earlier than start date."})
+
+            if end_date >= localdate():
+                raise ValidationError({"end_date": _("End date must be before today.")})
 
             self._reject_stale_total(amount, start_date, end_date)
 

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -54,7 +54,10 @@ from commcare_connect.opportunity.utils.invoice import (
     get_end_date_for_invoice,
     get_start_date_for_invoice,
 )
-from commcare_connect.opportunity.utils.invoice_line_items import bill_invoice
+from commcare_connect.opportunity.utils.invoice_line_items import (
+    bill_invoice,
+    get_billable_line_items,
+)
 from commcare_connect.organization.models import Organization
 from commcare_connect.program.models import ProgramApplicationStatus
 from commcare_connect.users.models import User, UserCredential
@@ -1926,7 +1929,28 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
             if end_date < start_date:
                 raise ValidationError({"end_date": "End date cannot be earlier than start date."})
 
+            self._reject_stale_total(amount, start_date, end_date)
+
         return cleaned_data
+
+    def _reject_stale_total(self, amount, start_date, end_date):
+        """Reject a submit if the posted total no longer matches the current billable total.
+
+        This provides a user-facing error when the preview has gone stale. `save()` still
+        recomputes the total under a lock and never trusts the posted amount.
+        """
+
+        # Use the same calculation as the preview, so a mismatch reflects a real state change.
+        billable_total = sum(
+            item.total_pay.local for item in get_billable_line_items(self.opportunity, start_date, end_date)
+        )
+        if amount != billable_total:
+            raise ValidationError(
+                _(
+                    "The billable total for this period has changed since this page was loaded. "
+                    "Please refresh the page to see the latest line items and total, then submit again."
+                )
+            )
 
     def save(self, commit=True):
         instance = super().save(commit=False)

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1756,7 +1756,13 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
         if not self.read_only:
             invoice_form_fields.append(
                 Div(
-                    Submit("submit", gettext("Submit"), css_class="button button-md primary-dark"),
+                    Submit(
+                        "submit",
+                        gettext("Submit"),
+                        css_class="button button-md primary-dark",
+                        # Disable when there is an error while fetching the line items
+                        **{":disabled": "isServiceDelivery && lineItemsError"},
+                    ),
                     css_class="flex justify-end mt-4",
                 )
             )
@@ -1998,8 +2004,33 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
         else:
             table = HTML(
                 """
+                {% load i18n %}
+                <div x-show="lineItemsError"
+                  x-cloak
+                  role="alert"
+                  class="flex items-center justify-between p-4 mb-4 rounded-lg border-[0.5px]
+                         bg-message-error text-message-error-text border-message-error-border">
+                  <div class="flex items-center gap-2">
+                    <i class="fa-solid fa-circle-exclamation"></i>
+                    <span>
+                      {% translate "Could not load the deliveries for this period. Please try again, and contact support if the problem persists." %}
+                    </span>
+                  </div>
+                  <button type="button"
+                          class="button button-md outline-style ml-4"
+                          @click="fetchInvoiceLineItems()">
+                    {% translate "Retry" %}
+                  </button>
+                </div>
                 <div id="invoice-line-items-wrapper" class="space-y-1 text-sm text-gray-500 mb-4"></div>
-            """
+                <div x-show="lineItemsLoading"
+                    x-cloak
+                    role="status"
+                    class="flex items-center justify-center gap-2 py-6 text-gray-500">
+                    <i class="fa-solid fa-spinner fa-spin"></i>
+                    <span>{% translate "Loading deliveries for this period…" %}</span>
+                </div>
+                """
             )
 
         return Fieldset(

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -2003,6 +2003,14 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
             HTML('{% include "opportunity/partials/invoice_line_items_fieldset.html" %}'),
         )
 
+    @property
+    def line_items_released(self):
+        """True when line items were released due to cancellation or rejection."""
+        return self.instance.pk is not None and self.instance.status in (
+            InvoiceStatus.CANCELLED_BY_NM,
+            InvoiceStatus.REJECTED_BY_PM,
+        )
+
 
 class CreateTaskForm(forms.Form):
     task = forms.ModelChoiceField(

--- a/commcare_connect/opportunity/tasks.py
+++ b/commcare_connect/opportunity/tasks.py
@@ -676,14 +676,20 @@ def generate_automated_service_delivery_invoice():
     for opportunity in Opportunity.objects.filter(
         active=True, is_test=False, start_date__gte=OPPORTUNITY_AUTO_INVOICE_START_DATE
     ).iterator(chunk_size=CHUNK_SIZE):
-        window_start = get_start_date_for_invoice(opportunity)
-        # Below indicates there are no unbilled completed works to invoice in previous month or earlier
-        if window_start > end_date_prev_month:
-            continue
+        try:
+            window_start = get_start_date_for_invoice(opportunity)
+            # Below indicates there are no unbilled completed works to invoice in previous month or earlier
+            if window_start > end_date_prev_month:
+                continue
 
-        invoice_id = _bill_opportunity(opportunity, window_start, end_date_prev_month)
-        if invoice_id:
-            created_invoices_ids.append(invoice_id)
+            invoice_id = _bill_opportunity(opportunity, window_start, end_date_prev_month)
+            if invoice_id:
+                created_invoices_ids.append(invoice_id)
+        except Exception:
+            logger.exception(
+                "Automated invoicing failed for Opportunity %s (%s)", opportunity.name, opportunity.opportunity_id
+            )
+            continue
 
     _send_auto_invoice_created_notification(created_invoices_ids)
 

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -831,6 +831,40 @@ class TestAutomatedPaymentInvoiceForm:
         assert cw.invoice is None  # the FK is no longer written
 
     @pytest.mark.parametrize(
+        "start_date, end_date, expected_error",
+        [
+            ("2025-10-01", "2025-10-31", None),
+            ("2025-10-31", "2025-10-01", "End date cannot be earlier than start date."),
+            ("2025-10-01", "2025-11-06", "End date must be before today."),
+            ("2025-10-01", "2025-11-30", "End date must be before today."),
+        ],
+        ids=["completed-period", "end-before-start", "ends-today", "future-end"],
+    )
+    @patch("commcare_connect.opportunity.forms.localdate", return_value=datetime.date(2025, 11, 6))
+    def test_service_delivery_window_must_be_a_completed_period(
+        self, mock_localdate, valid_opportunity, start_date, end_date, expected_error
+    ):
+        ExchangeRateFactory(rate_date=datetime.date(2020, 1, 1))
+
+        form = AutomatedPaymentInvoiceForm(
+            opportunity=valid_opportunity,
+            invoice_type="service_delivery",
+            data={
+                "invoice_number": "INV-WINDOW",
+                "amount": 0,
+                "date": "2025-11-06",
+                "start_date": start_date,
+                "end_date": end_date,
+                "description": "Monthly consulting services rendered.",
+            },
+            is_opportunity_pm=False,
+        )
+
+        assert form.is_valid() is (expected_error is None)
+        if expected_error:
+            assert expected_error in str(form.errors)
+
+    @pytest.mark.parametrize(
         "posted_amount, expect_valid",
         [(120.0, True), (100.0, False), (0, False)],
         ids=["matches", "stale-lower", "stale-zero"],

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -30,6 +30,7 @@ from commcare_connect.opportunity.models import (
     CompletedWorkInvoice,
     CompletedWorkStatus,
     CredentialConfiguration,
+    PaymentInvoice,
     PaymentUnit,
     TaskTypeModeChoices,
 )
@@ -778,68 +779,8 @@ class TestAutomatedPaymentInvoiceForm:
         assert invoice.title is None
         mock_bill_invoice.assert_not_called()
 
-    @patch("commcare_connect.opportunity.forms.bill_invoice")
-    def test_service_delivery_form(self, mock_bill_invoice, valid_opportunity):
-        ExchangeRateFactory(rate_date="2020-01-01")
-
-        form = AutomatedPaymentInvoiceForm(
-            opportunity=valid_opportunity,
-            invoice_type="service_delivery",
-            data={
-                "invoice_number": "INV-001",
-                "amount": 100.0,
-                "date": "2025-11-06",
-                "title": "Consulting Services Invoice",
-                "start_date": "2025-10-01",
-                "end_date": "2025-10-31",
-                "description": "Monthly consulting services rendered.",
-            },
-            is_opportunity_pm=False,
-        )
-        assert form.is_valid()
-        invoice = form.save()
-        assert invoice.service_delivery
-        assert str(invoice.start_date) == "2025-10-01"
-        assert str(invoice.end_date) == "2025-10-31"
-        assert invoice.description == "Monthly consulting services rendered."
-
-        mock_bill_invoice.assert_called_once()
-
-    @patch("commcare_connect.opportunity.forms.bill_invoice", return_value=[])
-    def test_service_delivery_amount_is_never_the_posted_one(self, mock_bill_invoice, valid_opportunity):
-        """The posted total is a preview artefact and must never survive onto the invoice.
-
-        bill_invoice is patched to return [] to stand in for the delta being billed
-        elsewhere between clean() and save() -- the race no validation can close. The invoice must
-        then be 0 rather than the 100 that was posted, so it never claims money it has no rows for.
-        """
-        ExchangeRateFactory(rate_date=datetime.date(2020, 1, 1))
-        form = AutomatedPaymentInvoiceForm(
-            opportunity=valid_opportunity,
-            invoice_type="service_delivery",
-            data={
-                "invoice_number": "INV-STALE",
-                "amount": 100.0,
-                "date": "2025-11-06",
-                "start_date": "2025-10-01",
-                "end_date": "2025-10-31",
-                "description": "Monthly consulting services rendered.",
-            },
-            is_opportunity_pm=False,
-        )
-
-        assert form.is_valid()
-        invoice = form.save()
-
-        invoice.refresh_from_db()
-        assert invoice.amount == Decimal("0")
-        assert invoice.amount_usd == Decimal("0")
-        assert not invoice.work_items.exists()
-
     def test_service_delivery_invoice_snapshots_its_line_items(self, valid_opportunity):
-        # Explicit date: the factory default is Faker("date_time"), which can land after the
-        # billed month and miss `latest_exchange_rate`'s rate_date filter intermittently.
-        ExchangeRateFactory(rate_date=datetime.date(2020, 1, 1))
+        ExchangeRateFactory(rate_date="2020-01-01")
         payment_unit = PaymentUnitFactory(opportunity=valid_opportunity, amount=100, org_amount=20)
         cw = CompletedWorkFactory(
             opportunity_access__opportunity=valid_opportunity,
@@ -856,7 +797,7 @@ class TestAutomatedPaymentInvoiceForm:
             invoice_type="service_delivery",
             data={
                 "invoice_number": "INV-001",
-                "amount": 100.0,
+                "amount": 120.0,
                 "date": "2025-11-06",
                 "title": "Consulting Services Invoice",
                 # Deliberately wider than the single month that has billable work, so the
@@ -880,7 +821,7 @@ class TestAutomatedPaymentInvoiceForm:
         assert row.org_amount_local == Decimal("20")
 
         invoice.refresh_from_db()
-        assert invoice.amount == Decimal("120")  # server-computed from the rows, not the posted 100
+        assert invoice.amount == Decimal("120")  # server-computed from the frozen rows
         # The window is the NM's input and is never narrowed to the months that were billable.
         assert invoice.start_date == datetime.date(2025, 9, 1)
         assert invoice.end_date == datetime.date(2025, 10, 31)
@@ -888,6 +829,91 @@ class TestAutomatedPaymentInvoiceForm:
         cw.refresh_from_db()
         assert cw.invoiced_approved_count == 1
         assert cw.invoice is None  # the FK is no longer written
+
+    @pytest.mark.parametrize(
+        "posted_amount, expect_valid",
+        [(120.0, True), (100.0, False), (0, False)],
+        ids=["matches", "stale-lower", "stale-zero"],
+    )
+    def test_service_delivery_rejects_a_total_that_no_longer_matches_the_window(
+        self, valid_opportunity, posted_amount, expect_valid
+    ):
+        """The amount is server-filled from the preview, so a mismatch means the deliveries moved.
+
+        Saving anyway would hand the NM an invoice for a figure they never reviewed.
+        """
+        ExchangeRateFactory(rate_date=datetime.date(2020, 1, 1), currency_code="USD", rate=1.0)
+        payment_unit = PaymentUnitFactory(opportunity=valid_opportunity, amount=100, org_amount=20)
+        cw = CompletedWorkFactory(
+            opportunity_access__opportunity=valid_opportunity,
+            payment_unit=payment_unit,
+            status=CompletedWorkStatus.approved,
+            saved_approved_count=1,
+        )
+        cw.status_modified_date = datetime.date(2025, 10, 5)
+        cw.save()
+
+        form = AutomatedPaymentInvoiceForm(
+            opportunity=valid_opportunity,
+            invoice_type="service_delivery",
+            data={
+                "invoice_number": "INV-001",
+                "amount": posted_amount,
+                "date": "2025-11-06",
+                "start_date": "2025-10-01",
+                "end_date": "2025-10-31",
+                "description": "Monthly consulting services rendered.",
+            },
+            is_opportunity_pm=False,
+        )
+
+        assert form.is_valid() is expect_valid
+        if not expect_valid:
+            assert "The billable total for this period has changed since this page was loaded." in str(form.errors)
+            assert not PaymentInvoice.objects.filter(invoice_number="INV-001").exists()
+
+    @patch("commcare_connect.opportunity.forms.bill_invoice", return_value=[])
+    def test_service_delivery_amount_is_never_the_posted_one(self, mock_bill_invoice, valid_opportunity):
+        """The posted total is a preview artefact and must never survive onto the invoice.
+
+        bill_invoice is patched to return [] to stand in for the delta being billed
+        elsewhere between clean() and save() -- the race no validation can close. The invoice must
+        then be 0 rather than the 120 that was posted, so it never claims money it has no rows for.
+        """
+        ExchangeRateFactory(rate_date=datetime.date(2020, 1, 1))
+        payment_unit = PaymentUnitFactory(opportunity=valid_opportunity, amount=100, org_amount=20)
+        cw = CompletedWorkFactory(
+            opportunity_access__opportunity=valid_opportunity,
+            payment_unit=payment_unit,
+            status=CompletedWorkStatus.approved,
+            saved_approved_count=1,
+        )
+        cw.status_modified_date = datetime.date(2025, 10, 5)
+        cw.save()
+
+        form = AutomatedPaymentInvoiceForm(
+            opportunity=valid_opportunity,
+            invoice_type="service_delivery",
+            data={
+                "invoice_number": "INV-STALE",
+                # Matches the window at validation time, so clean() passes; the patched writer then
+                # reports no delta, as if it had been billed elsewhere in between.
+                "amount": 120.0,
+                "date": "2025-11-06",
+                "start_date": "2025-10-01",
+                "end_date": "2025-10-31",
+                "description": "Monthly consulting services rendered.",
+            },
+            is_opportunity_pm=False,
+        )
+
+        assert form.is_valid()
+        invoice = form.save()
+
+        invoice.refresh_from_db()
+        assert invoice.amount == Decimal("0")
+        assert invoice.amount_usd == Decimal("0")
+        assert not invoice.work_items.exists()
 
     def test_readonly_form_initialization(self, valid_opportunity):
         invoice = PaymentInvoiceFactory(

--- a/commcare_connect/opportunity/tests/test_tasks.py
+++ b/commcare_connect/opportunity/tests/test_tasks.py
@@ -410,6 +410,35 @@ class TestGenerateAutomatedServiceDeliveryInvoice:
         assert invoice2.work_items.get().completed_work_id == completed_work2.id
         assert invoice2.work_items.get().billed_count == 1
 
+    def test_one_failing_opportunity_does_not_abort_the_run(self):
+        failing = OpportunityFactory(active=True, is_test=False, start_date=datetime.date(2026, 1, 1))
+        billable = OpportunityFactory(active=True, is_test=False, start_date=datetime.date(2026, 1, 1))
+        payment_unit = PaymentUnitFactory(opportunity=billable, amount=Decimal("100.00"), org_amount=0)
+        access = OpportunityAccessFactory(opportunity=billable)
+        CompletedWorkFactory(
+            opportunity_access=access,
+            payment_unit=payment_unit,
+            status=CompletedWorkStatus.approved,
+            status_modified_date=datetime.date(2024, 1, 4),
+            saved_approved_count=1,
+            invoiced_approved_count=0,
+        )
+
+        def start_date(opportunity):
+            if opportunity.id == failing.id:
+                raise Exception("no exchange rate for the billed month")
+            return datetime.date(2024, 1, 1)
+
+        self.mock_start_date.side_effect = start_date
+
+        with mock.patch("commcare_connect.opportunity.tasks._send_auto_invoice_created_notification") as mock_notify:
+            generate_automated_service_delivery_invoice()
+
+        assert not PaymentInvoice.objects.filter(opportunity=failing).exists()
+        invoice = PaymentInvoice.objects.get(opportunity=billable)
+        # The notification still fires, or the invoices that did get billed go unannounced.
+        mock_notify.assert_called_once_with([invoice.id])
+
     def test_no_invoice_for_inactive_opportunities(self):
         inactive_opportunity = OpportunityFactory(active=False, is_test=False, start_date=datetime.date(2026, 1, 1))
         payment_unit = PaymentUnitFactory(opportunity=inactive_opportunity)

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -1854,7 +1854,9 @@ class InvoiceCreateView(OrganizationUserMixin, OpportunityObjectMixin, CreateVie
 
         form = self.get_form()
         if not form.is_valid():
-            return self.get(request, org_slug, opp_id, **kwargs)
+            # Re-render the bound form to preserve validation errors.
+            self.object = None
+            return self.form_invalid(form)
 
         form.save()
         return redirect(reverse("opportunity:invoice_list", args=[org_slug, opp_id]))

--- a/commcare_connect/templates/opportunity/partials/invoice_form_handler.html
+++ b/commcare_connect/templates/opportunity/partials/invoice_form_handler.html
@@ -6,8 +6,9 @@
       currency: false,
       startDate: "{% firstof form.instance.start_date|date:'Y-m-d' form.start_date.value  '' %}",
       endDate: "{% firstof form.instance.end_date|date:'Y-m-d' form.end_date.value '' %}",
-      amount: "{{ form.amount.value|default:'null' }}",
-      usdAmount: "{{ form.amount_usd.value|default:'null' }}",
+      // Preserve zero amounts; using `default` converts 0.00 to `null`.
+      amount: "{{ form.amount.value|default_if_none:'' }}",
+      usdAmount: "{{ form.amount_usd.value|default_if_none:'' }}",
       lateDeltaUnits: {{ form.late_delta_units.value|default:0 }},
       isServiceDelivery: "{{ is_service_delivery|yesno:'true,false' }}" == 'true',
       isReadOnly: "{{ is_read_only|yesno:'true,false'}}" == "true",

--- a/commcare_connect/templates/opportunity/partials/invoice_form_handler.html
+++ b/commcare_connect/templates/opportunity/partials/invoice_form_handler.html
@@ -17,6 +17,8 @@
       showRejectModal: false,
       showSubmitModal: false,
       certifyChecked: false,
+      lineItemsError: false,
+      lineItemsLoading: false,
 
       init() {
         if (this.isServiceDelivery) {
@@ -54,6 +56,9 @@
       fetchInvoiceLineItems() {
         if (!this.startDate || !this.endDate) return;
 
+        this.lineItemsError = false;
+        this.lineItemsLoading = true;
+
         fetch('{% url "opportunity:invoice_items" org_slug=request.org.slug opp_id=opportunity.opportunity_id %}', {
           method: 'POST',
           headers: {
@@ -76,7 +81,14 @@
           console.error('Error fetching invoice items:', error);
           // Nothing known about the window, so drop the count rather than leave a stale one showing.
           this.lateDeltaUnits = null;
+          // Clear totals and table on failure to avoid showing stale data from another window.
+          document.getElementById('invoice-line-items-wrapper').innerHTML = '';
+          this.amount = null;
+          this.usdAmount = null;
           this.showDownloadButton = false;
+          this.lineItemsError = true;
+        }).finally(() => {
+          this.lineItemsLoading = false;
         });
       },
 

--- a/commcare_connect/templates/opportunity/partials/invoice_line_items_fieldset.html
+++ b/commcare_connect/templates/opportunity/partials/invoice_line_items_fieldset.html
@@ -1,7 +1,22 @@
 {% load i18n %}
 {% load django_tables2 %}
 {% if form.line_items_table %}
-  <div class="overflow-x-auto mb-4">{% render_table form.line_items_table %}</div>
+  {% if form.line_items_table.rows %}
+    <div class="overflow-x-auto mb-4">{% render_table form.line_items_table %}</div>
+  {% else %}
+    {# An empty table alone reads as a missing page. Say which of the two reasons it is. #}
+    <div role="status"
+         class="flex items-center gap-2 p-4 mb-4 rounded-lg border-[0.5px] bg-message-info text-message-info-text border-message-info-border">
+      <i class="fa-solid fa-circle-info"></i>
+      <span>
+        {% if form.line_items_released %}
+          {% translate "Since this invoice was cancelled or rejected, the deliveries it billed have been released and are no longer listed here." %}
+        {% else %}
+          {% translate "No deliveries were billable for this period, so this invoice has no line items." %}
+        {% endif %}
+      </span>
+    </div>
+  {% endif %}
 {% else %}
   <div x-show="lineItemsError"
        x-cloak

--- a/commcare_connect/templates/opportunity/partials/invoice_line_items_fieldset.html
+++ b/commcare_connect/templates/opportunity/partials/invoice_line_items_fieldset.html
@@ -3,6 +3,18 @@
 {% if form.line_items_table %}
   {% if form.line_items_table.rows %}
     <div class="overflow-x-auto mb-4">{% render_table form.line_items_table %}</div>
+    <div id="download-line-items-wrapper"
+         x-cloak
+         x-show="showDownloadButton"
+         class="my-4">
+      <a type="button"
+         class="button button-md outline-style"
+         :href="downloadLineItemsUrl()"
+         target="_blank">
+        <i class="fa-solid fa-download mr-2"></i>
+        {% translate "Download All Items" %}
+      </a>
+    </div>
   {% else %}
     {# An empty table alone reads as a missing page. Say which of the two reasons it is. #}
     <div role="status"
@@ -33,15 +45,3 @@
   <div id="invoice-line-items-wrapper"
        class="space-y-1 text-sm text-gray-500 mb-4"></div>
 {% endif %}
-<div id="download-line-items-wrapper"
-     x-cloak
-     x-show="showDownloadButton"
-     class="my-4">
-  <a type="button"
-     class="button button-md outline-style"
-     :href="downloadLineItemsUrl()"
-     target="_blank">
-    <i class="fa-solid fa-download mr-2"></i>
-    {% translate "Download All Items" %}
-  </a>
-</div>

--- a/commcare_connect/templates/opportunity/partials/invoice_line_items_fieldset.html
+++ b/commcare_connect/templates/opportunity/partials/invoice_line_items_fieldset.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% load django_tables2 %}
+{% if form.line_items_table %}
+  <div class="overflow-x-auto mb-4">{% render_table form.line_items_table %}</div>
+{% else %}
+  <div x-show="lineItemsError"
+       x-cloak
+       role="alert"
+       class="flex items-center justify-between p-4 mb-4 rounded-lg border-[0.5px] bg-message-error text-message-error-text border-message-error-border">
+    <div class="flex items-center gap-2">
+      <i class="fa-solid fa-circle-exclamation"></i>
+      <span>{% translate "Could not load the deliveries for this period, so the amount is unavailable." %}</span>
+    </div>
+    <button type="button"
+            class="button button-md outline-style ml-4"
+            @click="fetchInvoiceLineItems()">{% translate "Retry" %}</button>
+  </div>
+  <div id="invoice-line-items-wrapper"
+       class="space-y-1 text-sm text-gray-500 mb-4"></div>
+{% endif %}
+<div id="download-line-items-wrapper"
+     x-cloak
+     x-show="showDownloadButton"
+     class="my-4">
+  <a type="button"
+     class="button button-md outline-style"
+     :href="downloadLineItemsUrl()"
+     target="_blank">
+    <i class="fa-solid fa-download mr-2"></i>
+    {% translate "Download All Items" %}
+  </a>
+</div>


### PR DESCRIPTION
## Product Description
Follow up PR to the invoice line items work

Fixes to the invoice form and the invoice page, found while working on the line-item change in #1425. Most are pre-existing bugs(_minor nothing critical_) rather than anything the new billing code introduced.

## What this PR does

Fixes:
- A failed line-item request now shows an error banner with a Retry button, clears the stale amount and table, and disables Submit.
<img width="3299" height="408" alt="image" src="https://github.com/user-attachments/assets/a62eb938-c33f-44bc-85a5-7cedc503799a" />


- An invalid submit always shows why. The view was building and validating a second copy of the form while rendering, so the errors shown came from a second database read — and if the data changed back in between, no error was shown at all.
- Rejects an end date that is today or in the future. Billing can only include completed days, so yesterday is the latest allowed date.
- Shows a 0 amount properly instead of a blank field for invoices with zero amounts _(today the system allows creating it if there are no deliveries).
-  One task fix: if a single opportunity fails during the monthly invoicing run, the run now carries on. Before, one failure stopped everything, and the invoices that had already been created were never announced.

Improvements:
- Rejects a total that no longer matches the period. If the deliveries moved between opening the form and submitting it, the NM gets a clear error and the corrected figures rather than an invoice for a number they never saw.
- Replaces the empty line-item table with a message saying which case it is: released because the invoice was cancelled or rejected, or nothing was billable for that period. This allows to differentiate between the two scenarios, instead of user assuming something.

 **In case the invoice was cancelled**
<img width="3299" height="408" alt="image" src="https://github.com/user-attachments/assets/cc1ec1c9-8441-4d21-b0a2-261b18f8724e" />

**No deliveries found**
<img width="3299" height="408" alt="image" src="https://github.com/user-attachments/assets/e61f60b3-fbc2-4f7f-8df5-9d5b370676f4" />


Worth reviewing commit by commit.

## Technical Summary

Ticket: [CCCT-2526](https://dimagi.atlassian.net/browse/CCCT-2526) (epic [CCCT-2530](https://dimagi.atlassian.net/browse/CCCT-2530))


## Safety Assurance

### Safety story

No database changes. Everything here is either a form validation, a template change or an error-handling change, so a defect is a code revert.

The riskiest one is rejecting a total that no longer matches the period, because it can block a submit. It only triggers when the deliveries genuinely changed since the form was opened, and the page re-fetches so the NM can submit the corrected figures straight away.

Two of these need the earlier parts of the stack (the total check and the monthly task fix). The rest apply on their own.

### Automated test coverage

`pytest commcare_connect/opportunity` — 652 passed. `prek run -a` clean.

Covers the window rules (period must be finished, end after start, no future end), the posted total never being trusted, a stale total being rejected, an invalid submit rendering its own errors once, a zero invoice showing 0 rather than a blank, the empty-table message for both cases, and one opportunity failing without stopping the monthly run.

### QA Plan
QA to be considered as it has some UI changes.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2526]: https://dimagi.atlassian.net/browse/CCCT-2526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ