### PR TITLE
Worker Phone Number + ID in UI

### DIFF
--- a/commcare_connect/audit/services.py
+++ b/commcare_connect/audit/services.py
@@ -20,12 +20,15 @@ def stream_audit_report_csv(report, selected_workers=None):
     columns = column_specs(report.entries.all()[:1])
     writer = csv.writer(EchoWriter())
 
-    yield writer.writerow([gettext("Connect Worker"), *_column_headers(columns)])
+    yield writer.writerow(
+        [gettext("Connect Worker"), gettext("Username"), gettext("Phone Number"), *_column_headers(columns)]
+    )
 
     entries = entries_for_export(report, selected_workers)
     for entry in entries.iterator(chunk_size=STREAM_CHUNK_SIZE):
+        user = entry.opportunity_access.user
         cells = [_export_cell_value(entry.results, name) for name, _label, _tooltip in columns]
-        yield writer.writerow([entry.opportunity_access.user.name, *cells])
+        yield writer.writerow([user.name, user.username or "", user.phone_number or "", *cells])
 
 
 def _column_headers(columns):

--- a/commcare_connect/audit/tables.py
+++ b/commcare_connect/audit/tables.py
@@ -158,10 +158,16 @@ class AuditReportEntryTable(OrgContextTable):
         verbose_name=_l("Connect Worker"),
         attrs={"th": {"class": "whitespace-normal align-bottom w-40"}},
     )
+    phone_number = columns.Column(
+        accessor="opportunity_access__user__phone_number",
+        verbose_name=_l("Phone Number"),
+        default="—",
+        attrs={"th": {"class": "whitespace-normal align-bottom w-36"}},
+    )
 
     class Meta:
         model = AuditReportEntry
-        fields = ("user",)
+        fields = ("user", "phone_number")
         empty_text = _l("No workers.")
 
     def __init__(self, data, *, opportunity, report, columns_spec, **kw):
@@ -173,3 +179,15 @@ class AuditReportEntryTable(OrgContextTable):
         ]
         extra.append(("action", ActionColumn()))
         super().__init__(data, extra_columns=extra, **kw)
+
+    def render_user(self, value, record):
+        return format_html(
+            """
+            <div class="flex flex-col items-start">
+                <p class="text-sm text-slate-900">{}</p>
+                <p class="text-xs text-slate-400">{}</p>
+            </div>
+            """,
+            value,
+            record.opportunity_access.user.username or "",
+        )

--- a/commcare_connect/audit/tests/conftest.py
+++ b/commcare_connect/audit/tests/conftest.py
@@ -10,8 +10,8 @@ def make_audit_entry():
     ``calc_a`` result, for a worker named ``name``.
     """
 
-    def _make(report, name, value, has_data=True, in_range=True):
-        access = OpportunityAccessFactory(user=UserFactory(name=name))
+    def _make(report, name, value, has_data=True, in_range=True, phone_number=None):
+        access = OpportunityAccessFactory(user=UserFactory(name=name, phone_number=phone_number))
         return AuditReportEntryFactory(
             audit_report=report,
             opportunity_access=access,

--- a/commcare_connect/audit/tests/test_services.py
+++ b/commcare_connect/audit/tests/test_services.py
@@ -118,14 +118,15 @@ def test_entries_for_export_filters_by_selected_workers(make_audit_entry):
 @pytest.mark.django_db
 def test_stream_audit_report_csv_outputs_header_and_rows(make_audit_entry):
     report = AuditReportFactory()
-    make_audit_entry(report, "Bob", 0.5, in_range=False)  # out-of-range still exports raw value
-    make_audit_entry(report, "Ann", None, has_data=False)  # insufficient data -> "N/A"
+    # Out-of-range still exports the raw value; a worker without a phone number gets an empty column.
+    bob = make_audit_entry(report, "Bob", 0.5, in_range=False, phone_number="+2348031234567")
+    ann = make_audit_entry(report, "Ann", None, has_data=False)  # insufficient data -> "N/A"
 
     lines = "".join(stream_audit_report_csv(report)).splitlines()
 
-    assert lines[0] == "Connect Worker,Calc A"
-    assert "Ann,N/A" in lines
-    assert "Bob,0.5" in lines
+    assert lines[0] == "Connect Worker,Username,Phone Number,Calc A"
+    assert f"Ann,{ann.opportunity_access.user.username},,N/A" in lines
+    assert f"Bob,{bob.opportunity_access.user.username},+2348031234567,0.5" in lines
 
 
 @pytest.mark.django_db
@@ -170,4 +171,4 @@ def test_stream_audit_report_csv_appends_reference_range_to_header(isolated_regi
 
     header = "".join(stream_audit_report_csv(report)).splitlines()[0]
 
-    assert header == "Connect Worker,Calc A (0.5 - 1.0)"
+    assert header == "Connect Worker,Username,Phone Number,Calc A (0.5 - 1.0)"

--- a/commcare_connect/audit/tests/test_views.py
+++ b/commcare_connect/audit/tests/test_views.py
@@ -328,10 +328,10 @@ def test_detail_filter_limits_table_server_side(client, program_manager_org_user
     assert response.status_code == 200
     rendered_rows = [e.opportunity_access.user.name for e in response.context["table"].page.object_list.data]
     assert rendered_rows == ["Alice Smith"]
-    # Both workers remain available as filter options.
+    # Both workers remain available as filter options, labelled "name (username)".
     option_names = [name for _, name in response.context["worker_filter_choices"]]
-    assert "Alice Smith" in option_names
-    assert "Bob Jones" in option_names
+    assert f"Alice Smith ({alice_access.user.username})" in option_names
+    assert f"Bob Jones ({bob_access.user.username})" in option_names
 
 
 @pytest.mark.django_db

--- a/commcare_connect/audit/views.py
+++ b/commcare_connect/audit/views.py
@@ -85,7 +85,9 @@ def audit_report_detail(request, org_slug, opp_id, audit_report_id):
     )
     columns_spec = column_specs(all_entries)
 
-    worker_filter_choices = [(str(e.opportunity_access_id), e.opportunity_access.user.name) for e in all_entries]
+    worker_filter_choices = [
+        (str(e.opportunity_access_id), e.opportunity_access.user.display_name_with_username()) for e in all_entries
+    ]
 
     selected_workers = request.GET.getlist("worker")
     if selected_workers:

--- a/commcare_connect/microplanning/forms.py
+++ b/commcare_connect/microplanning/forms.py
@@ -143,4 +143,4 @@ class AssignmentModeForm(forms.Form):
                 .select_related("user")
                 .order_by("user__name")
             )
-            self.fields["assignee"].label_from_instance = lambda obj: obj.user.name
+            self.fields["assignee"].label_from_instance = lambda obj: obj.user.display_name_with_username()

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -755,6 +755,7 @@ class TestWorkAreaTileViewFiltering(BaseMicroplanningFlagTest):
         assert row.group_id == group.id
         assert row.group_name == group.name
         assert row.assignee_name == access.user.name
+        assert row.assignee_phone == access.user.phone_number
 
 
 @pytest.mark.django_db

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -406,7 +406,7 @@ def _get_assignment_mode_context(request, opportunity):
         "assignees_json": list(
             OpportunityAccess.objects.filter(opportunity=opportunity, accepted=True, suspended=False)
             .select_related("user")
-            .values("id", "user__name", "user__user_id")
+            .values("id", "user__name", "user__username", "user__user_id")
         ),
         "group_work_areas_url": reverse(
             "microplanning:get_work_areas_for_assignment",

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -636,6 +636,7 @@ class WorkAreaVectorLayer(VectorLayer):
         "group_id",
         "group_name",
         "assignee_name",
+        "assignee_phone",
         "slug",
         "visits_completed",
         "implementation_area_name",
@@ -653,6 +654,7 @@ class WorkAreaVectorLayer(VectorLayer):
             group_id=F("work_area_group__id"),
             group_name=F("work_area_group__name"),
             assignee_name=F("opportunity_access__user__name"),
+            assignee_phone=F("opportunity_access__user__phone_number"),
             visits_completed=Count("uservisit", filter=Q(uservisit__status=VisitValidationStatus.approved)),
         )
         return WorkAreaMapFilterSet(self.filter_params, queryset=qs, opportunity=self.opportunity).qs

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1866,6 +1866,11 @@ class BaseAssignedTaskTable(tables.Table):
 
 class AssignedTaskListTable(BaseAssignedTaskTable, OpportunityContextTable):
     connect_worker = tables.Column(verbose_name=gettext_lazy("Connect Worker"), accessor="opportunity_access__user")
+    phone_number = tables.Column(
+        verbose_name=gettext_lazy("Phone Number"),
+        accessor="opportunity_access__user__phone_number",
+        default="—",
+    )
     task_type = tables.Column(verbose_name=gettext_lazy("Task Type"), accessor="task_type__name")
     action = tables.TemplateColumn(
         verbose_name="",
@@ -1886,6 +1891,7 @@ class AssignedTaskListTable(BaseAssignedTaskTable, OpportunityContextTable):
         sequence = (
             "select",
             "connect_worker",
+            "phone_number",
             "status",
             "task_type",
             "assigned_date",

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2682,6 +2682,7 @@ def user_visit_data(request, org_slug, opp_id, pk):
         {
             "visit_date": visit_date.strftime(DATE_TIME_FORMAT),
             "worker_name": escape(user_visit.user.name),
+            "phone_number": escape(user_visit.user.phone_number) if user_visit.user.phone_number else None,
             "deliver_type": escape(user_visit.deliver_unit.name) if user_visit.deliver_unit else None,
             "worker_url": (
                 f"{worker_url}?{urlencode({'user': user_visit.user.user_id, 'visit_id': user_visit.user_visit_id})}"

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -462,7 +462,7 @@
                         class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500">
                   <option value="">{% translate "— Select FLW —" %}</option>
                   <template x-for="a in assignees" :key="a.id">
-                    <option :value="a.id" x-text="a.user__name"></option>
+                    <option :value="a.id" x-text="`${a.user__name} (${a.user__username})`"></option>
                   </template>
                 </select>
               </div>

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -281,6 +281,10 @@
                     <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
                         x-text="selectedFeature.assignee_name ?? '—'">
                     </dd>
+                    <dt class="text-sm text-gray-500">{% translate "Assignee Phone Number" %}</dt>
+                    <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
+                        x-text="selectedFeature.assignee_phone ?? '—'">
+                    </dd>
                     <dt class="text-sm text-gray-500">{% translate "Work Area Group" %}</dt>
                     <dd class="text-sm font-medium text-right border border-gray-200 rounded-lg px-3 py-2 bg-gray-50 truncate"
                         x-text="selectedFeature.group_name ?? '—'">

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -73,6 +73,7 @@
                             .setHTML(`
                                 <table><tbody>
                                 <tr><th class="text-left pr-4 whitespace-nowrap">{% translate "Connect Worker" %}</th><td>${data.worker_name}</td></tr>
+                                <tr><th class="text-left pr-4 whitespace-nowrap">{% translate "Phone Number" %}</th><td>${data.phone_number ?? '—'}</td></tr>
                                 <tr><th class="text-left pr-4 whitespace-nowrap">{% translate "Visit Date" %}</th><td>${data.visit_date}</td></tr>
                                 <tr><th class="text-left pr-4 whitespace-nowrap">{% translate "Deliver Type" %}</th><td>${data.deliver_type ?? '—'}</td></tr>
                                 </tbody></table>
@@ -664,6 +665,7 @@
                             if (props) {
                                 props.status = 'UNASSIGNED';
                                 props.assignee_name = null;
+                                props.assignee_phone = null;
                             }
                         }
                         if (unassignedIds.length > 0) this.invalidateGroupWorkAreasCache();


### PR DESCRIPTION
## Product Description

The worker's phone number and ID is now visible and shown more consistently in the UI.

On the progress map page, the work area detail panel shows an "Assignee Phone Number" row, and the visit popup shows a "Phone Number" row alongside the Connect worker:

<img width="426" height="524" alt="Screenshot_20260806_115259" src="https://github.com/user-attachments/assets/7b82143b-c633-46ae-acbe-471699c13010" />

<img width="319" height="208" alt="Screenshot_20260806_115238" src="https://github.com/user-attachments/assets/beccb06b-4011-4823-b6ee-d82e3608be87" />

Assignee dropdowns — both the assignment form and the map's FLW selector — now label workers as "name (username)" so that workers sharing a display name can be told apart:

<img width="483" height="346" alt="Screenshot_20260806_115500" src="https://github.com/user-attachments/assets/ccbfb608-c8d5-48bb-a773-e1d2f7e146f4" />

<img width="483" height="346" alt="Screenshot_20260806_115451" src="https://github.com/user-attachments/assets/903ccf44-7701-4d35-ab7f-d1af6f091e77" />

The weekly performance report lists each worker's username beneath their name and adds a Phone Number column; its worker filter options are labelled "name (username)", and the CSV export gains Username and Phone Number columns:
<img width="1166" height="613" alt="Screenshot_20260806_115552" src="https://github.com/user-attachments/assets/bee372cb-f0bd-49a1-a971-04ee4cc9d310" />

The assigned task list gains a Phone Number column directly after Connect Worker:
<img width="1110" height="803" alt="Screenshot_20260806_115621" src="https://github.com/user-attachments/assets/b4857f12-49ed-44cb-bd02-0a64a721b339" />


## Technical Summary

Link to tickets here:
- [CCCT-2718](https://dimagi.atlassian.net/browse/CCCT-2718)
- [CCCT-2719](https://dimagi.atlassian.net/browse/CCCT-2719)
- [CCCT-2721](https://dimagi.atlassian.net/browse/CCCT-2721)
- [CCCT-2722](https://dimagi.atlassian.net/browse/CCCT-2722)

This is a release path 3 feature — Experiments & early stage iterations of product area.

Phone number and username are read straight off the existing `User` record, so every addition is an accessor, annotation, or extra `values()` field on a query that already traverses to the user — no new endpoints, no schema changes, and no extra queries per row. On the map, `assignee_phone` is added to the vector tile layer's annotated fields so it travels with the tile data that already carries `assignee_name`; the unassign handler clears it from the client-side property cache alongside the name so an already-rendered feature stays consistent without a refetch.

## Safety Assurance

### Safety story

This is a read-only display change: it surfaces data already stored on the user record and touches no writes, migrations, or existing data. Missing values degrade to "—" (or an empty CSV cell) rather than erroring, and the map-facing changes remain behind the existing microplanning feature flag and org-admin permission checks.

### Automated test coverage

Tests cover the phone number annotation on the work area tile layer queryset, the audit report CSV export end-to-end (header plus rows, for workers both with and without a phone number), and the worker filter options now being labelled with the username. Existing audit report and table tests continue to pass unchanged, confirming the added columns don't disturb the current report output.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2718]: https://dimagi.atlassian.net/browse/CCCT-2718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ