### PR TITLE
Prefetch claim limits in the opportunity user data export

### DIFF
--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -18,7 +18,6 @@ from commcare_connect.opportunity.models import (
     CompletedWork,
     LabsRecord,
     Opportunity,
-    OpportunityClaimLimit,
     Payment,
     PaymentInvoice,
     TaskType,
@@ -73,6 +72,12 @@ class ProgramDataExportSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "delivery_type", "currency", "organization", "funder", "watchers"]
 
 
+# Reused across rows so the serializer's fields are only built once. It carries no
+# per-instance state, so it is safe to share. Kept at module level because a serializer
+# assigned as a class attribute would be collected as a declared field.
+_claim_limit_list_serializer = OpportunityClaimLimitSerializer(many=True)
+
+
 class OpportunityUserDataSerializer(serializers.Serializer):
     username = serializers.CharField()
     name = serializers.CharField()
@@ -91,8 +96,14 @@ class OpportunityUserDataSerializer(serializers.Serializer):
 
     @extend_schema_field(OpportunityClaimLimitSerializer.many_init())
     def get_claim_limits(self, obj):
-        claim_limits = OpportunityClaimLimit.objects.filter(opportunity_claim__opportunity_access=obj)
-        data = OpportunityClaimLimitSerializer(claim_limits, many=True).data
+        """Reads the claim limits prefetched by ``OpportunityUserDataView.get_queryset``.
+
+        Falls back to a query when the object was not loaded through that queryset.
+        """
+        claim = getattr(obj, "opportunityclaim", None)
+        if claim is None:
+            return []
+        data = _claim_limit_list_serializer.to_representation(claim.opportunityclaimlimit_set.all())
         return [dict(row) for row in data]
 
 

--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -96,10 +96,7 @@ class OpportunityUserDataSerializer(serializers.Serializer):
 
     @extend_schema_field(OpportunityClaimLimitSerializer.many_init())
     def get_claim_limits(self, obj):
-        """Reads the claim limits prefetched by ``OpportunityUserDataView.get_queryset``.
-
-        Falls back to a query when the object was not loaded through that queryset.
-        """
+        """Reads the claim limits prefetched by ``OpportunityUserDataView.get_queryset``."""
         claim = getattr(obj, "opportunityclaim", None)
         if claim is None:
             return []

--- a/commcare_connect/data_export/tests/test_views.py
+++ b/commcare_connect/data_export/tests/test_views.py
@@ -10,12 +10,17 @@ from django.utils import timezone
 from django.utils.timezone import now
 
 from commcare_connect.audit.tests.factories import AuditReportEntryFactory, AuditReportFactory
+from commcare_connect.data_export.serializer import OpportunityUserDataSerializer
+from commcare_connect.data_export.views import OpportunityUserDataView
 from commcare_connect.microplanning.tests.factories import WorkAreaFactory, WorkAreaGroupFactory
 from commcare_connect.opportunity.models import LabsRecord
 from commcare_connect.opportunity.tests.factories import (
     AssignedTaskFactory,
     BlobMetaFactory,
     OpportunityAccessFactory,
+    OpportunityClaimFactory,
+    OpportunityClaimLimitFactory,
+    PaymentUnitFactory,
     TaskTypeFactory,
     UserVisitFactory,
 )
@@ -289,6 +294,69 @@ class TestAuditReportEntryDataView:
         url = reverse("data_export:audit_report_entry_data", kwargs={"opp_id": opportunity.id})
         response = api_client.get(url)
         assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestOpportunityUserDataView:
+    def _build_queryset(self, opportunity):
+        view = OpportunityUserDataView()
+        view.opportunity = opportunity
+        return view.get_queryset(request=None, opp_id=opportunity.id)
+
+    def test_claim_limits_use_a_constant_number_of_queries(self, opportunity, django_assert_num_queries):
+        payment_units = [PaymentUnitFactory(opportunity=opportunity) for _ in range(2)]
+        for _ in range(3):
+            claim = OpportunityClaimFactory(
+                opportunity_access=OpportunityAccessFactory(opportunity=opportunity),
+            )
+            for payment_unit in payment_units:
+                OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit)
+
+        queryset = self._build_queryset(opportunity)
+        # accesses + claims + claim limits, regardless of how many users or claim limits there are
+        with django_assert_num_queries(3):
+            data = OpportunityUserDataSerializer(queryset, many=True).data
+
+        assert len(data) == 3
+        for row in data:
+            assert sorted(limit["payment_unit"] for limit in row["claim_limits"]) == sorted(
+                pu.id for pu in payment_units
+            )
+
+    def test_claim_limits_contents(self, opportunity):
+        payment_unit = PaymentUnitFactory(opportunity=opportunity)
+        claim = OpportunityClaimFactory(opportunity_access=OpportunityAccessFactory(opportunity=opportunity))
+        claim_limit = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit)
+
+        (row,) = OpportunityUserDataSerializer(self._build_queryset(opportunity), many=True).data
+
+        assert row["claim_limits"] == [
+            {
+                "max_visits": claim_limit.max_visits,
+                "payment_unit": payment_unit.id,
+                "payment_unit_id": str(payment_unit.payment_unit_id),
+            }
+        ]
+
+    def test_csv_stream_keeps_the_prefetch(self, opportunity, django_assert_num_queries):
+        """The v1.0 path iterates the queryset, which only keeps prefetches when a chunk size is set."""
+        payment_unit = PaymentUnitFactory(opportunity=opportunity)
+        claim = OpportunityClaimFactory(opportunity_access=OpportunityAccessFactory(opportunity=opportunity))
+        claim_limit = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit)
+
+        view = OpportunityUserDataView()
+        view.opportunity = opportunity
+        with django_assert_num_queries(3):
+            rows = list(view.get_data_generator(request=None, opp_id=opportunity.id))
+
+        assert str(claim_limit.max_visits) in rows[-1]
+
+    def test_access_without_claim_has_no_claim_limits(self, opportunity):
+        OpportunityAccessFactory(opportunity=opportunity)
+
+        (row,) = OpportunityUserDataSerializer(self._build_queryset(opportunity), many=True).data
+
+        assert row["claim_limits"] == []
 
 
 @pytest.mark.django_db

--- a/commcare_connect/data_export/tests/test_views.py
+++ b/commcare_connect/data_export/tests/test_views.py
@@ -298,10 +298,20 @@ class TestAuditReportEntryDataView:
 
 @pytest.mark.django_db
 class TestOpportunityUserDataView:
-    def _build_queryset(self, opportunity):
+    def _build_view(self, opportunity):
         view = OpportunityUserDataView()
         view.opportunity = opportunity
-        return view.get_queryset(request=None, opp_id=opportunity.id)
+        return view
+
+    def _build_queryset(self, opportunity):
+        return self._build_view(opportunity).get_queryset(request=None, opp_id=opportunity.id)
+
+    def _create_claim_limit(self, opportunity):
+        claim = OpportunityClaimFactory(opportunity_access=OpportunityAccessFactory(opportunity=opportunity))
+        return OpportunityClaimLimitFactory(
+            opportunity_claim=claim,
+            payment_unit=PaymentUnitFactory(opportunity=opportunity),
+        )
 
     def test_claim_limits_use_a_constant_number_of_queries(self, opportunity, django_assert_num_queries):
         payment_units = [PaymentUnitFactory(opportunity=opportunity) for _ in range(2)]
@@ -313,8 +323,8 @@ class TestOpportunityUserDataView:
                 OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit)
 
         queryset = self._build_queryset(opportunity)
-        # accesses + claims + claim limits, regardless of how many users or claim limits there are
-        with django_assert_num_queries(3):
+        # accesses (with their claim) + claim limits, regardless of how many users or claim limits there are
+        with django_assert_num_queries(2):
             data = OpportunityUserDataSerializer(queryset, many=True).data
 
         assert len(data) == 3
@@ -324,29 +334,24 @@ class TestOpportunityUserDataView:
             )
 
     def test_claim_limits_contents(self, opportunity):
-        payment_unit = PaymentUnitFactory(opportunity=opportunity)
-        claim = OpportunityClaimFactory(opportunity_access=OpportunityAccessFactory(opportunity=opportunity))
-        claim_limit = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit)
+        claim_limit = self._create_claim_limit(opportunity)
 
         (row,) = OpportunityUserDataSerializer(self._build_queryset(opportunity), many=True).data
 
         assert row["claim_limits"] == [
             {
                 "max_visits": claim_limit.max_visits,
-                "payment_unit": payment_unit.id,
-                "payment_unit_id": str(payment_unit.payment_unit_id),
+                "payment_unit": claim_limit.payment_unit_id,
+                "payment_unit_id": str(claim_limit.payment_unit.payment_unit_id),
             }
         ]
 
     def test_csv_stream_keeps_the_prefetch(self, opportunity, django_assert_num_queries):
         """The v1.0 path iterates the queryset, which only keeps prefetches when a chunk size is set."""
-        payment_unit = PaymentUnitFactory(opportunity=opportunity)
-        claim = OpportunityClaimFactory(opportunity_access=OpportunityAccessFactory(opportunity=opportunity))
-        claim_limit = OpportunityClaimLimitFactory(opportunity_claim=claim, payment_unit=payment_unit)
+        claim_limit = self._create_claim_limit(opportunity)
 
-        view = OpportunityUserDataView()
-        view.opportunity = opportunity
-        with django_assert_num_queries(3):
+        view = self._build_view(opportunity)
+        with django_assert_num_queries(2):
             rows = list(view.get_data_generator(request=None, opp_id=opportunity.id))
 
         assert str(claim_limit.max_visits) in rows[-1]

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -4,7 +4,7 @@ import uuid
 from collections import defaultdict
 
 from django.core.files.storage import storages
-from django.db.models import Count, F, Q
+from django.db.models import Count, F, Prefetch, Q
 from django.http import FileResponse, JsonResponse, StreamingHttpResponse
 from drf_spectacular.utils import extend_schema, inline_serializer
 from oauth2_provider.contrib.rest_framework.permissions import TokenHasScope
@@ -58,6 +58,7 @@ from commcare_connect.opportunity.models import (
     LabsRecord,
     Opportunity,
     OpportunityAccess,
+    OpportunityClaimLimit,
     Payment,
     PaymentInvoice,
     TaskType,
@@ -246,12 +247,21 @@ class OpportunityUserDataView(OpportunityScopedDataView):
     serializer_class = OpportunityUserDataSerializer
 
     def get_queryset(self, request, opp_id):
-        return OpportunityAccess.objects.filter(opportunity=self.opportunity).annotate(
-            username=F("user__username"),
-            name=F("user__name"),
-            phone=F("user__phone_number"),
-            user_invite_status=F("userinvite__status"),
-            date_claimed=F("opportunityclaim__date_claimed"),
+        return (
+            OpportunityAccess.objects.filter(opportunity=self.opportunity)
+            .annotate(
+                username=F("user__username"),
+                name=F("user__name"),
+                phone=F("user__phone_number"),
+                user_invite_status=F("userinvite__status"),
+                date_claimed=F("opportunityclaim__date_claimed"),
+            )
+            .prefetch_related(
+                Prefetch(
+                    "opportunityclaim__opportunityclaimlimit_set",
+                    queryset=OpportunityClaimLimit.objects.select_related("payment_unit"),
+                )
+            )
         )
 
 

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -249,6 +249,9 @@ class OpportunityUserDataView(OpportunityScopedDataView):
     def get_queryset(self, request, opp_id):
         return (
             OpportunityAccess.objects.filter(opportunity=self.opportunity)
+            # The claim is already joined for the date_claimed annotation, so selecting it
+            # costs nothing and saves the prefetch a round trip.
+            .select_related("opportunityclaim")
             .annotate(
                 username=F("user__username"),
                 name=F("user__name"),


### PR DESCRIPTION
## Product Description

No user-facing change. The opportunity user data export returns the same payload with far fewer queries.

## Technical Summary

`OpportunityUserDataSerializer.get_claim_limits` ran one query per user row, plus one per claim limit (`payment_unit_id` uses `source="payment_unit.payment_unit_id"`, which lazy-loads the FK). The serializer is built per object on both export paths — the v1.0 CSV stream and the v2.0 page — so this was an N×M+N.

Now the view prefetches the claim limits with their payment units, and the serializer reads that cache. The claim itself is `select_related` — it's already joined for the `date_claimed` annotation, so that's free and saves the prefetch a round trip. A 3 user × 2 payment unit export goes from **10 queries to 2**, flat in both dimensions.

Note: the shared `OpportunityClaimLimitSerializer(many=True)` has to live at module level — as a class attribute, DRF's metaclass would collect it as a declared field.

## Safety Assurance

### Safety story

Read-only change: no writes, no migrations, no API contract change. Output is identical; only the queries change.

### Automated test coverage

New `TestOpportunityUserDataView` covers query counts on both the v2.0 and CSV paths (the CSV test also guards the `chunk_size` that `.iterator()` needs to keep prefetches), plus output shape and the no-claim case. The query-count test fails against the old code with `Expected to perform 2 queries but 10 were done`. Full `pytest commcare_connect/data_export`: 80 passed.

### QA Plan

Covered by automated tests; no separate QA ticket.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
