### PR TITLE
Log HQ exception

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3781,7 +3781,8 @@ def create_task(request, org_slug, opp_id):
         )
     except TaskAlreadyAssignedError:
         messages.error(request, _("This task type is already assigned to the selected worker."))
-    except CommCareHQAPIException:
+    except CommCareHQAPIException as e:
+        logger.exception(f"CommCareHQ task creation failed: {str(e)}")
         messages.error(request, _("Task creation failed: could not update CommCare HQ. Please try again."))
     except OcsApiError as e:
         logger.exception(f"OCS task creation failed: {str(e)}")


### PR DESCRIPTION
## Technical Summary
Make sure HQ exceptions are logged to sentry during task assignment.

## Safety Assurance

### Safety story
It only adds a log, so inherently safe. 

### Automated test coverage
N.A

### QA Plan
N.A

### Labels & Review
- [x ] The set of people pinged as reviewers is appropriate for the level of risk of the change
