### PR TITLE
Rebuilds the current KMC donation page on Connect's new website

### DIFF
--- a/commcare_connect/prelogin/urls.py
+++ b/commcare_connect/prelogin/urls.py
@@ -24,6 +24,7 @@ MARKETING_ROUTES = [
     "insights",
     "release-notes",
     "frontline-network",
+    "support-kmc",
 ]
 
 urlpatterns = [path(route, views.home, name=route or "home") for route in MARKETING_ROUTES]

--- a/commcare_connect/static/prelogin/app.js
+++ b/commcare_connect/static/prelogin/app.js
@@ -163,6 +163,10 @@ const ROUTE_META = {
     title: 'Rooftop Sampling | Connect by Dimagi',
     desc: 'A GPS-navigated household survey method that uses satellite building footprints as the sampling frame, no household list required. Developed by IDinsight.',
   },
+  '/support-kmc': {
+    title: 'Fund a Frontline Worker | Connect by Dimagi',
+    desc: 'Your gift funds a trained Frontline Worker to deliver verified Kangaroo Mother Care home visits to small and vulnerable newborns. $60 covers one complete, verified intervention.',
+  },
 };
 
 // Only the SPA document (index.html) carries the home route; the standalone
@@ -1056,6 +1060,75 @@ document.addEventListener('click', (e) => {
   }
   function init() {
     document.querySelectorAll('.testimonial-carousel').forEach(setup);
+  }
+  if (document.readyState !== 'loading') init();
+  else document.addEventListener('DOMContentLoaded', init);
+})();
+
+// Support KMC (/support-kmc): donation frequency toggle swaps each
+// donate-button's href between its one-time / monthly / quarterly / yearly
+// Stripe Payment Link, and the sticky "Donate Now" bar appears once the hero
+// has scrolled out of view.
+(function () {
+  function setup(section) {
+    const oneTimeBtn = section.querySelector('#oneTimeBtn');
+    const recurringBtn = section.querySelector('#recurringBtn');
+    const recurringOptions = section.querySelector('#recurringOptions');
+    if (!oneTimeBtn || !recurringBtn || !recurringOptions) return;
+    const donateButtons = section.querySelectorAll('.donate-button');
+
+    function setFrequency(freq) {
+      donateButtons.forEach((btn) => {
+        const url = btn.dataset[freq === 'onetime' ? 'onetime' : freq];
+        if (url) btn.href = url;
+      });
+    }
+
+    oneTimeBtn.addEventListener('click', () => {
+      oneTimeBtn.classList.add('active');
+      recurringBtn.classList.remove('active');
+      recurringOptions.classList.remove('visible');
+      setFrequency('onetime');
+    });
+
+    recurringBtn.addEventListener('click', () => {
+      recurringBtn.classList.add('active');
+      oneTimeBtn.classList.remove('active');
+      recurringOptions.classList.add('visible');
+      const activeSub =
+        recurringOptions.querySelector('button.active') ||
+        recurringOptions.querySelector('button');
+      recurringOptions
+        .querySelectorAll('button')
+        .forEach((b) => b.classList.remove('active'));
+      activeSub.classList.add('active');
+      setFrequency(activeSub.dataset.frequency);
+    });
+
+    recurringOptions.querySelectorAll('button').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        recurringOptions
+          .querySelectorAll('button')
+          .forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+        setFrequency(btn.dataset.frequency);
+      });
+    });
+
+    const hero = section.querySelector('.hero-dark');
+    const stickyCta = section.querySelector('#stickyCta');
+    if (hero && stickyCta) {
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          stickyCta.classList.toggle('visible', !entry.isIntersecting);
+        },
+        { threshold: 0 },
+      );
+      observer.observe(hero);
+    }
+  }
+  function init() {
+    document.querySelectorAll('[data-page="/support-kmc"]').forEach(setup);
   }
   if (document.readyState !== 'loading') init();
   else document.addEventListener('DOMContentLoaded', init);

--- a/commcare_connect/static/prelogin/app.js
+++ b/commcare_connect/static/prelogin/app.js
@@ -1084,24 +1084,29 @@ document.addEventListener('click', (e) => {
       });
     }
 
+    function setPressed(btn, pressed) {
+      btn.classList.toggle('active', pressed);
+      btn.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+    }
+
     oneTimeBtn.addEventListener('click', () => {
-      oneTimeBtn.classList.add('active');
-      recurringBtn.classList.remove('active');
+      setPressed(oneTimeBtn, true);
+      setPressed(recurringBtn, false);
       recurringOptions.classList.remove('visible');
       setFrequency('onetime');
     });
 
     recurringBtn.addEventListener('click', () => {
-      recurringBtn.classList.add('active');
-      oneTimeBtn.classList.remove('active');
+      setPressed(recurringBtn, true);
+      setPressed(oneTimeBtn, false);
       recurringOptions.classList.add('visible');
       const activeSub =
         recurringOptions.querySelector('button.active') ||
         recurringOptions.querySelector('button');
       recurringOptions
         .querySelectorAll('button')
-        .forEach((b) => b.classList.remove('active'));
-      activeSub.classList.add('active');
+        .forEach((b) => setPressed(b, false));
+      setPressed(activeSub, true);
       setFrequency(activeSub.dataset.frequency);
     });
 
@@ -1109,18 +1114,29 @@ document.addEventListener('click', (e) => {
       btn.addEventListener('click', () => {
         recurringOptions
           .querySelectorAll('button')
-          .forEach((b) => b.classList.remove('active'));
-        btn.classList.add('active');
+          .forEach((b) => setPressed(b, false));
+        setPressed(btn, true);
         setFrequency(btn.dataset.frequency);
       });
     });
 
+    // Only float the sticky CTA while /support-kmc is the active SPA route —
+    // the hero sits in the DOM (just display:none) on every other page too,
+    // so an unguarded observer would flag it as "not intersecting" the
+    // moment the visitor navigates away and incorrectly show the CTA there.
     const hero = section.querySelector('.hero-dark');
     const stickyCta = section.querySelector('#stickyCta');
     if (hero && stickyCta) {
+      const setCtaVisible = (visible) => {
+        stickyCta.classList.toggle('visible', visible);
+        stickyCta.setAttribute('aria-hidden', visible ? 'false' : 'true');
+        stickyCta.setAttribute('tabindex', visible ? '0' : '-1');
+      };
       const observer = new IntersectionObserver(
         ([entry]) => {
-          stickyCta.classList.toggle('visible', !entry.isIntersecting);
+          setCtaVisible(
+            section.classList.contains('active') && !entry.isIntersecting,
+          );
         },
         { threshold: 0 },
       );

--- a/commcare_connect/static/prelogin/styles.css
+++ b/commcare_connect/static/prelogin/styles.css
@@ -10372,3 +10372,663 @@ a.explore-card:hover {
     margin-top: 36px;
   }
 }
+
+/* ── Support KMC (/support-kmc): donation landing page ── */
+.section-cta {
+  text-align: center;
+  margin-top: var(--space-lg);
+}
+
+/* Split narrative grid (proven intervention / hope arrives) */
+.split-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  align-items: start;
+}
+.split-grid + .split-grid {
+  margin-top: var(--space-lg);
+}
+.split-grid h3 {
+  color: var(--step-learn);
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+.split-grid p {
+  color: var(--ink-3);
+  font-size: 16px;
+  font-weight: 400;
+}
+.lede-text p {
+  font-size: var(--fs-lede);
+  font-weight: 300;
+  line-height: 1.6;
+}
+.challenge-head {
+  margin-bottom: var(--sec-head-gap);
+  text-align: center;
+}
+.challenge-head .eyebrow {
+  justify-content: center;
+}
+.challenge-head h2 {
+  font-size: var(--fs-statement);
+  font-weight: 300;
+  margin: 10px 0 0;
+  line-height: 1.15;
+  max-width: none;
+}
+.challenge-head h2 em {
+  font-style: normal;
+  font-weight: 600;
+  background: var(--grad-text);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.split-grid.align-stretch {
+  align-items: stretch;
+}
+.split-grid.align-stretch figure {
+  display: flex;
+  min-height: 100%;
+}
+.split-grid.align-stretch img {
+  height: 100%;
+  aspect-ratio: auto;
+  object-fit: cover;
+}
+.split-grid ul {
+  list-style: none;
+  margin-top: var(--space-xs);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.split-grid ul li {
+  position: relative;
+  padding-left: 22px;
+  color: var(--ink-3);
+  font-size: 16px;
+}
+.split-grid ul li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 10px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--indigo);
+}
+.split-grid figure {
+  margin: 0;
+}
+.split-grid img {
+  width: 100%;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 60px -24px rgba(10, 6, 32, 0.35);
+  object-fit: cover;
+  aspect-ratio: 4 / 3;
+  transition: transform 0.4s ease;
+}
+.split-grid figure:hover img {
+  transform: scale(1.015);
+}
+@media (max-width: 860px) {
+  .split-grid {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+  .split-grid.media-first figure {
+    order: -1;
+  }
+}
+
+/* 3-step impact cards */
+.step-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.step-card {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 30px 28px;
+  transition:
+    border-color 0.15s,
+    transform 0.15s,
+    box-shadow 0.2s;
+}
+.step-card:hover {
+  border-color: var(--indigo);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(56, 67, 208, 0.1);
+}
+.step-card .step-number {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--indigo-soft);
+  color: var(--indigo);
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+.step-card h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.step-card p {
+  color: var(--ink-3);
+  font-size: 14.5px;
+  margin: 0;
+}
+@media (max-width: 860px) {
+  .step-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Photo-band section (Ready to Reach Thousands More) */
+.photo-band {
+  position: relative;
+  background-size: cover;
+  background-position: center;
+  color: #fff;
+  border-top: none;
+}
+.photo-band--uganda {
+  background-image: url('images/field-photos/kmc/kmc-3.jpg');
+}
+.photo-band::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    120deg,
+    rgba(10, 6, 32, 0.92) 0%,
+    rgba(10, 6, 32, 0.72) 55%,
+    rgba(10, 6, 32, 0.5) 100%
+  );
+}
+.photo-band .wrap {
+  position: relative;
+  z-index: 1;
+}
+.photo-band-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  align-items: center;
+}
+.photo-band h2 {
+  color: #fff;
+  font-size: var(--fs-h2);
+  font-weight: 300;
+  margin-bottom: 16px;
+}
+.photo-band h2 em {
+  font-style: normal;
+  font-weight: 600;
+  background: var(--grad-text-on-dark);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.photo-band p {
+  color: var(--on-dark-secondary);
+  font-size: 16px;
+}
+.data-callout-box {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: var(--radius-lg);
+  padding: 28px 26px;
+  backdrop-filter: blur(6px);
+}
+.data-callout-box p {
+  margin: 0 0 10px;
+}
+.data-callout-box p.headline-stat {
+  font-weight: 600;
+  color: #fff;
+  font-size: 18px;
+  line-height: 1.5;
+  margin-bottom: 0;
+}
+@media (max-width: 860px) {
+  .photo-band-grid {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+}
+
+/* Ripple section: light background, divided 3-up grid, solid-indigo icon
+   badges (guaranteed contrast, unlike an emoji on a color background) */
+.ripple-foundation {
+  background: var(--paper);
+}
+.pf-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.pf-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 16px;
+  padding: 30px 28px;
+}
+.pf-item:not(:nth-child(3n)) {
+  border-right: 1px solid rgba(40, 50, 160, 0.14);
+}
+.pf-item:nth-child(-n + 3) {
+  border-bottom: 1px solid rgba(40, 50, 160, 0.14);
+}
+.pf-icn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 13px;
+  background: var(--indigo);
+  color: #fff;
+  flex-shrink: 0;
+}
+.pf-icn svg {
+  width: 22px;
+  height: 22px;
+}
+.pf-txt {
+  max-width: 260px;
+}
+.pf-title {
+  display: block;
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.ripple-close {
+  color: var(--ink-3);
+  font-size: var(--fs-lede);
+  font-weight: 300;
+  line-height: 1.55;
+  text-align: center;
+  max-width: 56ch;
+  margin: var(--space-lg) auto 0;
+}
+@media (max-width: 860px) {
+  .pf-row {
+    grid-template-columns: repeat(2, 1fr);
+    max-width: 620px;
+  }
+  .pf-item:not(:nth-child(3n)) {
+    border-right: none;
+  }
+  .pf-item:nth-child(-n + 3) {
+    border-bottom: none;
+  }
+  .pf-item:nth-child(odd) {
+    border-right: 1px solid rgba(40, 50, 160, 0.14);
+  }
+  .pf-item:nth-child(-n + 2) {
+    border-bottom: 1px solid rgba(40, 50, 160, 0.14);
+  }
+}
+@media (max-width: 560px) {
+  .pf-row {
+    grid-template-columns: 1fr;
+    max-width: 320px;
+  }
+  .pf-item {
+    border-right: none !important;
+    border-bottom: 1px solid rgba(40, 50, 160, 0.14) !important;
+  }
+  .pf-item:last-child {
+    border-bottom: none !important;
+  }
+}
+
+/* Donation section: bold indigo band (same color as the primary CTA buttons),
+   radial glow + dot-grid overlay matching Connect's closing-cta treatment.
+   Tier cards stay solid white so they still read as boxes. */
+.donation-section {
+  position: relative;
+  background: var(--indigo);
+  color: #fff;
+  overflow: hidden;
+}
+.donation-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 60% 50% at 100% 0%,
+    rgba(255, 255, 255, 0.14),
+    transparent 65%
+  );
+  pointer-events: none;
+}
+.donation-section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(
+    ellipse at 50% 30%,
+    rgba(0, 0, 0, 0.8),
+    transparent 75%
+  );
+  -webkit-mask-image: radial-gradient(
+    ellipse at 50% 30%,
+    rgba(0, 0, 0, 0.8),
+    transparent 75%
+  );
+  pointer-events: none;
+}
+.donation-section .wrap {
+  position: relative;
+  z-index: 1;
+}
+.donation-section .eyebrow {
+  color: var(--on-dark-secondary);
+}
+.donation-section .eyebrow::before {
+  background: rgba(255, 255, 255, 0.5);
+}
+.donation-section .sec-head h2 {
+  color: #fff;
+}
+.donation-section .sec-head h2 em {
+  background: var(--grad-text-on-dark);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.donation-section .sec-head .sub {
+  color: var(--on-dark-secondary);
+}
+.donation-fineprint {
+  text-align: center;
+  color: var(--on-dark-muted);
+  font-size: 12.5px;
+  line-height: 1.6;
+  max-width: 64ch;
+  margin: var(--space-md) auto 0;
+}
+.frequency-toggle-wrap {
+  margin-bottom: var(--space-lg);
+  text-align: center;
+}
+.frequency-toggle-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--on-dark-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+.frequency-toggle {
+  display: inline-flex;
+  background: var(--paper-warm);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 4px;
+}
+.frequency-toggle button {
+  border: none;
+  background: transparent;
+  padding: 10px 22px;
+  border-radius: 999px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink-3);
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    color 0.15s,
+    box-shadow 0.15s;
+}
+.frequency-toggle button.active {
+  background: var(--paper-2);
+  color: var(--indigo);
+  box-shadow:
+    0 1px 2px rgba(20, 16, 58, 0.06),
+    0 4px 12px -6px rgba(20, 16, 58, 0.18);
+}
+.recurring-options {
+  display: none;
+  gap: 8px;
+  margin-top: 14px;
+  justify-content: center;
+}
+.recurring-options.visible {
+  display: flex;
+}
+.recurring-options button {
+  border: 1px solid var(--line);
+  background: var(--paper-2);
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-3);
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s,
+    background-color 0.15s;
+}
+.recurring-options button.active {
+  border-color: var(--indigo);
+  color: var(--indigo);
+  background: var(--indigo-soft);
+}
+.donation-tiers-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.tier-card {
+  position: relative;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 30px 26px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition:
+    border-color 0.15s,
+    transform 0.15s,
+    box-shadow 0.2s;
+}
+.tier-card:hover {
+  border-color: var(--indigo);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(56, 67, 208, 0.1);
+}
+.tier-card.featured {
+  border-color: var(--indigo);
+  box-shadow: 0 12px 32px rgba(56, 67, 208, 0.12);
+}
+.tier-badge {
+  position: absolute;
+  top: -11px;
+  left: 26px;
+  background: var(--mango);
+  color: #fff;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(224, 74, 34, 0.35);
+}
+.tier-heading {
+  font-size: 19px;
+  font-weight: 600;
+  color: var(--ink);
+}
+.tier-desc {
+  color: var(--ink-3);
+  font-size: 14px;
+  line-height: 1.6;
+  flex-grow: 1;
+  margin: 0;
+}
+.tier-card .btn-primary {
+  align-self: flex-start;
+  margin-top: 6px;
+}
+@media (max-width: 900px) {
+  .donation-tiers-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 600px) {
+  .donation-tiers-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* FAQ: rounded panel + divided rows, mono numbering */
+.faq-panel {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.faq-row {
+  border-bottom: 1px solid var(--line);
+  transition: background-color 0.15s;
+}
+.faq-row:last-of-type {
+  border-bottom: none;
+}
+.faq-row:hover {
+  background: var(--paper-warm);
+}
+.faq-row summary {
+  cursor: pointer;
+  list-style: none;
+  display: grid;
+  grid-template-columns: 34px 1fr 22px;
+  align-items: center;
+  gap: 16px;
+  padding: 22px 28px;
+}
+.faq-row summary::-webkit-details-marker {
+  display: none;
+}
+.faq-num {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--indigo);
+  letter-spacing: 0.02em;
+}
+.faq-q {
+  font-size: 16.5px;
+  font-weight: 500;
+  color: var(--ink);
+  line-height: 1.4;
+}
+.faq-icon {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+.faq-icon::before,
+.faq-icon::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  background: var(--indigo);
+  transform: translate(-50%, -50%);
+  transition: transform 0.2s ease;
+}
+.faq-icon::before {
+  width: 12px;
+  height: 2px;
+}
+.faq-icon::after {
+  width: 2px;
+  height: 12px;
+}
+.faq-row[open] .faq-icon::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+  opacity: 0;
+}
+.faq-row .answer {
+  padding: 0 28px 26px 78px;
+  color: var(--ink-3);
+  font-size: 15px;
+  line-height: 1.65;
+}
+.faq-row .answer ul {
+  margin: 10px 0 0;
+  padding-left: 20px;
+  list-style: disc;
+}
+.faq-row .answer li {
+  margin-bottom: 6px;
+}
+.faq-cta {
+  text-align: center;
+  margin-top: var(--space-lg);
+}
+@media (max-width: 640px) {
+  .faq-row summary {
+    grid-template-columns: 26px 1fr 20px;
+    padding: 18px 20px;
+  }
+  .faq-row .answer {
+    padding: 0 20px 22px 62px;
+  }
+}
+
+/* Sticky "Donate Now" CTA */
+.sticky-cta {
+  position: fixed;
+  bottom: 22px;
+  right: 22px;
+  z-index: 60;
+  opacity: 0;
+  transform: translateY(12px);
+  pointer-events: none;
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease;
+}
+.sticky-cta.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}

--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -1553,11 +1553,362 @@
       <h2>$60 funds one newborn. <em>Verified delivery.</em></h2>
       <p class="lead">$60 covers the full Connect KMC cycle for one small and vulnerable newborn: Kangaroo wraps, scales, thermometers, pulse oximeters, Frontline Worker training, payment for visits, and supervision. Every dollar is tied to a verified outcome. Individual donors, foundations, and program funders all welcome.</p>
       <div class="cta-actions">
-        <a href="https://sites.dimagi.com/support-kmc" class="btn btn-primary" target="_blank" rel="noopener">Donate $60 · Fund a Baby</a>
+        <a href="/support-kmc" class="btn btn-primary">Donate $60 · Fund a Baby</a>
         <a href="mailto:connect-kmc@dimagi.com" class="btn btn-ghost-on-dark">Design a Program</a>
       </div>
     </div>
   </div>
+
+</section>
+
+<!-- ================================ SUPPORT KMC, DONATION LANDING ================================ -->
+<section class="page" data-page="/support-kmc">
+
+  <div class="hero-dark hero-dark-chc">
+    <div class="wrap">
+      <div class="chc-hero-grid">
+        <div class="chc-hero-text">
+          <span class="eyebrow on-dark">Support Kangaroo Mother Care</span>
+          <h1>A Mother's Embrace Is <em>Life-Saving</em>.</h1>
+          <p class="lede">You can help deliver it. Each year, 2.3 million newborns die in their first month of life. Kangaroo Mother Care, simple skin-to-skin contact and breastfeeding support, can reduce that risk by up to 40%.</p>
+          <div class="hero-actions">
+            <a href="#donate" class="btn btn-primary">Fund a Frontline Worker</a>
+            <a href="/portfolio/kangaroo-mother-care" class="btn btn-ghost-on-dark">See the Full Program</a>
+          </div>
+        </div>
+        <div class="chc-hero-photo">
+          <div class="photo-circle" style="background: #2b2b2b url('{% static 'prelogin/images/field-photos/kmc/kmc-1.jpg' %}') center/cover no-repeat; border: 3px solid rgba(255,255,255,0.18); box-shadow: 0 30px 70px -20px rgba(0,0,0,0.6);" role="img" aria-label="Kangaroo Mother Care home visit for a small and vulnerable newborn."></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="stats-cool">
+    <div class="wrap">
+      <div class="sec-head">
+        <div class="label-group">
+          <h2>Kangaroo Mother Care<br><em>At a glance</em></h2>
+        </div>
+      </div>
+      <div class="hero-stats">
+        <div class="hero-stats-row">
+          <span class="hero-stats-tag">Program Stats</span>
+          <div class="hero-stats-items">
+            <div><div class="num">$60</div><div class="label">Per newborn</div></div>
+            <div><div class="num">5k+</div><div class="label">Cases tracked</div></div>
+            <div><div class="num">50K</div><div class="label">Uganda 2-yr case target</div></div>
+          </div>
+        </div>
+        <div class="hero-stats-row">
+          <span class="hero-stats-tag">Global Context</span>
+          <div class="hero-stats-items">
+            <div><div class="num">2.3M</div><div class="label">Neonatal deaths per year</div></div>
+            <div><div class="num">40%</div><div class="label">Mortality reduction possible with KMC</div></div>
+            <div><div class="num">&lt;5%</div><div class="label">Current global KMC coverage</div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section warm">
+    <div class="wrap">
+      <div class="challenge-head">
+        <span class="eyebrow">The Challenge</span>
+        <h2>2.3 million newborns <em>lost each year</em></h2>
+      </div>
+      <div class="split-grid align-stretch">
+        <div class="lede-text">
+          <p>Imagine a baby born too small and too soon, fighting for every breath. Leaving the hospital is just the beginning of a perilous journey, and families often lack the support to help them survive and grow.</p>
+          <p>There is a powerful, proven solution: Kangaroo Mother Care, a simple practice of skin-to-skin contact and breastfeeding support that can reduce mortality in premature babies by up to 40%.</p>
+          <p>But the challenge isn't the solution, it's delivering it. Kangaroo Mother Care coverage remains below 5% for eligible infants worldwide, leaving millions of newborns at risk.</p>
+        </div>
+        <figure>
+          <img src="{% static 'prelogin/images/field-photos/kmc/kmc-4.jpg' %}" alt="A mother holds her small and vulnerable newborn, swaddled after a Kangaroo Mother Care home visit" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </div>
+
+  <div class="section no-border">
+    <div class="wrap">
+      <div class="sec-head">
+        <div class="label-group">
+          <span class="eyebrow">How Your Gift Works</span>
+          <h2>Hope arrives <em>at the doorstep</em></h2>
+          <p class="sub">This is where you come in.</p>
+        </div>
+      </div>
+      <div class="split-grid">
+        <figure>
+          <img src="{% static 'prelogin/images/field-photos/kmc/kmc-2.jpg' %}" alt="A Frontline Worker uses the Connect app on her phone during a home visit with a mother and newborn" loading="lazy">
+        </figure>
+        <div>
+          <p>Your support sends a trained, local Frontline Worker, often a woman from her own community, directly to a new mother's home.</p>
+          <p>We make this possible through our mobile platform, <a class="prose-link" href="/platform">Connect by Dimagi</a>. Think of it as the direct link between your generosity and that mother's doorstep. It ensures every Frontline Worker is paid for her life-saving work and that every dollar you give is tied to a verified visit.</p>
+          <p>Frontline Workers use Dimagi's Connect app on a simple smartphone to complete training on Kangaroo Mother Care, deliver services, and receive payments for verified delivery.</p>
+        </div>
+      </div>
+      <div class="split-grid media-first">
+        <figure>
+          <img src="{% static 'prelogin/images/field-photos/kmc/kmc-5.jpg' %}" alt="A mother carries her baby after receiving Kangaroo Mother Care guidance and support" loading="lazy">
+        </figure>
+        <div>
+          <p>With the Connect KMC app, Frontline Workers are equipped with the knowledge to:</p>
+          <ul>
+            <li>Guide a mother through KMC best practices.</li>
+            <li>Counsel her on breastfeeding.</li>
+            <li>Screen the baby for critical danger signs and make life-saving referrals.</li>
+          </ul>
+          <p class="tight-top">This model combats the community stigma often faced by mothers of premature babies by pairing families with a trusted mentor for essential support and encouragement.</p>
+        </div>
+      </div>
+      <div class="section-cta">
+        <a href="#donate" class="btn btn-primary">Fund a Frontline Worker</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="section warm">
+    <div class="wrap">
+      <div class="sec-head">
+        <div class="label-group">
+          <span class="eyebrow">Verified, Every Step</span>
+          <h2>How your gift creates <em>verifiable impact</em></h2>
+          <p class="sub">We believe in trust through transparency. Our Connect platform ensures your generosity creates real-world impact you can count on. Here's how:</p>
+        </div>
+      </div>
+      <div class="step-grid">
+        <div class="step-card">
+          <div class="step-number">1</div>
+          <h3>You Give</h3>
+          <p>Your donation trains a local Frontline Worker and gives her life-saving tools, a digital app and essential supplies to support mothers and newborns.</p>
+        </div>
+        <div class="step-card">
+          <div class="step-number">2</div>
+          <h3>She Delivers Care</h3>
+          <p>A trained Frontline Worker visits a new mother at home, providing expert guidance, checking the baby's health, and offering compassionate support.</p>
+        </div>
+        <div class="step-card">
+          <div class="step-number">3</div>
+          <h3>Impact Is Verified</h3>
+          <p>Using her phone, the worker confirms the visit, verifying that the baby was checked and the mother received essential support. It's how we ensure your gift makes a real impact.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section photo-band no-border photo-band--uganda">
+    <div class="wrap">
+      <div class="photo-band-grid">
+        <div>
+          <span class="eyebrow on-dark">Proven and Ready to Grow</span>
+          <h2>Ready to reach <em>thousands more</em></h2>
+          <p>Our approach is designed to be simple, effective, and scalable. We invest in local Frontline Workers, providing them with the training and fair pay needed to deliver proven newborn care directly in a family's home.</p>
+          <p>This efficient and effective framework is ready to grow. Your support helps us expand this vital work to thousands more families in new communities and countries.</p>
+        </div>
+        <div class="data-callout-box">
+          <p>We recently tested the power of this community-led model in a pilot program in Uganda. The results showed its incredible potential for rapid deployment:</p>
+          <p class="headline-stat">In just eight weeks, our partners reached and provided care for more than 650 small and vulnerable newborns.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section ripple-foundation">
+    <div class="wrap">
+      <div class="sec-head">
+        <div class="label-group">
+          <span class="eyebrow">Multiplied Impact</span>
+          <h2>One gift creates <em>a ripple of change</em></h2>
+          <p class="sub">When you fund a Frontline Worker, your impact is multiplied across an entire community. That means:</p>
+        </div>
+      </div>
+      <div class="pf-row">
+        <div class="pf-item">
+          <span class="pf-icn" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20.5s-7.2-4.6-9.7-9.2A5.4 5.4 0 0112 5.8a5.4 5.4 0 019.7 5.5c-2.5 4.6-9.7 9.2-9.7 9.2z"/></svg></span>
+          <span class="pf-txt"><span class="pf-title">A baby gets the best possible chance at a healthy life.</span></span>
+        </div>
+        <div class="pf-item">
+          <span class="pf-icn" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20.5s-7.2-4.6-9.7-9.2A5.4 5.4 0 0112 5.8a5.4 5.4 0 019.7 5.5c-2.5 4.6-9.7 9.2-9.7 9.2z"/></svg></span>
+          <span class="pf-txt"><span class="pf-title">A mother gains confidence and feels supported, not isolated.</span></span>
+        </div>
+        <div class="pf-item">
+          <span class="pf-icn" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20.5s-7.2-4.6-9.7-9.2A5.4 5.4 0 0112 5.8a5.4 5.4 0 019.7 5.5c-2.5 4.6-9.7 9.2-9.7 9.2z"/></svg></span>
+          <span class="pf-txt"><span class="pf-title">A Frontline Worker earns fair compensation for her life-saving work.</span></span>
+        </div>
+      </div>
+      <p class="ripple-close">This is a sustainable, community-powered solution that changes futures.</p>
+      <div class="section-cta">
+        <a href="#donate" class="btn btn-primary">Create a Ripple of Change</a>
+      </div>
+    </div>
+  </div>
+
+  <div id="donate" class="section donation-section">
+    <div class="wrap">
+      <div class="sec-head">
+        <div class="label-group">
+          <span class="eyebrow">Support Kangaroo Care</span>
+          <h2>Fund a Frontline Worker. <em>Help a newborn.</em></h2>
+          <p class="sub">Your gift provides the training, tools, and support a Frontline Worker needs to deliver this life-saving care.</p>
+        </div>
+      </div>
+
+      <div class="frequency-toggle-wrap">
+        <span class="frequency-toggle-label">Choose your donation frequency</span>
+        <div class="frequency-toggle">
+          <button id="oneTimeBtn" class="active" data-frequency="onetime">One-Time</button>
+          <button id="recurringBtn" data-frequency="recurring">Recurring</button>
+        </div>
+        <div id="recurringOptions" class="recurring-options">
+          <button data-frequency="monthly" class="active">Monthly</button>
+          <button data-frequency="quarterly">Quarterly</button>
+          <button data-frequency="yearly">Yearly</button>
+        </div>
+      </div>
+
+      <div class="donation-tiers-grid">
+        <div class="tier-card">
+          <div class="tier-heading">$60 &ndash; Support One Family</div>
+          <p class="tier-desc">This foundational gift funds the complete cycle of Kangaroo Mother Care support for one vulnerable newborn and their mother, from the first home visit to a healthy start in life.</p>
+          <a href="https://donate.stripe.com/cNi3cx4EL0Td91ydPG6Vq00" target="_blank" rel="noopener" class="btn btn-primary donate-button"
+             data-onetime="https://donate.stripe.com/cNi3cx4EL0Td91ydPG6Vq00"
+             data-monthly="https://donate.stripe.com/9B6dRbfjp8lF0v2fXO6Vq01"
+             data-quarterly="https://donate.stripe.com/14A6oJ7QX7hBa5C3b26Vq02"
+             data-yearly="https://donate.stripe.com/eVq4gB7QX45pfpW12U6Vq03">Donate</a>
+        </div>
+
+        <div class="tier-card featured">
+          <span class="tier-badge">Popular</span>
+          <div class="tier-heading">$180 &ndash; Support Three Families</div>
+          <p class="tier-desc">Your gift supports three newborns and their mothers, allowing a Frontline Worker to build a trusted relationship and deliver consistent, life-saving guidance within her community.</p>
+          <a href="https://donate.stripe.com/14A28t9Z56dxdhO4f66Vq04" target="_blank" rel="noopener" class="btn btn-primary donate-button"
+             data-onetime="https://donate.stripe.com/14A28t9Z56dxdhO4f66Vq04"
+             data-monthly="https://donate.stripe.com/eVq6oJ5IPcBV5PmcLC6Vq05"
+             data-quarterly="https://donate.stripe.com/4gMaEZ2wDatNb9G12U6Vq06"
+             data-yearly="https://donate.stripe.com/cNi4gB4EL8lF5PmcLC6Vq07">Donate</a>
+        </div>
+
+        <div class="tier-card">
+          <div class="tier-heading">$600 &ndash; Support 10 Families</div>
+          <p class="tier-desc">This gift equips a Frontline Worker with the tools, transport, and fair pay to support 10 babies. You are creating a powerful ripple of change and ensuring an entire cohort of vulnerable newborns receives care.</p>
+          <a href="https://donate.stripe.com/4gMfZj4EL8lFa5C5ja6Vq08" target="_blank" rel="noopener" class="btn btn-primary donate-button"
+             data-onetime="https://donate.stripe.com/4gMfZj4EL8lFa5C5ja6Vq08"
+             data-monthly="https://donate.stripe.com/4gMcN7efl31lgu0h1S6Vq09"
+             data-quarterly="https://donate.stripe.com/bJefZjc7d31l6Tq5ja6Vq0a"
+             data-yearly="https://donate.stripe.com/7sY28tgnt6dx7XubHy6Vq0b">Donate</a>
+        </div>
+
+        <div class="tier-card">
+          <div class="tier-heading">$1,800 &ndash; Support 30 Families</div>
+          <p class="tier-desc">This transformative gift provides a full caseload to a Frontline Worker for six months, enabling her to support 30 babies and their mothers, dramatically improving the survival rate for premature newborns across an entire village or neighborhood.</p>
+          <a href="https://donate.stripe.com/14A8wR4ELdFZa5C12U6Vq0c" target="_blank" rel="noopener" class="btn btn-primary donate-button"
+             data-onetime="https://donate.stripe.com/14A8wR4ELdFZa5C12U6Vq0c"
+             data-monthly="https://donate.stripe.com/28E4gBb396dxdhO9zq6Vq0d"
+             data-quarterly="https://donate.stripe.com/14AfZj3AH45p7XueTK6Vq0e"
+             data-yearly="https://donate.stripe.com/14AcN78V11Xh5PmeTK6Vq0f">Donate</a>
+        </div>
+
+        <div class="tier-card">
+          <div class="tier-heading">Donate a Custom Amount</div>
+          <p class="tier-desc">Your generous gift of any amount will directly support a Frontline Worker and the families in her care.</p>
+          <a href="https://donate.stripe.com/5kQ6oJ5IP6dxcdK26Y6Vq0g" target="_blank" rel="noopener" class="btn btn-primary donate-button"
+             data-onetime="https://donate.stripe.com/5kQ6oJ5IP6dxcdK26Y6Vq0g"
+             data-monthly="https://donate.stripe.com/7sY00lefl8lFb9GbHy6Vq0h"
+             data-quarterly="https://donate.stripe.com/7sY8wR0ovgSbgu0aDu6Vq0i"
+             data-yearly="https://donate.stripe.com/eVqfZjfjp31lfpW3b26Vq0j">Donate</a>
+        </div>
+      </div>
+
+      <p class="donation-fineprint">Donations to Connect Kangaroo Mother Care are made through Players Philanthropy Fund, a registered 501(c)(3) non-profit serving as fiscal sponsor. All gifts are tax-deductible to the extent allowed by law.</p>
+    </div>
+  </div>
+
+  <div class="section warm">
+    <div class="wrap-narrow">
+      <div class="sec-head">
+        <div class="label-group">
+          <span class="eyebrow">Common Questions</span>
+          <h2>Your questions, <em>answered</em></h2>
+        </div>
+      </div>
+
+      <div class="faq-panel">
+        <details class="faq-row">
+          <summary>
+            <span class="faq-num">01</span>
+            <span class="faq-q">Is my gift tax-deductible?</span>
+            <span class="faq-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="answer">
+            <p>Yes, all donations are tax-deductible. Our fiscal sponsor, Players Philanthropy Fund (PPF), is a registered 501(c)(3) organization. You will receive an email confirmation from PPF after your donation is processed, and tax receipts will also be provided at a later date for donations over $250.</p>
+          </div>
+        </details>
+        <details class="faq-row">
+          <summary>
+            <span class="faq-num">02</span>
+            <span class="faq-q">Where does my money go?</span>
+            <span class="faq-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="answer">
+            <p>Your donation directly funds the cost of delivering care to a vulnerable newborn. This involves a trained Frontline Worker who identifies an at-risk baby at a health facility and then makes regular home visits for the next 1&ndash;2 months of the child's life. During each visit, she spends valuable time counseling the mother and other caregivers and screens the child for any danger signs. A gift of $60 covers the full program for one baby, which includes:</p>
+            <ul>
+              <li>Fair payment to the Frontline Worker for her time and transport during these home visits.</li>
+              <li>Costs for the local organization to provide supervision and supplies (like a Kangaroo Mother Care wrap, weighing scales, and other medical equipment).</li>
+              <li>The Connect platform fee (20% of the cost) that makes the verification and payment possible.</li>
+            </ul>
+          </div>
+        </details>
+        <details class="faq-row">
+          <summary>
+            <span class="faq-num">03</span>
+            <span class="faq-q">Which countries do you work in?</span>
+            <span class="faq-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="answer">
+            <p>Currently, our Kangaroo Mother Care program is active in Ethiopia, India, Kenya, Nigeria, and Uganda. We are focused on sustainable growth and are in the process of expanding to additional countries. Your generous donation supports our work across all regions.</p>
+          </div>
+        </details>
+        <details class="faq-row">
+          <summary>
+            <span class="faq-num">04</span>
+            <span class="faq-q">How do you know the visits actually happen?</span>
+            <span class="faq-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="answer">
+            <p>This is what makes our model different. The Connect platform uses digital markers like GPS data and timestamps to verify that a Frontline Worker was at the right place at the right time, and that quality care data was submitted. This allows us to pay for proven impact with confidence.</p>
+          </div>
+        </details>
+        <details class="faq-row">
+          <summary>
+            <span class="faq-num">05</span>
+            <span class="faq-q">How can I get in touch if I have more questions?</span>
+            <span class="faq-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="answer">
+            <p>If you'd like to learn more about the Kangaroo Mother Care program or have any questions about your donation, please contact us at <a class="prose-link" href="mailto:connect-kmc@dimagi.com">connect-kmc@dimagi.com</a>. We're happy to provide additional information.</p>
+          </div>
+        </details>
+        <details class="faq-row">
+          <summary>
+            <span class="faq-num">06</span>
+            <span class="faq-q">I saw that Dimagi is a for-profit company. Why are you collecting donations?</span>
+            <span class="faq-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="answer">
+            <p>While Dimagi is a for-profit social enterprise, all donations received are exclusively dedicated to charitable programs. To ensure that your contribution directly supports its intended cause, we partner with Players Philanthropy Fund (PPF), a registered 501(c)(3) non-profit fiscal sponsor. PPF is responsible for the management and allocation of these funds to program activities.</p>
+          </div>
+        </details>
+      </div>
+
+      <div class="faq-cta">
+        <a href="#donate" class="btn btn-primary">Donate Now</a>
+      </div>
+    </div>
+  </div>
+
+  <a id="stickyCta" href="#donate" class="btn btn-primary sticky-cta">Donate Now</a>
 
 </section>
 

--- a/commcare_connect/templates/prelogin/home.html
+++ b/commcare_connect/templates/prelogin/home.html
@@ -1758,13 +1758,13 @@
       <div class="frequency-toggle-wrap">
         <span class="frequency-toggle-label">Choose your donation frequency</span>
         <div class="frequency-toggle">
-          <button id="oneTimeBtn" class="active" data-frequency="onetime">One-Time</button>
-          <button id="recurringBtn" data-frequency="recurring">Recurring</button>
+          <button id="oneTimeBtn" class="active" data-frequency="onetime" aria-pressed="true">One-Time</button>
+          <button id="recurringBtn" data-frequency="recurring" aria-pressed="false">Recurring</button>
         </div>
         <div id="recurringOptions" class="recurring-options">
-          <button data-frequency="monthly" class="active">Monthly</button>
-          <button data-frequency="quarterly">Quarterly</button>
-          <button data-frequency="yearly">Yearly</button>
+          <button data-frequency="monthly" class="active" aria-pressed="true">Monthly</button>
+          <button data-frequency="quarterly" aria-pressed="false">Quarterly</button>
+          <button data-frequency="yearly" aria-pressed="false">Yearly</button>
         </div>
       </div>
 
@@ -1842,7 +1842,7 @@
             <span class="faq-icon" aria-hidden="true"></span>
           </summary>
           <div class="answer">
-            <p>Yes, all donations are tax-deductible. Our fiscal sponsor, Players Philanthropy Fund (PPF), is a registered 501(c)(3) organization. You will receive an email confirmation from PPF after your donation is processed, and tax receipts will also be provided at a later date for donations over $250.</p>
+            <p>Yes, your gift is tax-deductible to the extent allowed by law. Our fiscal sponsor, Players Philanthropy Fund (PPF), is a registered 501(c)(3) organization. You will receive an email confirmation from PPF after your donation is processed, and tax receipts will also be provided at a later date for donations over $250.</p>
           </div>
         </details>
         <details class="faq-row">
@@ -1908,7 +1908,7 @@
     </div>
   </div>
 
-  <a id="stickyCta" href="#donate" class="btn btn-primary sticky-cta">Donate Now</a>
+  <a id="stickyCta" href="#donate" class="btn btn-primary sticky-cta" aria-hidden="true" tabindex="-1">Donate Now</a>
 
 </section>
 

--- a/commcare_connect/templates/prelogin/sitemap.xml
+++ b/commcare_connect/templates/prelogin/sitemap.xml
@@ -20,4 +20,5 @@
   <url><loc>https://connect.dimagi.com/portfolio/survey-data-collection</loc><lastmod>2026-06-01</lastmod></url>
   <url><loc>https://connect.dimagi.com/portfolio/therapeutic-food</loc><lastmod>2026-06-01</lastmod></url>
   <url><loc>https://connect.dimagi.com/portfolio/rooftop-sampling</loc><lastmod>2026-06-01</lastmod></url>
+  <url><loc>https://connect.dimagi.com/support-kmc</loc><lastmod>2026-08-07</lastmod></url>
 </urlset>


### PR DESCRIPTION
## Product Description

Adds `/support-kmc` to the live marketing site — a donation landing page for the Kangaroo Mother Care program ("Fund a Frontline Worker").  It replaces the standalone page previously hosted at `sites.dimagi.com/support-kmc`, now built natively into connect.dimagi.com with the site's real header/nav/footer and design system.

The KMC portfolio page's (`/portfolio/kangaroo-mother-care`) "Donate $60 · Fund a Baby" button now links to the new internal `/support-kmc` route instead of the retired external URL.

Page includes: hero, program stats, the problem/solution narrative, a 3-step "how your gift works" explainer, a Uganda pilot data callout, a ripple-effect section, 5 donation tiers (one-time/monthly/quarterly/yearly via existing Stripe Payment Links), an FAQ accordion, and a sticky "Donate Now" bar.

## Technical Summary

**This is a scoped promotion, not the standard full three-directory copy** described in connect-labs' `docs/prelogin-marketing-site.md`. Prod's `prelogin/{home.html,app.js,styles.css}` have drifted from labs since the last promotion — most notably, labs' shared header now sources the "Sign In" link from a `views.py`-supplied `app_login_url` context variable (a pending, separate labs feature), while prod's header still uses a hardcoded `{% url 'account_login' %}`. A full directory copy would have silently brought that unrelated, unreviewed change along, and `connect_labs/prelogin/apps.py`'s `AppConfig.name` also isn't portable between repos (`connect_labs.prelogin` vs `commcare_connect.prelogin`).

So this PR cherry-picks only what the KMC donation page needs, applied directly to prod's current files:
- `commcare_connect/prelogin/urls.py` — added `support-kmc` to `MARKETING_ROUTES`
- `commcare_connect/templates/prelogin/home.html` — new `<section data-page="/support-kmc">` (inserted after the existing KMC portfolio section, reusing prod's own header/footer/shared classes — the new section doesn't reference `app_login_url` or anything else that's diverged), and updated the KMC portfolio page's donate link
- `commcare_connect/static/prelogin/app.js` — added `/support-kmc` to the per-route `ROUTE_META` title/description map, and the donation-frequency-toggle + sticky-CTA-visibility widget (self-contained, follows the existing pattern for page-specific widgets in this file)
- `commcare_connect/static/prelogin/styles.css` — appended only the CSS classes genuinely new to this page (donation tiers, FAQ accordion, step cards, photo band, ripple section, sticky CTA); confirmed zero collisions with prod's existing 10k+ line stylesheet before appending
- `commcare_connect/templates/prelogin/sitemap.xml` — added the new route

Images reuse field photos already checked into this repo (`kmc-1.jpg` through `kmc-5.jpg`) — no new assets needed.

**Prod and labs will remain slightly out of sync** after this merges (labs still has the pending `app_login_url` header change prod doesn't). That's a separate, pre-existing promotion gap unrelated to this PR — flagging here so it isn't mistaken for something this PR should have included.

## Safety Assurance

### Safety story

Additive marketing content only, no backend/DB/model changes — `HomeView` is a plain `TemplateView`. Verified locally:
- `home.html` renders end-to-end through Django's template engine with no errors
- `<section>` tags balanced (18 open / 18 close) and all new element IDs unique across the document
- Full `pre-commit run` on all changed files passes: prettier, django-upgrade, pyupgrade, ruff, ruff-format, eslint
- CSS brace-balance and JS syntax checked directly; confirmed no new CSS class collides with an existing one in the shared stylesheet
- Already live and working on `labs.connect.dimagi.com/support-kmc` since the source PR merged

### Automated test coverage

None added — static marketing content, consistent with how other prelogin routes in this app are covered (`commcare_connect/prelogin/tests/test_views.py` tests routing generically; not modified here since this PR doesn't touch `views.py`/`urls.py` route-registration logic beyond the one new route string).

### QA Plan

- [ ] After merge/deploy, verify `/support-kmc` renders correctly on `connect.dimagi.com` (hero, stats, donation tiers, frequency toggle, FAQ accordion, sticky CTA) on desktop and mobile
- [ ] Click through from `/portfolio/kangaroo-mother-care`'s donate button to confirm the new internal link works
- [ ] Confirm the 5 Stripe donation links resolve correctly for all four frequency options
- [ ] Confirm `/robots.txt` and `/sitemap.xml` reflect the new route

### Labels & Review

- [ ] @calellowitz pinged as a reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)