### PR TITLE
Upgrade open-chat-studio-widget to 0.11.0

### DIFF
--- a/commcare_connect/templates/base.html
+++ b/commcare_connect/templates/base.html
@@ -59,7 +59,7 @@
       </main>
     </div>
     {% if request.user.is_authenticated and chat_widget_enabled %}
-      <open-chat-studio-widget class="z-50" visible="false" chatbot-id="{{ chatbot_id }}" embed-key="{{ chatbot_embed_key }}" button-text="{% translate 'Need help?' %}" position="right" expanded="false">
+      <open-chat-studio-widget class="z-50" visible="false" chatbot-id="{{ chatbot_id }}" embed-key="{{ chatbot_embed_key }}" button-text="{% translate 'Need help?' %}" position="right">
       </open-chat-studio-widget>
     {% endif %}
     {% block inline_javascript %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "htmx.org": "^2.0.9",
         "mapbox-gl": "^3.13.0",
         "mini-css-extract-plugin": "^2.4.5",
-        "open-chat-studio-widget": "^0.5.2",
+        "open-chat-studio-widget": "^0.11.0",
         "postcss": "^8.5.3",
         "postcss-loader": "^8.2.1",
         "sass": "^1.43.4",
@@ -5135,9 +5135,9 @@
       }
     },
     "node_modules/open-chat-studio-widget": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.5.3.tgz",
-      "integrity": "sha512-gaPGHE6eKrAECxbre01Xskbwg4CVmKkYyoopv5kJlsoaUqdHRHQ8uV6/TR9x/v+Lw5FVmfR4DsGw9YgllaN4MQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.11.0.tgz",
+      "integrity": "sha512-eifYu/Hyinup5Zk0oSn2x+Fx4/ZWvICDKtyQH3aLKe1lK4MVD8s2xd0M+I15TlsyfBuarvNeOxpEAgssmZM4zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "htmx.org": "^2.0.9",
     "mapbox-gl": "^3.13.0",
     "mini-css-extract-plugin": "^2.4.5",
-    "open-chat-studio-widget": "^0.5.2",
+    "open-chat-studio-widget": "^0.11.0",
     "postcss": "^8.5.3",
     "postcss-loader": "^8.2.1",
     "sass": "^1.43.4",


### PR DESCRIPTION
Upgrade OCS widget to latest version. Current version (0.5.3) is deprecated and will be removed on 2026-10-01.

No breaking changes across 0.6.0–0.11.0 per the [changelog](https://docs.openchatstudio.com/chat_widget/changelog/).

The `expanded="false"` removal is unrelated to the upgrade. This attribute was removed in [v0.4.1](https://docs.openchatstudio.com/chat_widget/changelog/?h=expanded#v041)

Nothing new adopted. Several new features are now available if we want them later: `disabled` read-only mode, configurable banners, JS lifecycle events (`ocs:open`, `ocs:message:sent`, …), `page-context` for passing page data to the bot.

## Safety Assurance

### Safety story

Widget is behind the `open_chat_studio_widget` waffle flag and only renders for authenticated users, so blast radius is limited to flag-enabled users. Verified the webpack build succeeds. No data or server-side changes.

### Automated test coverage

N/A

### QA Plan

None