### PR TITLE
Fix last-paid popup table scroll and viewport misalignment

### DIFF
--- a/commcare_connect/templates/components/worker_page/last_paid.html
+++ b/commcare_connect/templates/components/worker_page/last_paid.html
@@ -2,15 +2,16 @@
 {% load static %}
 {% load crispy_forms_tags %}
 <div class="relative underline"
-     x-data="{ isOpen: false, historyLoaded: false, positionMenu() { const rect = this.$el.getBoundingClientRect(); const menu = this.$refs.menu; const top = rect.bottom + 5; const left = rect.left + rect.width/2 - menu.offsetWidth/2; menu.style.top = top + 'px'; menu.style.left = left + 'px'; } }"
+     x-data="{ isOpen: false, historyLoaded: false, positionMenu() { const rect = this.$el.getBoundingClientRect(); const menu = this.$refs.menu; const left = rect.left + rect.width/2 - menu.offsetWidth/2; let top = rect.bottom + 5; const maxTop = window.innerHeight - menu.offsetHeight - 8; if (top > maxTop) top = Math.max(8, maxTop); menu.style.top = top + 'px'; menu.style.left = left + 'px'; } }"
      x-init="$watch('isOpen', value => { if (value && !historyLoaded) { $dispatch('load-payment-history'); historyLoaded = true; } })"
-     x-on:click="isOpen = true; $nextTick(() => { if(isOpen) positionMenu() })">
+     x-on:click="isOpen = true; $nextTick(() => { if(isOpen) positionMenu() })"
+     x-on:htmx:after-swap.window="if (isOpen) $nextTick(() => positionMenu())">
   <span class="px-3 py-1 rounded-lg cursor-pointer hover:bg-slate-200">{{ value }}</span>
   <div x-ref="menu"
        x-show="isOpen"
        x-on:click.outside="isOpen = false"
        x-transition
-       class="fixed z-40 p-5 text-sm bg-white rounded-lg shadow-md text-brand-deep-purple text-nowrap whitespace-nowrap"
+       class="fixed z-40 p-5 text-sm bg-white rounded-lg shadow-md text-brand-deep-purple text-nowrap whitespace-nowrap max-h-[70vh] overflow-y-auto"
        style="display: none">
     <div hx-get="{% url 'opportunity:worker_payment_history' org_slug=org_slug opp_id=opp_id access_id=record.opportunity_access_id %}"
          hx-trigger="load-payment-history from:closest div[x-data]"

--- a/commcare_connect/templates/components/worker_page/last_paid.html
+++ b/commcare_connect/templates/components/worker_page/last_paid.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load crispy_forms_tags %}
 <div class="relative underline"
-     x-data="{ isOpen: false, historyLoaded: false, positionMenu() { const rect = this.$el.getBoundingClientRect(); const menu = this.$refs.menu; const left = rect.left + rect.width/2 - menu.offsetWidth/2; let top = rect.bottom + 5; const maxTop = window.innerHeight - menu.offsetHeight - 8; if (top > maxTop) top = Math.max(8, maxTop); menu.style.top = top + 'px'; menu.style.left = left + 'px'; } }"
+     x-data="{ isOpen: false, historyLoaded: false, positionMenu() { const rect = this.$el.getBoundingClientRect(); const menu = this.$refs.menu; let top = rect.bottom + 5; const maxTop = window.innerHeight - menu.offsetHeight - 8; if (top > maxTop) top = Math.max(8, maxTop); let left = rect.left + rect.width / 2 - menu.offsetWidth / 2; const maxLeft = window.innerWidth - menu.offsetWidth - 8; left = Math.min(Math.max(8, left), Math.max(8, maxLeft)); menu.style.top = top + 'px'; menu.style.left = left + 'px'; }, }"
      x-init="$watch('isOpen', value => { if (value && !historyLoaded) { $dispatch('load-payment-history'); historyLoaded = true; } })"
      x-on:click="isOpen = true; $nextTick(() => { if(isOpen) positionMenu() })"
      x-on:htmx:after-swap.window="if (isOpen) $nextTick(() => positionMenu())">
@@ -11,7 +11,7 @@
        x-show="isOpen"
        x-on:click.outside="isOpen = false"
        x-transition
-       class="fixed z-40 p-5 text-sm bg-white rounded-lg shadow-md text-brand-deep-purple text-nowrap whitespace-nowrap max-h-[70vh] overflow-y-auto"
+       class="fixed z-40 p-5 text-sm bg-white rounded-lg shadow-md text-brand-deep-purple text-nowrap whitespace-nowrap max-h-[70vh] max-w-[90vw] overflow-y-auto overflow-x-auto"
        style="display: none">
     <div hx-get="{% url 'opportunity:worker_payment_history' org_slug=org_slug opp_id=opp_id access_id=record.opportunity_access_id %}"
          hx-trigger="load-payment-history from:closest div[x-data]"


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CI-895

- Align the last paid table popup so that it fits in viewport than overflowing out of it
- When the table is long, add a scroll bar. 
<img width="1000" height="491" alt="Screenshot 2026-08-14 at 12 02 09 PM" src="https://github.com/user-attachments/assets/41ce962b-e940-4a88-87e8-427d4f815c4a" />


## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA
### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
