### PR TITLE
CCCT-2525: Backfill CompletedWorkInvoice snapshot rows

### DIFF
--- a/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
+++ b/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
@@ -2,7 +2,7 @@ from django.core.management import BaseCommand
 from django.db import transaction
 from django.db.models import F
 
-from commcare_connect.opportunity.models import CompletedWork, CompletedWorkInvoice, ExchangeRate
+from commcare_connect.opportunity.models import CompletedWork, CompletedWorkInvoice, ExchangeRate, InvoiceStatus
 from commcare_connect.utils.itertools import batched
 
 BATCH_SIZE = 1000
@@ -39,6 +39,7 @@ class Command(BaseCommand):
                 saved_approved_count__gt=F("invoiced_approved_count"),
                 invoice__service_delivery=True,
             )
+            .exclude(invoice__status__in=[InvoiceStatus.CANCELLED_BY_NM, InvoiceStatus.REJECTED_BY_PM])
             .select_related("invoice", "opportunity_access__opportunity__currency")
             .order_by("id")
         )
@@ -91,8 +92,14 @@ class Command(BaseCommand):
                 .select_for_update(of=("self",))
             )
             # Re-derive under the lock: a concurrent write may have already caught a work up
-            # (or changed its delta) since the unlocked read that selected `works`.
-            to_process = [work for work in locked_works if work.saved_approved_count > work.invoiced_approved_count]
+            # (or changed its delta), or its invoice may have been cancelled/rejected, since the
+            # unlocked read that selected `works`.
+            to_process = [
+                work
+                for work in locked_works
+                if work.saved_approved_count > work.invoiced_approved_count
+                and work.invoice.status not in (InvoiceStatus.CANCELLED_BY_NM, InvoiceStatus.REJECTED_BY_PM)
+            ]
             if not to_process:
                 return 0, 0
 

--- a/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
+++ b/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
@@ -1,0 +1,156 @@
+from django.core.management import BaseCommand
+from django.db import transaction
+from django.db.models import F
+
+from commcare_connect.opportunity.models import CompletedWork, CompletedWorkInvoice, ExchangeRate
+from commcare_connect.utils.itertools import batched
+
+BATCH_SIZE = 1000
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill CompletedWorkInvoice snapshots and invoiced_approved_count "
+        "for service-delivery works with unbilled approved units."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=BATCH_SIZE,
+            help="Number of works processed per atomic transaction.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Compute what would be created/updated without committing any changes.",
+        )
+
+    def handle(self, *args, **options):
+        batch_size = options["batch_size"]
+        dry_run = options["dry_run"]
+        # invoiced_approved_count defaults to 0, so this single condition catches both a work
+        # that's never been snapshotted and one that was snapshotted but has since accrued more
+        # approved units than it was billed for — rerunning this command picks up both.
+        works_qs = (
+            CompletedWork.objects.filter(
+                invoice__isnull=False,
+                saved_approved_count__gt=F("invoiced_approved_count"),
+                invoice__service_delivery=True,
+            )
+            .select_related("invoice", "opportunity_access__opportunity__currency")
+            .order_by("id")
+        )
+        total = works_qs.count()
+        self.stdout.write(f"Backfilling {total} invoiced work(s) with an unbilled delta...")
+
+        created = updated = 0
+        for batch in batched(
+            works_qs.iterator(chunk_size=batch_size),
+            batch_size,
+        ):
+            batch_created, batch_updated = self._process_batch(batch, dry_run)
+            created += batch_created
+            updated += batch_updated
+            self.stdout.write(f"  ...{created + updated}/{total}")
+
+        prefix = "Dry run. Would" if dry_run else "Done."
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix} create {created} snapshot row(s), update {updated} existing snapshot row(s)."
+            )
+        )
+
+    def _process_batch(self, works, dry_run):
+        if dry_run:
+            return self._simulate_batch(works)
+        return self._write_batch(works)
+
+    def _simulate_batch(self, works):
+        # Read-only
+        rate_cache = {}
+        existing_by_work_id = self._existing_rows(works)
+        created = updated = 0
+        for work in works:
+            self._row_values(work, existing_by_work_id.get(work.id), rate_cache)
+            if work.id in existing_by_work_id:
+                updated += 1
+            else:
+                created += 1
+        return created, updated
+
+    def _write_batch(self, works):
+        rate_cache = {}
+        with transaction.atomic():
+            # Lock the works so concurrent approve/invoice processing can't change saved_*
+            # values between our read and the invoiced_approved_count update below.
+            locked_works = list(
+                CompletedWork.objects.filter(pk__in=[work.id for work in works])
+                .select_related("invoice", "opportunity_access__opportunity__currency")
+                .select_for_update(of=("self",))
+            )
+            # Re-derive under the lock: a concurrent write may have already caught a work up
+            # (or changed its delta) since the unlocked read that selected `works`.
+            to_process = [work for work in locked_works if work.saved_approved_count > work.invoiced_approved_count]
+            if not to_process:
+                return 0, 0
+
+            existing_by_work_id = self._existing_rows(to_process)
+            to_create = []
+            to_update = []
+            for work in to_process:
+                existing_row = existing_by_work_id.get(work.id)
+                values = self._row_values(work, existing_row, rate_cache)
+                if existing_row is None:
+                    to_create.append(CompletedWorkInvoice(invoice=work.invoice, completed_work=work, **values))
+                else:
+                    for field, value in values.items():
+                        setattr(existing_row, field, value)
+                    to_update.append(existing_row)
+                work.invoiced_approved_count = work.saved_approved_count
+
+            if to_create:
+                CompletedWorkInvoice.objects.bulk_create(to_create)
+            if to_update:
+                CompletedWorkInvoice.objects.bulk_update(
+                    to_update,
+                    fields=[
+                        "billed_count",
+                        "flw_amount_local",
+                        "flw_amount_usd",
+                        "org_amount_local",
+                        "org_amount_usd",
+                    ],
+                )
+            CompletedWork.objects.bulk_update(to_process, fields=["invoiced_approved_count"])
+        return len(to_create), len(to_update)
+
+    @staticmethod
+    def _existing_rows(works):
+        rows = CompletedWorkInvoice.objects.filter(completed_work_id__in=[work.id for work in works])
+        return {row.completed_work_id: row for row in rows}
+
+    def _row_values(self, work, existing_row, rate_cache):
+        values = {
+            "billed_count": work.saved_approved_count,
+            "flw_amount_local": work.saved_payment_accrued,
+            "flw_amount_usd": work.saved_payment_accrued_usd,
+            "org_amount_local": work.saved_org_payment_accrued,
+            "org_amount_usd": work.saved_org_payment_accrued_usd,
+        }
+        if existing_row is None:
+            # Attribute billed units to the approval month (status_modified_date), matching
+            # get_invoice_items' TruncMonth grouping.
+            month = work.status_modified_date.date().replace(day=1)
+            values["month"] = month
+            values["exchange_rate"] = self._exchange_rate(work, month, rate_cache)
+        return values
+
+    @staticmethod
+    def _exchange_rate(work, billed_month, rate_cache):
+        currency_code = work.opportunity_access.opportunity.currency_code
+        key = (currency_code, billed_month)
+        if key not in rate_cache:
+            rate_cache[key] = ExchangeRate.latest_exchange_rate(currency_code, billed_month)
+        return rate_cache[key]

--- a/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
+++ b/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
@@ -8,6 +8,7 @@ from commcare_connect.utils.itertools import batched
 BATCH_SIZE = 1000
 
 
+# TODO One time run command. Remove this once it has run.
 class Command(BaseCommand):
     help = (
         "Backfill CompletedWorkInvoice snapshots and invoiced_approved_count "
@@ -71,11 +72,11 @@ class Command(BaseCommand):
     def _simulate_batch(self, works):
         # Read-only
         rate_cache = {}
-        existing_by_work_id = self._existing_rows(works)
+        existing_work_invoice_rows = self._existing_work_invoice_rows(works)
         created = updated = 0
         for work in works:
-            self._row_values(work, existing_by_work_id.get(work.id), rate_cache)
-            if work.id in existing_by_work_id:
+            self._row_values(work, existing_work_invoice_rows.get(work.id), rate_cache)
+            if work.id in existing_work_invoice_rows:
                 updated += 1
             else:
                 created += 1
@@ -103,18 +104,18 @@ class Command(BaseCommand):
             if not to_process:
                 return 0, 0
 
-            existing_by_work_id = self._existing_rows(to_process)
+            existing_work_invoice_rows = self._existing_work_invoice_rows(to_process)
             to_create = []
             to_update = []
             for work in to_process:
-                existing_row = existing_by_work_id.get(work.id)
-                values = self._row_values(work, existing_row, rate_cache)
-                if existing_row is None:
+                work_invoice_row = existing_work_invoice_rows.get(work.id)
+                values = self._row_values(work, work_invoice_row, rate_cache)
+                if work_invoice_row is None:
                     to_create.append(CompletedWorkInvoice(invoice=work.invoice, completed_work=work, **values))
                 else:
                     for field, value in values.items():
-                        setattr(existing_row, field, value)
-                    to_update.append(existing_row)
+                        setattr(work_invoice_row, field, value)
+                    to_update.append(work_invoice_row)
                 work.invoiced_approved_count = work.saved_approved_count
 
             if to_create:
@@ -134,7 +135,7 @@ class Command(BaseCommand):
         return len(to_create), len(to_update)
 
     @staticmethod
-    def _existing_rows(works):
+    def _existing_work_invoice_rows(works):
         rows = CompletedWorkInvoice.objects.filter(completed_work_id__in=[work.id for work in works])
         return {row.completed_work_id: row for row in rows}
 

--- a/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
+++ b/commcare_connect/opportunity/management/commands/backfill_invoice_line_items.py
@@ -14,6 +14,7 @@ class Command(BaseCommand):
         "Backfill CompletedWorkInvoice snapshots and invoiced_approved_count "
         "for service-delivery works with unbilled approved units."
     )
+    rate_cache = {}
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -47,6 +48,7 @@ class Command(BaseCommand):
         total = works_qs.count()
         self.stdout.write(f"Backfilling {total} invoiced work(s) with an unbilled delta...")
 
+        self.rate_cache = {}
         created = updated = 0
         for batch in batched(
             works_qs.iterator(chunk_size=batch_size),
@@ -71,11 +73,10 @@ class Command(BaseCommand):
 
     def _simulate_batch(self, works):
         # Read-only
-        rate_cache = {}
         existing_work_invoice_rows = self._existing_work_invoice_rows(works)
         created = updated = 0
         for work in works:
-            self._row_values(work, existing_work_invoice_rows.get(work.id), rate_cache)
+            self._row_values(work, existing_work_invoice_rows.get(work.id))
             if work.id in existing_work_invoice_rows:
                 updated += 1
             else:
@@ -83,7 +84,6 @@ class Command(BaseCommand):
         return created, updated
 
     def _write_batch(self, works):
-        rate_cache = {}
         with transaction.atomic():
             # Lock the works so concurrent approve/invoice processing can't change saved_*
             # values between our read and the invoiced_approved_count update below.
@@ -109,7 +109,7 @@ class Command(BaseCommand):
             to_update = []
             for work in to_process:
                 work_invoice_row = existing_work_invoice_rows.get(work.id)
-                values = self._row_values(work, work_invoice_row, rate_cache)
+                values = self._row_values(work, work_invoice_row)
                 if work_invoice_row is None:
                     to_create.append(CompletedWorkInvoice(invoice=work.invoice, completed_work=work, **values))
                 else:
@@ -139,7 +139,7 @@ class Command(BaseCommand):
         rows = CompletedWorkInvoice.objects.filter(completed_work_id__in=[work.id for work in works])
         return {row.completed_work_id: row for row in rows}
 
-    def _row_values(self, work, existing_row, rate_cache):
+    def _row_values(self, work, existing_row):
         values = {
             "billed_count": work.saved_approved_count,
             "flw_amount_local": work.saved_payment_accrued,
@@ -152,13 +152,12 @@ class Command(BaseCommand):
             # get_invoice_items' TruncMonth grouping.
             month = work.status_modified_date.date().replace(day=1)
             values["month"] = month
-            values["exchange_rate"] = self._exchange_rate(work, month, rate_cache)
+            values["exchange_rate"] = self._exchange_rate(work, month)
         return values
 
-    @staticmethod
-    def _exchange_rate(work, billed_month, rate_cache):
+    def _exchange_rate(self, work, billed_month):
         currency_code = work.opportunity_access.opportunity.currency_code
         key = (currency_code, billed_month)
-        if key not in rate_cache:
-            rate_cache[key] = ExchangeRate.latest_exchange_rate(currency_code, billed_month)
-        return rate_cache[key]
+        if key not in self.rate_cache:
+            self.rate_cache[key] = ExchangeRate.latest_exchange_rate(currency_code, billed_month)
+        return self.rate_cache[key]

--- a/commcare_connect/opportunity/tests/test_management_commands.py
+++ b/commcare_connect/opportunity/tests/test_management_commands.py
@@ -129,6 +129,27 @@ class TestBackfillInvoiceLineItems:
 
         assert CompletedWorkInvoice.objects.count() == 0
 
+    @pytest.mark.parametrize("status", [InvoiceStatus.CANCELLED_BY_NM, InvoiceStatus.REJECTED_BY_PM])
+    def test_ignores_work_on_cancelled_or_rejected_invoice(self, status):
+        opp = OpportunityFactory()
+        access = OpportunityAccessFactory(opportunity=opp)
+        payment_unit = PaymentUnitFactory(opportunity=opp)
+        invoice = PaymentInvoiceFactory(opportunity=opp, status=status)
+        work = CompletedWorkFactory(
+            opportunity_access=access,
+            payment_unit=payment_unit,
+            invoice=invoice,
+            saved_approved_count=2,
+            status="approved",
+            status_modified_date=datetime.datetime(2026, 3, 10, tzinfo=datetime.UTC),
+        )
+
+        call_command("backfill_invoice_line_items")
+
+        assert not CompletedWorkInvoice.objects.filter(completed_work=work).exists()
+        work.refresh_from_db()
+        assert work.invoiced_approved_count == 0
+
     def test_rerun_corrects_existing_row_when_more_approvals_land(self):
         opp = OpportunityFactory()
         invoice, work = _invoiced_work(opp, saved_approved_count=2)

--- a/commcare_connect/opportunity/tests/test_management_commands.py
+++ b/commcare_connect/opportunity/tests/test_management_commands.py
@@ -1,13 +1,22 @@
 import datetime
+from decimal import Decimal
 
+import pytest
 from django.core.management import call_command
 
 from commcare_connect.opportunity.models import (
+    CompletedWorkInvoice,
+    Currency,
+    ExchangeRate,
     InvoiceStatus,
 )
 from commcare_connect.opportunity.tests.factories import (
+    CompletedWorkFactory,
+    ExchangeRateFactory,
+    OpportunityAccessFactory,
     OpportunityFactory,
     PaymentInvoiceFactory,
+    PaymentUnitFactory,
 )
 
 
@@ -47,3 +56,134 @@ class ArchivePendingInvoicesTest:
 
         assert invoice5.status == InvoiceStatus.ARCHIVED
         assert invoice5.archived_date is not None
+
+
+def _invoiced_work(opportunity, **saved):
+    access = OpportunityAccessFactory(opportunity=opportunity)
+    payment_unit = PaymentUnitFactory(opportunity=opportunity)
+    invoice = PaymentInvoiceFactory(opportunity=opportunity, date=datetime.date(2026, 3, 15))
+    defaults = dict(
+        saved_approved_count=2,
+        saved_payment_accrued=100,
+        saved_payment_accrued_usd=1,
+        saved_org_payment_accrued=40,
+        saved_org_payment_accrued_usd="0.40",
+        status="approved",
+        status_modified_date=datetime.datetime(2026, 3, 10, tzinfo=datetime.UTC),
+    )
+    defaults.update(saved)
+
+    billed_month = defaults["status_modified_date"].date().replace(day=1)
+    ExchangeRate.objects.get_or_create(
+        currency_code=opportunity.currency_code, rate_date=billed_month, defaults={"rate": 1}
+    )
+    work = CompletedWorkFactory(opportunity_access=access, payment_unit=payment_unit, invoice=invoice, **defaults)
+    return invoice, work
+
+
+@pytest.mark.django_db
+class TestBackfillInvoiceLineItems:
+    def test_creates_row_with_flw_and_org_amounts(self):
+        opp = OpportunityFactory(currency=Currency.objects.get(code="KES"))
+        rate = ExchangeRateFactory(currency_code="KES", rate=50, rate_date=datetime.date(2026, 3, 1))
+        invoice, work = _invoiced_work(opp)
+
+        call_command("backfill_invoice_line_items")
+
+        row = CompletedWorkInvoice.objects.get(invoice=invoice, completed_work=work)
+        assert row.billed_count == 2
+        assert row.flw_amount_local == 100
+        assert row.flw_amount_usd == 1
+        assert row.org_amount_local == 40
+        assert row.org_amount_usd == Decimal("0.40")
+        assert row.month == datetime.date(2026, 3, 1)  # first of status_modified_date's month
+        assert row.exchange_rate == rate
+        work.refresh_from_db()
+        assert work.invoiced_approved_count == work.saved_approved_count
+
+    def test_skips_zero_approved_count_work(self):
+        opp = OpportunityFactory()
+        _, work = _invoiced_work(opp, saved_approved_count=0)
+
+        call_command("backfill_invoice_line_items")
+
+        assert not CompletedWorkInvoice.objects.filter(completed_work=work).exists()
+        work.refresh_from_db()
+        assert work.invoiced_approved_count == 0
+
+    def test_is_idempotent(self):
+        opp = OpportunityFactory()
+        invoice, work = _invoiced_work(opp)
+
+        call_command("backfill_invoice_line_items")
+        call_command("backfill_invoice_line_items")
+
+        assert CompletedWorkInvoice.objects.filter(invoice=invoice, completed_work=work).count() == 1
+
+    def test_ignores_uninvoiced_work(self):
+        opp = OpportunityFactory()
+        access = OpportunityAccessFactory(opportunity=opp)
+        CompletedWorkFactory(opportunity_access=access, invoice=None, saved_approved_count=2, status="approved")
+
+        call_command("backfill_invoice_line_items")
+
+        assert CompletedWorkInvoice.objects.count() == 0
+
+    def test_rerun_corrects_existing_row_when_more_approvals_land(self):
+        opp = OpportunityFactory()
+        invoice, work = _invoiced_work(opp, saved_approved_count=2)
+        call_command("backfill_invoice_line_items")
+        work.refresh_from_db()
+        row = CompletedWorkInvoice.objects.get(invoice=invoice, completed_work=work)
+        assert work.invoiced_approved_count == 2
+        assert row.billed_count == 2
+
+        # More approvals land after the first backfill; the live count and cached totals grow.
+        work.saved_approved_count = 3
+        work.saved_payment_accrued = 150
+        work.saved_payment_accrued_usd = "1.50"
+        work.saved_org_payment_accrued = 60
+        work.saved_org_payment_accrued_usd = "0.60"
+        work.save(
+            update_fields=[
+                "saved_approved_count",
+                "saved_payment_accrued",
+                "saved_payment_accrued_usd",
+                "saved_org_payment_accrued",
+                "saved_org_payment_accrued_usd",
+            ]
+        )
+
+        call_command("backfill_invoice_line_items")
+
+        work.refresh_from_db()
+        row.refresh_from_db()
+        # The existing row is corrected in place to the new totals, not appended as a delta row
+        assert row.billed_count == 3
+        assert row.flw_amount_local == 150
+        assert row.org_amount_local == 60
+        assert row.month == datetime.date(2026, 3, 1)  # unchanged
+        assert work.invoiced_approved_count == 3
+        assert CompletedWorkInvoice.objects.filter(completed_work=work).count() == 1
+
+    def test_dry_run_does_not_persist(self):
+        opp = OpportunityFactory()
+        invoice, work = _invoiced_work(opp)
+
+        call_command("backfill_invoice_line_items", "--dry-run")
+
+        assert not CompletedWorkInvoice.objects.filter(invoice=invoice, completed_work=work).exists()
+        work.refresh_from_db()
+        assert work.invoiced_approved_count == 0
+
+    def test_batch_size_processes_all_works_across_batches(self):
+        opp = OpportunityFactory()
+        _, w1 = _invoiced_work(opp)
+        _, w2 = _invoiced_work(opp)
+
+        call_command("backfill_invoice_line_items", "--batch-size", "1")
+
+        assert CompletedWorkInvoice.objects.filter(completed_work__in=[w1, w2]).count() == 2
+        for w in (w1, w2):
+            w.refresh_from_db()
+            assert w.invoiced_approved_count == w.saved_approved_count


### PR DESCRIPTION
## Product Description

No user-facing change — backend data-management command only.

## Technical Summary

Adds `backfill_invoice_line_items`: creates the missing `CompletedWorkInvoice` snapshot row for works that are present in existing invoices.  It is also safe to rerun and only captures if any work changes in between runs.

## Safety Assurance

### Safety story

Tested on local, will be tested on staging. Does not affect the `invoice` field on `CompletedWork`. No changes to any billing amounts — amounts are copied from `CompletedWork`'s existing `saved_payment_accrued`/`saved_org_payment_accrued` values, not recomputed.

### Automated test coverage

`test_management_commands.py::TestBackfillInvoiceLineItems` — create, correct-in-place on rerun, idempotency, dry-run, batching, zero-count skip, uninvoiced-work skip.

### QA Plan
QA is planned for the entire functionality.
The output of this command should ensure that line items are visible for existing invoices, and that will be tested.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)