### PR TITLE
Centralize HQ Case Create Flag

### DIFF
--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -184,11 +184,20 @@ def create_or_update_case(
 def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> None:
     """Update usercase properties on CommCare HQ for multiple users in a single bulk request.
 
-    All entries in `updates` must belong to the same opportunity. The domain, API key, and
-    HQ server are derived from the first entry and applied to the entire batch.
+    `updates` maps each worker's `OpportunityAccess` to the case update to apply to their
+    usercase, in the shape HQ's case API expects, e.g.::
+
+        {access: {"properties": {"task_case_id": ""}}}
+
+    All entries must belong to the same opportunity, since the domain, API key, and HQ server
+    are derived from the first entry and applied to the entire batch.
     """
     if not updates:
         return
+
+    opportunity_ids = {access.opportunity_id for access in updates}
+    if len(opportunity_ids) > 1:
+        raise ValueError(f"All updates must belong to the same opportunity, got {sorted(opportunity_ids)}.")
 
     first_access = next(iter(updates))
     domain = first_access.opportunity.deliver_app.cc_domain

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -114,10 +114,10 @@ def bulk_create_or_update_cases_by_work_areas(
     for wa in work_areas:
         case_data = dict(WorkAreaCaseSerializer(wa).data)
         case_data["owner_id"] = owner_id_by_username[wa.opportunity_access.user.username.lower()]
-        case_data["create"] = None  # UPSERT: HQ decides create vs update via external_id
         cases_data.append(case_data)
 
-    cases = bulk_create_or_update_cases(api_key, domain, cases_data)
+    # UPSERT: HQ decides create vs update via external_id
+    cases = bulk_create_or_update_cases(api_key, domain, cases_data, create=None)
 
     wa_by_id = {str(wa.pk): wa for wa in work_areas if wa.case_id is None}
     newly_created = []
@@ -136,13 +136,17 @@ def bulk_create_or_update_cases(
     api_key: HQApiKey,
     domain: str,
     cases_data: list[dict[str, Any]],
+    create: bool | None = False,
 ) -> list[CommCareCase]:
     url = f"{api_key.hq_server.url}/a/{domain}/api/case/v2/"
     headers = {"Authorization": f"ApiKey {api_key.user.email}:{api_key.api_key}"}
     cases = []
     with httpx.Client(headers=headers) as client:
         for i in range(0, len(cases_data), HQ_CASE_BULK_CHUNK_SIZE):
-            chunk = cases_data[i : i + HQ_CASE_BULK_CHUNK_SIZE]  # noqa: E203
+            chunk = [
+                {**case_data, "create": create}
+                for case_data in cases_data[i : i + HQ_CASE_BULK_CHUNK_SIZE]  # noqa: E203
+            ]
             try:
                 response = client.post(url, json=chunk)
                 response.raise_for_status()
@@ -206,7 +210,7 @@ def bulk_update_usercases(updates: dict[OpportunityAccess, dict[str, Any]]) -> N
             link.save()
         else:
             hq_case_id = link.hq_case_id
-        cases_data.append({"case_id": hq_case_id, "create": False, **data})
+        cases_data.append({"case_id": hq_case_id, **data})
 
     bulk_create_or_update_cases(api_key, domain, cases_data)
 

--- a/commcare_connect/commcarehq/tests/test_api.py
+++ b/commcare_connect/commcarehq/tests/test_api.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from unittest.mock import patch
 
@@ -5,6 +6,7 @@ import pytest
 
 from commcare_connect.commcarehq.api import (
     CommCareCase,
+    bulk_create_or_update_cases,
     bulk_create_or_update_cases_by_work_areas,
     bulk_update_usercases,
     create_or_update_case_by_work_area,
@@ -176,6 +178,7 @@ class TestBulkCreateOrUpdateCasesByWorkAreas:
             bulk_create_or_update_cases_by_work_areas([wa_with_stored, wa_to_fetch], opportunity)
 
         mock_fetch.assert_called_once()
+        assert mock_bulk.call_args.kwargs["create"] is None  # UPSERT keyed on external_id
         sent_cases = mock_bulk.call_args[0][2]
         owners_by_external_id = {c["external_id"]: c["owner_id"] for c in sent_cases}
         assert owners_by_external_id[str(wa_with_stored.id)] == stored_uuid
@@ -248,4 +251,25 @@ class TestBulkUpdateUsercases:
         mock_get_usercase.assert_called_once_with(access)
         mock_bulk.assert_called_once()
         cases_data = mock_bulk.call_args[0][2]
-        assert cases_data == [{"case_id": hq_case_id, "create": False, "properties": {"prop": "value"}}]
+        assert cases_data == [{"case_id": hq_case_id, "properties": {"prop": "value"}}]
+
+
+@pytest.mark.django_db
+class TestBulkCreateOrUpdateCases:
+    @pytest.mark.parametrize("create", [False, None, True])
+    def test_injects_create_flag_into_every_row(self, httpx_mock, create):
+        api_key = HQApiKeyFactory(hq_server=HQServerFactory())
+        httpx_mock.add_response(json={"cases": []})
+
+        bulk_create_or_update_cases(
+            api_key,
+            DOMAIN,
+            [{"case_id": "case-1"}, {"case_id": "case-2"}],
+            create=create,
+        )
+
+        payload = json.loads(httpx_mock.get_requests()[0].content)
+        assert payload == [
+            {"case_id": "case-1", "create": create},
+            {"case_id": "case-2", "create": create},
+        ]

--- a/commcare_connect/commcarehq/tests/test_api.py
+++ b/commcare_connect/commcarehq/tests/test_api.py
@@ -253,6 +253,17 @@ class TestBulkUpdateUsercases:
         cases_data = mock_bulk.call_args[0][2]
         assert cases_data == [{"case_id": hq_case_id, "properties": {"prop": "value"}}]
 
+    def test_raises_when_updates_span_multiple_opportunities(self):
+        api_key = HQApiKeyFactory(hq_server=HQServerFactory())
+        access = OpportunityAccessFactory(opportunity__api_key=api_key)
+        other_access = OpportunityAccessFactory(opportunity__api_key=api_key)
+
+        with patch("commcare_connect.commcarehq.api.bulk_create_or_update_cases") as mock_bulk:
+            with pytest.raises(ValueError, match="same opportunity"):
+                bulk_update_usercases({access: {"properties": {}}, other_access: {"properties": {}}})
+
+        mock_bulk.assert_not_called()
+
 
 @pytest.mark.django_db
 class TestBulkCreateOrUpdateCases:

--- a/commcare_connect/microplanning/helpers.py
+++ b/commcare_connect/microplanning/helpers.py
@@ -154,7 +154,7 @@ def exclude_work_areas_for_opportunity(opportunity, work_area_ids, user, exclusi
     for i in range(0, len(needs_hq), HQ_BULK_CHUNK_SIZE):
         chunk = needs_hq[i : i + HQ_BULK_CHUNK_SIZE]  # noqa: E203
         # HQ's "unassigned" convention is "-"; empty string falls back to the submitting user.
-        updates = [{"case_id": str(wa.case_id), "owner_id": "-", "create": False} for wa in chunk]
+        updates = [{"case_id": str(wa.case_id), "owner_id": "-"} for wa in chunk]
         try:
             with transaction.atomic(), pghistory.context(**pghistory_ctx):
                 _bulk_exclude(chunk, user, exclusion_reason)
@@ -269,7 +269,7 @@ def unassign_work_areas_for_opportunity(opportunity, work_area_ids, user):
 
     for chunk in batched(needs_hq, HQ_UNASSIGN_BULK_CHUNK_SIZE):
         # HQ's "unassigned" convention is "-"; empty string falls back to the submitting user.
-        updates = [{"case_id": str(wa.case_id), "owner_id": "-", "create": False} for wa in chunk]
+        updates = [{"case_id": str(wa.case_id), "owner_id": "-"} for wa in chunk]
         try:
             with transaction.atomic(), pghistory.context(**pghistory_ctx):
                 _bulk_unassign(chunk)

--- a/commcare_connect/microplanning/tests/test_helpers.py
+++ b/commcare_connect/microplanning/tests/test_helpers.py
@@ -408,7 +408,6 @@ class TestUnassignWorkAreas:
         assert mock_bulk_hq.call_count == 1
         sent_updates = mock_bulk_hq.call_args.args[2]
         assert all(u["owner_id"] == "-" for u in sent_updates)
-        assert all(u["create"] is False for u in sent_updates)
 
     @patch("commcare_connect.microplanning.helpers.bulk_create_or_update_cases")
     def test_already_unassigned_areas_are_skipped(self, mock_bulk_hq, org_user_admin, opportunity):


### PR DESCRIPTION
## Product Description

No user-facing changes. This is an internal refactor of the CommCare HQ bulk case-update
helpers; the requests Connect sends to HQ are byte-for-byte identical to before.

## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2511)
This is a release path 3 feature — Experiments & early stage iterations of product area

Follow-up on the remaining open review feedback from
[#1174](https://github.com/dimagi/commcare-connect/pull/1174).

HQ's case API treats `create` as a per-row flag, so every caller of
`bulk_create_or_update_cases` was hand-stamping it onto each case dict it assembled. That
put a correctness-critical decision (`None` = upsert keyed on `external_id` vs `False` =
update-only) in four places where it was easy to omit on a new row and invisible at the
call site. It is now a single `create` parameter on the helper, injected into every row of
every chunk, so each call site states its intent once.

`bulk_update_usercases` derives the domain, API key and HQ server from the first entry and
applies them to the whole batch. That contract was documented but unenforced, so a
mixed-opportunity batch would have posted the remainder to the wrong domain. It now raises
rather than silently mis-routing, and the docstring spells out the expected `updates` shape.

## Safety Assurance

### Safety story

The refactor is behaviour-preserving at the HQ boundary — work-area upserts still send
`create: None` and every other path `create: False` — so no existing case data is affected.
The one behavioural change is a new `ValueError` guard that fires only on an input shape no
current caller produces, converting a silent wrong-domain write into a loud failure. Both
commits are independently revertible and neither touches models or migrations.

### Automated test coverage

Tests assert the `create` flag is injected into every row of the outgoing HQ payload across
all three flag values, that the work-area upsert path still requests `create=None`, and that
the usercase and unassign/exclude paths send the payload shape HQ expects. A new test covers
the mixed-opportunity guard, verifying it raises before any HQ request is issued.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
