### PR TITLE
CCCT-2527: Show catch-up units on the invoice form

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -48,6 +48,7 @@ from commcare_connect.opportunity.models import (
     VisitReviewStatus,
     VisitValidationStatus,
 )
+from commcare_connect.opportunity.tables import header_with_tooltip
 from commcare_connect.opportunity.utils.invoice import (
     generate_invoice_number,
     get_end_date_for_invoice,
@@ -1610,6 +1611,13 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
         widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
         required=False,
     )
+    # Derived for display only, so `disabled` rather than `readonly`: Django then ignores whatever
+    # is posted, and a stale figure can never add a field error that blocks the invoice.
+    late_delta_units = forms.IntegerField(
+        required=False,
+        disabled=True,
+        widget=forms.NumberInput(),
+    )
     description = forms.CharField(
         label="",
         widget=forms.Textarea(attrs={"rows": 3}),
@@ -1645,6 +1653,7 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
         self.invoice_type = kwargs.pop("invoice_type", PaymentInvoice.InvoiceType.service_delivery)
         self.read_only = kwargs.pop("read_only", False)
         self.line_items_table = kwargs.pop("line_items_table", None)
+        self.late_delta_units = kwargs.pop("late_delta_units", 0)
         self.status = kwargs.pop("status", InvoiceStatus.PENDING_NM_REVIEW)
         self.is_opportunity_pm = kwargs.pop("is_opportunity_pm")
 
@@ -1676,6 +1685,15 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
                 currency_code=self.opportunity.currency_code or "Local Currency"
             )
             self.fields["amount"].help_text = _("Local currency is determined by the opportunity.")
+
+            self.fields["late_delta_units"].label = header_with_tooltip(
+                format_html('{} <i class="fa-solid fa-circle-info text-gray-400"></i>', _("Catch-up Units")),
+                _(
+                    "Additional deliveries for work that an earlier invoice already billed. They were "
+                    "approved after that invoice was issued, so they are billed here."
+                ),
+            )
+            self.fields["late_delta_units"].initial = self.late_delta_units
 
             self.fields["description"].widget.attrs.update(
                 {
@@ -1759,6 +1777,16 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
                 },
             ),
         ]
+
+        if not self.read_only:
+            third_row.append(
+                Div(
+                    Field("late_delta_units", **{"x-model": "lateDeltaUnits"}),
+                    **{"x-show": "lateDeltaUnits > 0", "x-cloak": ""},
+                )
+            )
+        elif self.late_delta_units:
+            third_row.append(Field("late_delta_units"))
 
         return [
             Div(

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1681,14 +1681,16 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
             self.fields["status"].initial = self.instance.get_status_display()
 
         if self.is_service_delivery:
-            self.fields["amount"].label = _("Amount ({currency_code})").format(
+            self.fields["amount"].label = gettext("Amount ({currency_code})").format(
                 currency_code=self.opportunity.currency_code or "Local Currency"
             )
-            self.fields["amount"].help_text = _("Local currency is determined by the opportunity.")
+            self.fields["amount"].help_text = gettext("Local currency is determined by the opportunity.")
 
             self.fields["late_delta_units"].label = header_with_tooltip(
-                format_html('{} <i class="fa-solid fa-circle-info text-gray-400"></i>', _("Additional Deliveries")),
-                _(
+                format_html(
+                    '{} <i class="fa-solid fa-circle-info text-gray-400"></i>', gettext("Additional Deliveries")
+                ),
+                gettext(
                     "Additional deliveries for previously billed work. These were delivered or approved "
                     "after the previous invoice was issued and are included on this invoice."
                 ),
@@ -1697,7 +1699,7 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
 
             self.fields["description"].widget.attrs.update(
                 {
-                    "placeholder": _("Describe service delivery details, references, or notes..."),
+                    "placeholder": gettext("Describe service delivery details, references, or notes..."),
                 }
             )
 
@@ -1719,10 +1721,10 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
                 }
             )
             self.fields["description"].required = True
-            self.fields["description"].label = _("Justification")
+            self.fields["description"].label = gettext("Justification")
             self.fields["description"].widget.attrs.update(
                 {
-                    "placeholder": _("Provide a justification for this expense..."),
+                    "placeholder": gettext("Provide a justification for this expense..."),
                 }
             )
             self.fields["date_of_expense"].required = True
@@ -1736,7 +1738,7 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
         if not self.read_only:
             invoice_form_fields.append(
                 Div(
-                    Submit("submit", _("Submit"), css_class="button button-md primary-dark"),
+                    Submit("submit", gettext("Submit"), css_class="button button-md primary-dark"),
                     css_class="flex justify-end mt-4",
                 )
             )
@@ -1797,7 +1799,7 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
             ),
             self.line_items,
             Fieldset(
-                _("Service Delivery Notes"),
+                gettext("Service Delivery Notes"),
                 Field("description", **{"x-ref": "description"}),
             ),
         ]
@@ -1813,7 +1815,7 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
         second_row = [
             Field(
                 "amount",
-                label=_("Amount"),
+                label=gettext("Amount"),
                 **{
                     "x-ref": "amount",
                     "x-model": "amount",

--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1687,10 +1687,10 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
             self.fields["amount"].help_text = _("Local currency is determined by the opportunity.")
 
             self.fields["late_delta_units"].label = header_with_tooltip(
-                format_html('{} <i class="fa-solid fa-circle-info text-gray-400"></i>', _("Catch-up Units")),
+                format_html('{} <i class="fa-solid fa-circle-info text-gray-400"></i>', _("Additional Deliveries")),
                 _(
-                    "Additional deliveries for work that an earlier invoice already billed. They were "
-                    "approved after that invoice was issued, so they are billed here."
+                    "Additional deliveries for previously billed work. These were delivered or approved "
+                    "after the previous invoice was issued and are included on this invoice."
                 ),
             )
             self.fields["late_delta_units"].initial = self.late_delta_units

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from allauth.socialaccount.models import SocialAccount
+from crispy_forms.utils import render_crispy_form
 from dateutil.relativedelta import relativedelta
 from django.core.cache import cache
 from django.utils.timezone import now
@@ -934,10 +935,49 @@ class TestAutomatedPaymentInvoiceForm:
             invoice_type="service_delivery",
             read_only=True,
             line_items_table=mock_table,
+            late_delta_units=3,
             is_opportunity_pm=False,
         )
 
         assert form.line_items_table == mock_table
+        assert form.fields["late_delta_units"].initial == 3
+        # Derived for display, so nothing posted for it can reach cleaned_data or raise an error.
+        assert form.fields["late_delta_units"].disabled is True
+
+    @pytest.mark.parametrize(
+        "read_only, late_delta_units, visibility",
+        [
+            pytest.param(True, 3, "visible", id="saved-with-late-deltas"),
+            pytest.param(True, 0, "absent", id="saved-without-late-deltas"),
+            # The create form has no count until the fetch returns, so it always renders the field
+            # and lets Alpine decide whether to reveal it.
+            pytest.param(False, 0, "gated", id="create-form"),
+        ],
+    )
+    def test_late_delta_units_field_shows_only_when_there_are_late_deltas(
+        self, valid_opportunity, read_only, late_delta_units, visibility
+    ):
+        kwargs = {}
+        if read_only:
+            kwargs["instance"] = PaymentInvoiceFactory(
+                opportunity=valid_opportunity,
+                service_delivery=True,
+                start_date=datetime.date(2025, 10, 1),
+                end_date=datetime.date(2025, 10, 31),
+            )
+
+        form = AutomatedPaymentInvoiceForm(
+            opportunity=valid_opportunity,
+            invoice_type="service_delivery",
+            read_only=read_only,
+            late_delta_units=late_delta_units,
+            is_opportunity_pm=False,
+            **kwargs,
+        )
+
+        html = render_crispy_form(form)
+        assert ("id_late_delta_units" in html) is (visibility != "absent")
+        assert ('x-show="lateDeltaUnits &gt; 0"' in html) is (visibility == "gated")
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_invoice_line_items.py
+++ b/commcare_connect/opportunity/tests/test_invoice_line_items.py
@@ -32,6 +32,7 @@ from commcare_connect.opportunity.utils.invoice_line_items import (
     get_invoice_line_items,
     group_line_items,
     rollback_invoice_line_items,
+    total_late_delta_units,
 )
 from commcare_connect.utils.datetime import get_end_date_previous_month, get_month_start_date
 
@@ -451,6 +452,9 @@ class TestCancelledFirstBilling:
         assert row.billed_count == 1
         assert row.month == JAN  # its approval month
         assert row.is_delta is False
+        # Cancelling January released the unit's first billing, so re-billing it is a first billing
+        # again and not a late delta. The displayed count has to follow that, not the earlier invoice.
+        assert total_late_delta_units(get_invoice_line_items(reissued)) == 0
 
     def test_start_date_reaches_back_to_the_approval_month(self, cancelled_first_billing):
         access, _ = cancelled_first_billing
@@ -472,6 +476,7 @@ class TestInvoicedLineItems:
 
         by_name = {item.payment_unit_name: item for item in items}
         assert len(items) == 2
+        assert total_late_delta_units(items) == 0  # every work here is a first billing
         assert by_name[payment_unit.name].number_approved == 2
         assert by_name[payment_unit.name].flw_pay.local == Decimal("200")
         assert by_name[payment_unit.name].org_pay.local == Decimal("40")
@@ -561,6 +566,11 @@ class TestWorkPayRowReaders:
         late.save(update_fields=["saved_approved_count"])
         fresh = completed_work(access, payment_unit, approved_on=FEB_APPROVAL)
 
+        (previewed,) = get_billable_line_items(access.opportunity, FEB, FEB_END)
+        # total 2 new deliveries, 1 of which is a late delta
+        assert previewed.number_approved == 2
+        assert previewed.late_delta_units == 1
+
         february = billed_invoice(access.opportunity, FEB, FEB_END)
 
         rows = {row.completed_work: row for row in get_invoice_delivery_rows(february)}
@@ -570,6 +580,10 @@ class TestWorkPayRowReaders:
         assert rows[late].is_delta is True
         assert rows[fresh].billed_count == 1
         assert rows[fresh].is_delta is False
+
+        (frozen,) = get_invoice_line_items(february)
+        assert frozen.number_approved == 2
+        assert frozen.late_delta_units == 1
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_tables.py
+++ b/commcare_connect/opportunity/tests/test_tables.py
@@ -47,6 +47,7 @@ def test_invoice_line_items_table_reads_money_off_line_items():
         month=datetime.date(2026, 1, 1),
         payment_unit_name="Household visit",
         number_approved=2,
+        late_delta_units=0,
         flw_pay=Money(Decimal("40"), Decimal("4")),
         org_pay=Money(Decimal("10"), Decimal("1")),
         exchange_rate=Decimal("10"),

--- a/commcare_connect/opportunity/utils/invoice_line_items.py
+++ b/commcare_connect/opportunity/utils/invoice_line_items.py
@@ -5,6 +5,7 @@ from decimal import ROUND_HALF_EVEN, Decimal
 
 from django.db import transaction
 from django.db.models import Exists, F, Max, OuterRef, Q, Sum
+from django.db.models.functions import Coalesce
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
@@ -134,6 +135,7 @@ class LineItem:
     month: datetime.date
     payment_unit_name: str
     number_approved: int
+    late_delta_units: int
     flw_pay: Money
     org_pay: Money
     exchange_rate: Decimal
@@ -152,12 +154,15 @@ def group_line_items(rows):
             {
                 "payment_unit_name": payment_unit.name,
                 "number_approved": 0,
+                "late_delta_units": 0,
                 "flw_pay": Money.zero(),
                 "org_pay": Money.zero(),
                 "exchange_rate": row.exchange_rate.rate,
             },
         )
         group["number_approved"] += row.billed_count
+        if row.is_delta:
+            group["late_delta_units"] += row.billed_count
         group["flw_pay"] += row.flw_pay
         group["org_pay"] += row.org_pay
 
@@ -166,6 +171,11 @@ def group_line_items(rows):
         return (month, group["payment_unit_name"])
 
     return [LineItem(month=month, **group) for (month, _), group in sorted(groups.items(), key=display_order)]
+
+
+def total_late_delta_units(line_items):
+    """Additional deliveries billed here for work that an earlier invoice already billed."""
+    return sum(item.late_delta_units for item in line_items)
 
 
 def get_billable_line_items(opportunity, start_date, end_date):
@@ -179,6 +189,7 @@ def get_invoice_line_items(invoice):
         .annotate(
             payment_unit_name=F("completed_work__payment_unit__name"),
             number_approved=Sum("billed_count"),
+            late_delta_units=Coalesce(Sum("billed_count", filter=Q(is_delta=True)), 0),
             flw_local=Sum("flw_amount_local"),
             org_local=Sum("org_amount_local"),
             flw_usd=Sum("flw_amount_usd"),
@@ -194,6 +205,7 @@ def get_invoice_line_items(invoice):
             month=record["month"],
             payment_unit_name=record["payment_unit_name"],
             number_approved=record["number_approved"],
+            late_delta_units=record["late_delta_units"],
             flw_pay=Money(record["flw_local"], record["flw_usd"]),
             org_pay=Money(record["org_local"], record["org_usd"]),
             exchange_rate=record["rate"],

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -194,6 +194,7 @@ from commcare_connect.opportunity.utils.invoice_line_items import (
     get_invoice_delivery_rows,
     get_invoice_line_items,
     rollback_invoice_line_items,
+    total_late_delta_units,
 )
 from commcare_connect.opportunity.visit_import import (
     ImportException,
@@ -1890,8 +1891,10 @@ class InvoiceReviewView(OrganizationUserMixin, OpportunityObjectMixin, DetailVie
         )
 
         line_items_table = None
+        late_delta_units = 0
         if invoice.service_delivery:
             line_items = get_invoice_line_items(invoice)
+            late_delta_units = total_late_delta_units(line_items)
             show_org = any(item.org_pay.local for item in line_items)
             line_items_table = InvoiceLineItemsTable(opportunity.currency_code, line_items, show_org=show_org)
         return AutomatedPaymentInvoiceForm(
@@ -1899,6 +1902,7 @@ class InvoiceReviewView(OrganizationUserMixin, OpportunityObjectMixin, DetailVie
             opportunity=opportunity,
             invoice_type=invoice_type,
             line_items_table=line_items_table,
+            late_delta_units=late_delta_units,
             read_only=True,
             is_opportunity_pm=self.request.is_opportunity_pm,
         )
@@ -3545,6 +3549,7 @@ def invoice_items(request, *args, **kwargs):
             "line_items_table_html": html,
             "total_amount": total.local,
             "total_usd_amount": total.usd,
+            "late_delta_units": total_late_delta_units(line_items),
         }
     )
 

--- a/commcare_connect/templates/opportunity/partials/invoice_form_handler.html
+++ b/commcare_connect/templates/opportunity/partials/invoice_form_handler.html
@@ -8,6 +8,7 @@
       endDate: "{% firstof form.instance.end_date|date:'Y-m-d' form.end_date.value '' %}",
       amount: "{{ form.amount.value|default:'null' }}",
       usdAmount: "{{ form.amount_usd.value|default:'null' }}",
+      lateDeltaUnits: {{ form.late_delta_units.value|default:0 }},
       isServiceDelivery: "{{ is_service_delivery|yesno:'true,false' }}" == 'true',
       isReadOnly: "{{ is_read_only|yesno:'true,false'}}" == "true",
       invoiceId: "{{ form.instance.payment_invoice_id|default:'' }}",
@@ -67,9 +68,12 @@
           document.getElementById('invoice-line-items-wrapper').innerHTML = data.line_items_table_html;
           this.amount = data.total_amount;
           this.usdAmount = data.total_usd_amount;
+          this.lateDeltaUnits = data.late_delta_units;
           this.showDownloadButton = true;
         }).catch(error => {
           console.error('Error fetching invoice items:', error);
+          // Nothing known about the window, so drop the count rather than leave a stale one showing.
+          this.lateDeltaUnits = null;
           this.showDownloadButton = false;
         });
       },


### PR DESCRIPTION
## Product Description

When reviewing an invoice you can now see how much of it is catch-up work — extra deliveries against a job an earlier invoice already paid for. It shows up as a read-only **Catch-up Units** field next to the amounts, with a tooltip explaining
what it counts.

The field only appears when there actually are some, so a normal invoice looks exactly as it did before. Most invoices won't show it.

<img width="3230" height="1418" alt="image" src="https://github.com/user-attachments/assets/9076f43e-443c-4dd2-be9a-c50e935ad18a" />


## Technical Summary

[CCCT-2527](https://dimagi.atlassian.net/browse/CCCT-2527) Stacked on #1432; ships after the forward-delta cutover.

"Catch-up" is the reviewer's word for this, so it lives only in the label and tooltip. The code says *late delta* throughout, matching `invoice.py` and the existing docstrings.

## Safety Assurance

### Safety story

This is display-only. Nothing about what gets billed changed: no writes, no migration, no new queries, and no change to how a delta is selected or priced. The count is read off `is_delta`, which the cutover already sets. The worst a bug here
can do is show a wrong number in a field nobody can edit.

### Automated test coverage
Added.

- the two readers agree on the same mixed month — Python grouping vs SQL aggregate
- the count drops back to zero when a cancelled invoice is re-billed
- the field is absent with no late deltas, visible with some, and Alpine-gated on the
  create form where the count isn't known until the fetch returns
- the form field is disabled, so nothing posted for it reaches `cleaned_data`

Full `commcare_connect/opportunity` suite passes.

### QA Plan

QA required.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2410]: https://dimagi.atlassian.net/browse/CCCT-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCCT-2527]: https://dimagi.atlassian.net/browse/CCCT-2527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ