### PR TITLE
Superset Upgrade Plan

### DIFF
--- a/docs/plans/2026-08-20-superset-pg16-inplace-upgrade-plan.md
+++ b/docs/plans/2026-08-20-superset-pg16-inplace-upgrade-plan.md
@@ -1,0 +1,478 @@
+# Superset PG16 In-Place Upgrade — Implementation Plan
+
+**Goal:** Upgrade the Superset/analytics RDS instance from PostgreSQL **15.17 to 16.13** in place,
+and reconnect logical replication from the Connect primary afterwards.
+
+---
+
+## Before Starting
+
+**Three ways to break this permanently, all of them silent:**
+
+1. **Task 1's `GRANT` must land before the upgrade.** It is legal on PG15, refused on PG16, and no
+   role you can log in as can apply it afterwards. Skip it and all 29 tables freeze permanently.
+2. **Never run `ALTER SUBSCRIPTION ... ENABLE` before Task 8's probe.** Enabling with wiped
+   subscriber state gives a subscription that reports `apply_error_count = 0` and applies nothing
+   forever, while advancing the slot past the backlog. Verified.
+3. **Never pass `--recreate` to `setup_logical_replication`.** It drops the subscription and
+   re-creates it without a slot name, colliding with the orphaned slot it just detached — failing
+   *after* the subscription is gone.
+
+**Connection helper.** Several statements need true autocommit as a specific role — `postgres`,
+the subscriber's master user. Pass `dbname="superset_meta"` to reach the metadata database:
+
+```python
+import psycopg2, getpass
+from django.conf import settings
+from django.db import connections
+
+def secondary(user="postgres", password=None, dbname=None, autocommit=True):
+    s = connections[settings.SECONDARY_DB_ALIAS].settings_dict
+    c = psycopg2.connect(host=s["HOST"], port=s["PORT"], dbname=dbname or s["NAME"],
+                         user=user, password=password or getpass.getpass(f"{user}: "),
+                         sslmode="require")
+    c.autocommit = autocommit
+    return c
+
+def q(c, sql, args=None):
+    with c.cursor() as cur:
+        cur.execute(sql, args)
+        try: return cur.fetchall()
+        except psycopg2.ProgrammingError: return None
+```
+
+**Verified production facts this plan is built on** (2026-08-12 and 2026-08-20):
+
+| Fact | Value |
+|---|---|
+| Secondary version | 15.17. |
+| **Target engine** | **16.13** — *not* `16.13-R2`. Chosen because it ships PostGIS **3.4.3**, the version already installed, so no extension update is needed and no precheck version mismatch arises. |
+| Databases on the instance | `ccc_analytics`, `ccc_analytics_old`, `postgres`, `rdsadmin`, `superset`, `superset_meta` |
+| **Analytics (replicated) database** | **`superset`** — from `SECONDARY_DATABASE_URL`. |
+| **Superset metadata database** | **`superset_meta`** |
+| PostGIS | **3.4.3, owner `rdsadmin`, in BOTH `superset` and `superset_meta`**. Already the newest version PG15 offers — nothing to update pre-upgrade. |
+| Table ownership | all 91 tables `connect_superset`, except `spatial_ref_sys` (`rdsadmin`) |
+| Superset version | **5.0.0**. Supports PG16; no compatibility test needed. |
+| Superset sessions | filesystem (`flask_session/`) — **a restart logs everyone out**; say so in the downtime comms |
+| Metadata colocation | **confirmed** — live backends on both `superset` (2) and `superset_meta` (5), so the upgrade takes Superset itself down, not just analytics freshness. `superset_meta` is the half worth dumping (Task 5). |
+| Replication role (primary) | **`postgres_repl`** — verified 2026-08-27 as the role the live subscriber authenticates with (`pg_stat_replication.usename`, `application_name = tables_for_superset_sub`). `rolreplication = false`, because RDS grants replication through **`rds_replication` membership** rather than the attribute. |
+| Subscription owner | `postgres` — `rolsuper = false`, `rolcreaterole = true`, **member of `rds_superuser`** |
+| Members of `connect_superset` | **none** — the Task 1 grant is required |
+| `max_slot_wal_keep_size` (primary) | **`-1`** — the slot is never invalidated |
+| Slot state | one slot, active, 56 bytes retained, no backlog |
+| Publication vs subscription | **no drift** — 29 published, 29 at `srsubstate = 'r'` |
+
+---
+
+## Phase 1 — Pre-flight on PG15
+
+Nothing here requires a specific time window.
+
+### Task 1: Apply the one-way GRANT
+
+**Why:** PG16's apply worker `SET ROLE`s to each replicated table's owner. The subscription is owned
+by `postgres`; the tables are owned by `connect_superset`; nothing is a member of `connect_superset`.
+On PG15 `CREATEROLE` implies the right to grant membership in any non-superuser role, so `postgres`
+can grant this today. PG16 removed that implication — a `CREATEROLE` role may only administer roles
+it created or holds `ADMIN OPTION` on — and `rdsadmin`, though flagged `rolcanlogin`, is an
+AWS-internal role whose credentials nobody outside AWS holds. **After the upgrade there is no path
+to apply it.** Both halves verified in Docker.
+
+**Who can run this:** The instance has exactly two loginable privileged
+roles: `postgres` (the RDS master user) and `rdsadmin` (AWS-internal, unusable). Django connects as
+`connect_superset`, which has neither `CREATEROLE` nor superuser. **`postgres` is the only role that
+can apply this**.
+
+**Step 1: Confirm the precondition**
+
+```python
+from django.db import connections
+with connections["secondary"].cursor() as c:
+    c.execute("""SELECT grantee.rolname, m.admin_option
+                 FROM pg_auth_members m
+                 JOIN pg_roles target  ON target.oid  = m.roleid
+                 JOIN pg_roles grantee ON grantee.oid = m.member
+                 WHERE target.rolname = 'connect_superset';""")
+    print(c.fetchall())
+```
+The expected output here is `[]`.
+
+**Step 2: Apply it as `postgres`.**
+
+```python
+conn = secondary(user="postgres")
+q(conn, 'GRANT "connect_superset" TO "postgres";')
+```
+
+If this errors *on PG15*, stop and escalate — it only becomes harder on 16.
+
+**Step 3: Verify.** Re-run Step 1; it must no longer be empty. `admin_option = False` is fine —
+`INHERIT` membership is what the apply worker needs, and it survives `pg_upgrade` (verified).
+
+---
+
+### Task 2: Baselines and credentials
+
+**Step 1: Row counts both sides**
+
+```bash
+./manage.py logical_replication_status
+```
+
+Interactive; prompts for secondary superuser credentials. Without this baseline there is no way to
+prove afterwards that nothing froze — frozen tables keep plausible counts.
+
+**Step 2: Confirm no publication drift persists** (verified clean 2026-08-20, re-check on the day):
+
+```python
+with connections["default"].cursor() as c:
+    c.execute("SELECT count(*) FROM pg_publication_tables WHERE pubname='tables_for_superset_pub';")
+    print(c.fetchone())          # expect 29
+with connections["secondary"].cursor() as c:
+    c.execute("SELECT srsubstate, count(*) FROM pg_subscription_rel GROUP BY 1;")
+    print(c.fetchall())          # expect [('r', 29)]
+```
+
+**Step 3: Record** the baseline counts and the drift check.
+
+---
+
+## Phase 2 — Scheduling gates
+
+### Task 3: Backups
+
+Confirm backup retention > 0, so RDS takes an automatic pre-upgrade snapshot:
+
+```bash
+aws rds describe-db-instances --db-instance-identifier <instance-id> \
+  --query 'DBInstances[].[BackupRetentionPeriod,PreferredBackupWindow,DBInstanceStatus]' --output table
+```
+
+A retention of `0` means automated backups are **off** and no pre-upgrade snapshot is taken — enable
+it before proceeding. The manual snapshot is taken in the window, at Task 5 Step 4.
+
+### Task 4: Agree the window and the deploy freeze
+
+**Step 1:** Agree the outage window.
+
+**Step 2:** Ensure no deploys happen during outage window.
+
+**Step 3: Agree on the re-copy fallback** so the upgrade path is not blocked mid-window. If the
+probe (Task 8) sends you to Task 10, all 29 tables are truncated and re-copied from the primary.
+Agree *now* that this is acceptable, and record it. What the approver is signing off:
+
+- **Superset serves empty tables until the copy finishes** — blank dashboards, not stale ones.
+- **Sustained read load on the Connect primary** for the duration; `opportunity_uservisit` is the
+  largest of the 29.
+
+Unlikely to be needed — `max_slot_wal_keep_size = -1` means the slot survives, so the fast path
+stays available — but worth agreeing in advance.
+
+---
+
+## Phase 3 — The window
+
+### Task 5: Announce and freeze
+
+**Step 1:** Post the downtime notice.
+
+**Step 2:** Activate the deploy freeze.
+
+**Step 3:** Dump Superset's metadata — the only irreplaceable data on the instance, and the rollback
+artifact if Superset breaks after the upgrade:
+
+```bash
+pg_dump -h <endpoint> -U postgres -d superset_meta -Fc -f superset_meta_window_start.dump
+```
+
+**Step 4:** Take the manual snapshot, at the true starting state, and wait for it:
+
+```bash
+aws rds create-db-snapshot --db-instance-identifier <instance-id> \
+  --db-snapshot-identifier superset-pre-pg16-<yyyymmdd>-1
+
+aws rds wait db-snapshot-completed \
+  --db-snapshot-identifier superset-pre-pg16-<yyyymmdd>-1
+```
+
+**Do not start the upgrade until the wait returns** — a snapshot still in `creating` is not a
+rollback. **Record the identifier**; Phase 5 refers to it. Bump the `-1` on a same-day retry, since
+RDS refuses a duplicate.
+
+**Step 5:** Record timestamps.
+
+### Task 6: Disable the subscription
+
+```python
+conn = secondary(user="postgres")
+q(conn, "ALTER SUBSCRIPTION tables_for_superset_sub DISABLE;")
+print(q(conn, "SELECT subname, subenabled FROM pg_subscription;"))   # expect False
+```
+
+**Then record the slot position on the primary** — that is where the backlog replays from:
+
+```python
+from django.db import connections
+cur = connections["default"].cursor()
+cur.execute("""SELECT slot_name, active, restart_lsn, confirmed_flush_lsn,
+                      pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained
+               FROM pg_replication_slots;""")
+print(cur.fetchall())
+cur.close()
+```
+
+**Record the `restart_lsn` and the wall-clock time.** Re-run this query periodically through the
+window: `retained` is the WAL the primary is holding on the slot's behalf, and it only stops growing
+once the subscription is re-enabled. `max_slot_wal_keep_size = -1` means the slot will **not** be
+dropped to protect the disk, so **watch primary free space** rather than assuming it self-limits.
+
+### Task 7: Run the engine upgrade
+
+**Step 1:** RDS console → Modify → engine version **16.13** → apply immediately. Not `16.13-R2`.
+**Step 2:** Wait. **Record start and end times**.
+**Step 3:** Confirm the engine reports 16.13:
+
+```python
+conn = secondary(user="postgres")
+print(q(conn, "SELECT version();"))
+```
+
+**Step 4: Verify PostGIS survived — no update, in either database.**
+
+```python
+for db in ("superset", "superset_meta"):
+    c = secondary(user="postgres", dbname=db)
+    print(db, q(c, """SELECT e.extversion, a.default_version
+                     FROM pg_extension e
+                     JOIN pg_available_extensions a ON a.name = e.extname
+                     WHERE e.extname = 'postgis';"""))
+    c.close()
+```
+
+Expect `[('3.4.3', '3.4.3')]` for both — installed and available matching, so there is nothing to
+update.
+
+If `default_version` unexpectedly reads 3.4.6, the wrong minor was applied (likely `16.13-R2`).
+PostGIS still works at 3.4.3 on PG16 — do **not** treat it as a rollback trigger; note it and carry
+the update as a follow-up.
+
+**Step 5:** Confirm geometry still queries:
+
+```python
+print(q(conn, """SELECT ST_AsText(ST_Centroid(geometry))
+                 FROM microplanning_workarea WHERE geometry IS NOT NULL LIMIT 1;"""))
+```
+
+### Task 8: The probe — before anything destructive
+
+**Step 1: Confirm the expected post-upgrade state**
+
+```python
+conn = secondary(user="postgres")
+print(q(conn, "SELECT subname, subenabled FROM pg_subscription;"))     # expect False
+print(q(conn, "SELECT count(*) FROM pg_subscription_rel;"))            # expect 0 -- wiped
+```
+
+**Step 2: Probe**
+
+```python
+print(q(conn, "SELECT pg_has_role('postgres','pg_create_subscription','USAGE');"))
+print(q(conn, "SELECT has_database_privilege(current_user, current_database(), 'CREATE');"))
+```
+
+**Both must be `True`.** PG16 gates `CREATE SUBSCRIPTION` on two things, not one:
+`pg_create_subscription` membership *and* `CREATE` on the current database. Task 9 opens by
+dropping the subscription, so attempting it on a `False` strands the instance with no way to
+reconnect — snapshot restore only. Treat either `False` as a `False` overall.
+
+**Step 3: Branch, and write the branch into the log before acting.**
+
+- Both `True` → Task 9 (replay from the slot, no re-copy)
+- Either `False` → Task 10 (rebuild). Do **not** attempt Task 9.
+
+### Task 9: Replay from the retained slot (probe returned `True`)
+
+The slot is intact — `max_slot_wal_keep_size = -1` guarantees it was never invalidated — so the whole
+outage backlog replays with no re-copy.
+
+**Step 1: Detach and drop**
+
+```python
+q(conn, "ALTER SUBSCRIPTION tables_for_superset_sub SET (slot_name = NONE);")
+q(conn, "DROP SUBSCRIPTION tables_for_superset_sub;")
+```
+
+**Step 2: Re-create against the retained slot, not copying**
+
+```python
+q(conn, """CREATE SUBSCRIPTION tables_for_superset_sub
+             CONNECTION 'host=<primary> port=5432 dbname=<db> user=postgres_repl password=<pw> sslmode=require'
+             PUBLICATION tables_for_superset_pub
+             WITH (copy_data = false,
+                   slot_name = 'tables_for_superset_sub',
+                   create_slot = false,
+                   enabled = false);""")
+```
+
+**If `create_slot = false` is refused** (unverified on RDS), fall through to Step 4.
+
+**Step 3: Enable and let it replay**
+
+```python
+q(conn, "ALTER SUBSCRIPTION tables_for_superset_sub ENABLE;")
+```
+
+Expected: `pg_subscription_rel` populates at state `r` with no copying, and the backlog replays.
+Go to Phase 4.
+
+**Step 4: Only if Step 2 was refused.** Copy instead of replaying. Order matters — the slot goes
+first.
+
+**4a. Drop the retained slot on the primary.** Step 1 detached it deliberately, so it is still there
+under the subscription's name. Re-creating without `slot_name` / `create_slot` makes Postgres try to
+create a slot by that name and fail with `replication slot ... already exists` — the same collision
+that makes `--recreate` unsafe, again after the subscription is gone.
+
+```sql
+-- on the primary: confirm inactive, then drop
+SELECT slot_name, active FROM pg_replication_slots WHERE slot_name = 'tables_for_superset_sub';
+SELECT pg_drop_replication_slot('tables_for_superset_sub');
+```
+
+**4b. Truncate the 29 tables** — copying into populated tables fails with `duplicate key value
+violates unique constraint`, so this is mandatory.
+
+```python
+q(conn, "SET ROLE connect_superset; TRUNCATE <the 29 replicated tables>;")
+q(conn, "RESET ROLE;")   # session-scoped; left set, the DDL below runs as connect_superset and fails
+```
+
+**4c. Re-create as in Step 2**, with `copy_data = true` and no `slot_name` / `create_slot`, then
+enable it — that template carries `enabled = false`, and Step 3 is above this one, so a subscription
+created here replicates nothing until you say so.
+
+```python
+q(conn, "ALTER SUBSCRIPTION tables_for_superset_sub ENABLE;")
+```
+
+### Task 10: Rebuild via the management command (probe returned `False`)
+
+Verified end to end in Docker under prod-shaped roles. Needs only subscription ownership.
+
+**Step 1: Enable** — required, `REFRESH` is refused on a disabled subscription (verified):
+
+```python
+q(conn, "ALTER SUBSCRIPTION tables_for_superset_sub ENABLE;")
+```
+
+**Step 2: Truncate** — mandatory, and skipping it fails *silently*: `REFRESH` with `copy_data = true`
+into populated tables returns no error while every tablesync loops on duplicate keys.
+
+```python
+q(conn, "SET ROLE connect_superset; TRUNCATE <the 29 replicated tables>;")
+q(conn, "RESET ROLE;")   # Step 4 sends you back here; leave it set and the later DDL fails
+```
+
+Table list: `commcare_connect/multidb/constants.py` → `REPLICATION_ALLOWED_MODELS`.
+
+**Step 3: Run the command, no flags**
+
+```bash
+./manage.py setup_logical_replication
+```
+
+It takes the REFRESH branch (the subscription exists), sets autocommit itself, and re-grants
+`superset_readonly` its SELECTs. Its `ALTER PUBLICATION ... SET TABLE` against the primary is a
+no-op — Task 2 Step 2 confirmed the published set matches. **Never `--recreate`.**
+
+**Step 4: Watch the copy.** States progress `i` → `d` → `r`; errors stay `0|0`. Superset serves
+**empty** tables until this completes. **Do not trust the command's output** — it reports success
+regardless. A table parked at `d` means the truncate missed it; truncate it now and it self-heals.
+
+### Task 11: Lift the deploy freeze
+
+Only after Phase 4 passes. Run a real deploy and confirm `migrate_multi` succeeds against the 16
+secondary.
+
+---
+
+## Phase 4 — Verification
+
+The failure mode reports success, so no single check suffices.
+
+**Task 12: Structural**
+
+```python
+print(q(conn, "SELECT srsubstate, count(*) FROM pg_subscription_rel GROUP BY 1;"))  # ('r', 29)
+print(q(conn, "SELECT * FROM pg_stat_subscription_stats;"))                          # 0 | 0
+print(q(conn, """SELECT tableowner, count(*) FROM pg_tables
+                 WHERE schemaname='public' GROUP BY 1;"""))    # connect_superset + rdsadmin
+```
+
+Expected: `connect_superset` for all 90, plus `rdsadmin` for `spatial_ref_sys` alone — the exception
+recorded in the facts table above, and unchanged by the upgrade. Any *other* owner, or a
+`connect_superset` count below 90, is the real signal.
+
+An empty `pg_subscription_rel`, or anything at `d`, means replication is dead regardless of what
+anything printed.
+
+**Task 13: Data — movement, not just counts**
+
+**Step 1:** `./manage.py logical_replication_status`, compare to the Task 2 baseline.
+**Step 2:** Wait several minutes and sample again. **Step 3:** Confirm the counts moved — a single
+sample cannot distinguish frozen from current, which is exactly how this failure hides.
+**Step 4:** Insert a synthetic row into one replicated table, confirm it reaches the secondary, then
+delete it and confirm the delete replicates too — the plan's one write to the primary, so log both
+statements. **Step 5:** Slot on the primary is `active`, retained bytes small and falling.
+
+**Task 14: Superset** — dashboards load, logins work, a saved chart still queries the analytics
+database, and geometry-backed content renders.
+
+**Task 15: Close out** — summarise the measured upgrade duration, the probe answer, and whether the
+PostGIS extension upgrade worked as a non-owner. Fold all three back into the investigation doc;
+they were the open unknowns.
+
+---
+
+## Phase 5 — Rollback and abort
+
+**There is no in-place rollback.** Snapshot restore is the only path back and it yields a **new
+endpoint**, so `SECONDARY_DATABASE_URL` and Superset's config change anyway — in-place's "no config
+change" advantage holds only on the success path. Pre-stage where both are set.
+
+| Trigger | Action |
+|---|---|
+| Precheck fails when the upgrade is initiated | Safe — it aborts and nothing changes. Retrieve `pg_upgrade_precheck.log` from the RDS console, fix the flagged extension, retry. Cost is a wasted window, not damage. |
+| Task 7 — PostGIS not at 3.4.3 after the upgrade | **Not a rollback trigger.** Wrong minor applied; 3.4.3 is supported on PG16. Verify geometry (Step 5) and carry the update as a follow-up. |
+| Task 8 probe returns `False` | Proceed to Task 10 — pre-authorised in Task 4 Step 3. No in-window approval needed. |
+| Task 10 — tables stuck at `d` | Truncate them again; the sync self-heals. Verified. |
+| Primary free space falling during the window | **Do not re-enable the subscription to relieve it** — the `ENABLE` prohibition holds regardless of storage pressure, and enabling before the Task 8 probe is what produces the silent permanent freeze. **Prefer pressing on to Task 8** and taking the re-copy branch, which releases the slot and keeps the subscription. Drop the subscription only if the window itself has to be abandoned — and note that doing so puts Task 10 out of reach (see below). |
+| Superset broken after the upgrade | Restore the Task 5 window-start metadata dump (procedure below); if that fails, restore the snapshot. |
+
+**Dropping the subscription forecloses Task 10**, which enables the existing one and needs the
+`REFRESH` branch. The only route back is then Task 9 Step 4 standalone — drop the slot, truncate,
+`CREATE SUBSCRIPTION` with `copy_data = true`, `ENABLE` — untested end to end. Hence pressing on to
+Task 8 instead.
+
+**Restoring the metadata dump.** `superset_meta` still exists at this point, so a plain
+`pg_restore` will not replace what is in it — it errors on every existing object and leaves a
+half-old, half-new database. Stop Superset first, then:
+
+```bash
+pg_restore -h <endpoint> -U postgres -d superset_meta \
+  --clean --if-exists superset_meta_window_start.dump
+```
+
+`--clean --if-exists` drops each object before recreating it. **Do not pass `--no-owner` or
+`--role`** — the dump carries the right `ALTER ... OWNER` statements and `postgres` can apply them,
+so ownership returns as it was. `postgis` is dropped and recreated too, so confirm it is back at
+3.4.3 before restarting Superset, then check logins and one saved chart.
+
+`pg_restore` continues past errors and exits `1` if it ignored any, so read the error list rather
+than the exit code — the `postgis` owner and comment statements fail benignly on RDS.
+
+**What bounds the downside:** the primary is written to in three places only — Task 1's `GRANT`,
+`setup_logical_replication`'s `ALTER PUBLICATION ... SET TABLE`, and Task 13's canary and its delete
+— and the replicated tables are reproducible by definition. The worst realistic outcome is Superset
+down for hours, analytics rebuilt from scratch, possibly a snapshot restore onto a new endpoint with
+some Superset metadata lost.

--- a/docs/plans/2026-08-20-superset-pg16-parallel-upgrade-plan.md
+++ b/docs/plans/2026-08-20-superset-pg16-parallel-upgrade-plan.md
@@ -1,0 +1,440 @@
+# Superset PG16 Parallel Upgrade — Implementation Plan
+
+**Goal:** Stand up a new PostgreSQL 16 RDS instance, populate it from the Connect primary by
+logical replication, validate it while 15.17 keeps serving, then cut Superset and Connect over.
+
+---
+
+## Before Starting
+
+**Two rules**, both about things the steps cannot enforce for you:
+
+1. **The primary is read-only** except where flagged: the `GRANT SELECT` and
+   `ALTER PUBLICATION ... SET TABLE` that `setup_logical_replication` issues (Task 4), the canary row
+   (Task 7), the slot cleanup (Task 11), and the publication rewrite Task 13's `REFRESH` exercise
+   triggers. **Never invoke `migrate_multi` by hand** — it migrates every configured database, the
+   primary included. Deploys run it normally; that is fine, and expected at Task 10.
+2. **Both subscribers must receive every migration during the overlap.** `migrate_multi` migrates
+   `default` plus *the one* configured secondary, so whichever instance the config does not name
+   drifts. For the whole overlap, either hold migrations that touch `REPLICATION_ALLOWED_MODELS`, or
+   run `./manage.py migrate --database=<alias>` against **both** instances after each deploy that
+   carries one. Check Task 7's counters after any such deploy.
+
+**Connection helper.** Subscription DDL needs autocommit as a specific role. `new` is the PG16
+instance, `old` is 15.17, and Django's `connections["default"]` is the primary:
+
+```python
+import psycopg2, getpass
+def conn(host, dbname, user, password=None, autocommit=True):
+    c = psycopg2.connect(host=host, port=5432, dbname=dbname, user=user,
+                         password=password or getpass.getpass(f"{user}@{host}: "),
+                         sslmode="require")
+    c.autocommit = autocommit
+    return c
+
+def q(c, sql, args=None):
+    with c.cursor() as cur:
+        cur.execute(sql, args)
+        try: return cur.fetchall()
+        except psycopg2.ProgrammingError: return None
+```
+
+**Verified production facts:**
+
+| Fact | Value |
+|---|---|
+| Superset version | **5.0.0**, supports PG16 |
+| Metadata database | **`superset_meta`**, colocated with analytics on the old instance |
+| PostGIS | **3.4.3, owner `rdsadmin`, in BOTH `superset` and `superset_meta`.** The new instance must offer ≥ 3.4.3, and **`superset_meta` needs the extension created before the restore** (Task 9). No `address_standardizer*` anywhere. |
+| Publication coverage | **29/29, no drift** |
+| Replica identity | **All 29 tables clean** — primary key on each, `relreplident = 'd'` |
+| Subscription owner | **`postgres`**, the RDS master user — member of `rds_superuser` |
+| Replication role | **`postgres_repl`**, credential held and verified. `rolreplication = false`; RDS grants it via `rds_replication` membership. |
+
+---
+
+## Phase 1 — Build the new instance
+
+*Nothing here affects anything live.*
+
+### Task 1: Provision
+
+One console form. Engine **16.15** (ships PostGIS 3.4.6). Same VPC and security group as the current
+secondary, so the primary is reachable. Instance class at least as large as the current one — the
+initial `COPY` is the heaviest work it will ever do. Automated backups on.
+
+Then confirm connectivity and PostGIS from the app host:
+
+```python
+new = conn("<new-endpoint>", "postgres", "postgres")
+print(q(new, "SELECT version();"))
+print(q(new, "SELECT name, default_version FROM pg_available_extensions WHERE name = 'postgis';"))
+```
+
+And from the Superset host, which reaches the database by a different route and is the one that
+breaks silently at cutover if the security group is wrong:
+
+```bash
+psql "postgresql://postgres@<new-endpoint>:5432/postgres?sslmode=require" -c "SELECT 1;"
+```
+
+### Task 2: Create the roles
+
+Create them **as `postgres`**: PG16 auto-grants the creator `ADMIN OPTION`, which is what the apply
+worker's `SET ROLE` needs. On the old instance nobody could `SET ROLE` to `connect_superset` and it
+took a one-way grant to fix; here it comes free.
+
+Create the analytics database with the **same name as on the old instance (`superset`)**, so only
+the host changes at cutover — Superset's stored connection and `SECONDARY_DATABASE_URL` then differ
+in one component rather than two.
+
+```python
+new = conn("<new-endpoint>", "superset", "postgres")
+q(new, "CREATE ROLE connect_superset LOGIN PASSWORD '<pw>';")
+q(new, "CREATE ROLE superset_readonly LOGIN PASSWORD '<pw>';")
+q(new, "GRANT CREATE ON DATABASE superset TO connect_superset;")
+q(new, "GRANT USAGE, CREATE ON SCHEMA public TO connect_superset;")
+q(new, 'GRANT "connect_superset" TO "postgres";')
+
+print(q(new, "SELECT has_schema_privilege('connect_superset','public','CREATE');"))   # expect True
+```
+
+**The schema grant is not optional.** `GRANT CREATE ON DATABASE` confers the right to create
+*schemas*, not tables in `public`. Since PG15 the `public` schema is owned by `pg_database_owner`
+and no longer carries `CREATE` for `PUBLIC`, so without that grant Task 4's migration fails with
+`permission denied for schema public`.
+
+---
+
+## Phase 2 — Start replication
+
+### Task 3: Add a `--subscription-name` option to `setup_logical_replication` `[CODE]`
+
+The command creates a subscription with no explicit `slot_name`, so Postgres names the slot after
+the subscription. The two subscribers are on different instances and their *subscription* names
+would not clash — but they share one primary, and the old subscriber's **slot** there is already
+called `tables_for_superset_sub`. Run as it stands, the command fails with *replication slot already
+exists*.
+
+**Take the name as an argument rather than renaming the constant.** A rename would leave the code
+referring to a subscription that does not exist on the live instance — `logical_replication_status`
+would report it missing, and anyone running `setup_logical_replication` against the old instance
+would create a *second* subscription alongside the live one. Arguments avoid all of that: the
+constants keep describing what is actually deployed, and the overlap is expressed at the call site.
+
+**Files:** `setup_logical_replication.py`, `logical_replication_status.py`, `constants.py`
+
+1. **Add `--subscription-name` to `setup_logical_replication`**, defaulting to
+   `SUBSCRIPTION_NAME`.
+
+2. **Add the same option to `logical_replication_status`** so it can inspect either subscriber
+   during the overlap.
+
+3. **Dedupe the constants.** `PUBLICATION_NAME` and `SUBSCRIPTION_NAME` are defined **twice** —
+   `constants.py:28-29` (dead; nothing imports it) and `setup_logical_replication.py:10-11` (live,
+   and what `logical_replication_status` imports). Delete the second pair and import from
+   `constants`.
+
+4. **While in that file:** `setup_logical_replication` calls `psycopg2.sql.SQL(...)` after only
+   `import psycopg2`. It works because Django's stack imports the submodule first. Add
+   `from psycopg2 import sql`.
+
+Lint, then `pytest commcare_connect/multidb/ -q`.
+
+**This change is safe to deploy at any time.** Defaults preserve current behaviour exactly, and
+nothing runs the command unattended — `docker/start_migrate` runs only `migrate_multi`.
+
+**After decommission (Task 12), update `SUBSCRIPTION_NAME` to `tables_for_superset_sub_v2`** so the
+constant again describes the only subscriber that exists. The `_v2` name is permanent — slots cannot
+be renamed, so reverting would require another rebuild.
+
+### Task 4: Create the subscription `[GATE]`
+
+This is where the one open privilege question gets answered. If `CREATE SUBSCRIPTION` is refused,
+stop — the old subscriber is untouched and in-place is the remaining option.
+
+**Pre-flight:**
+
+```python
+print(q(new, "SELECT pg_has_role('postgres','pg_create_subscription','USAGE');"))   # expect True
+```
+
+Confirm Task 3 is deployed where you are running from — `./manage.py setup_logical_replication
+--help` should list `--subscription-name`.
+
+**Point `SECONDARY_DATABASE_URL` at the new instance**, using the **`connect_superset`**
+credentials, and build the schema. The tables must exist before subscribing — `copy_data = true`
+fails during tablesync against a missing table — and creating them as `connect_superset` gives the
+uniform ownership PG16's apply worker requires.
+
+```bash
+./manage.py migrate --database=<SECONDARY_DB_ALIAS>
+```
+
+```python
+print(q(new, "SELECT tableowner, count(*) FROM pg_tables WHERE schemaname='public' GROUP BY 1;"))
+```
+
+Expect `connect_superset` only, plus `rdsadmin` for `spatial_ref_sys`, roughly 91 tables.
+
+**Record the primary's row counts** with a timestamp, so the copy can be verified later:
+
+```python
+from django.db import connections
+from commcare_connect.multidb.constants import REPLICATION_ALLOWED_MODELS
+cur = connections["default"].cursor()
+for m in REPLICATION_ALLOWED_MODELS:
+    cur.execute(f"SELECT count(*) FROM {m._meta.db_table};")
+    print(m._meta.db_table, cur.fetchone()[0])
+cur.close()
+```
+
+**Run it in a low-traffic window** — the copy starts immediately.
+
+```bash
+./manage.py setup_logical_replication --subscription-name tables_for_superset_sub_v2
+```
+
+Interactive: answer `yes`; accept `postgres_repl` on the primary; supply the new instance's
+superuser credentials; supply the primary replication credentials; accept `superset_readonly`.
+
+It grants `SELECT` to the replication user on the **primary**, issues `ALTER PUBLICATION ... SET
+TABLE` there with `main`'s 29 models, creates the subscription with `copy_data = true`, and grants
+`SELECT` to `superset_readonly`.
+
+**That publication write rewrites what the old subscriber reads from.** It is a no-op only because
+the published set already matches `main`'s 29 models. If it has drifted, this silently removes
+tables and *both* subscribers stop syncing them — re-confirm the count first.
+
+Then confirm two slots exist on the primary, both active:
+
+```python
+from django.db import connections
+cur = connections["default"].cursor()
+cur.execute("""SELECT slot_name, active, pg_size_pretty(
+                        pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained
+               FROM pg_replication_slots;""")
+print(cur.fetchall()); cur.close()
+```
+
+**Finally, revert `SECONDARY_DATABASE_URL` to the old instance** — the subscription is created and
+the config has no further part to play until cutover. Leaving it pointed at the new instance cuts
+Connect over silently, before any of Phase 3's validation has run, and the next deploy would
+`migrate_multi` against it. The old instance stays the configured secondary, and the rollback stays
+real, until Task 10.
+
+### Task 5: Watch the initial copy `[RISK]`
+
+`opportunity_uservisit` is large and the sync holds a slot open on the primary while reading it. A
+stalled copy accumulates WAL there with real disk-fill risk. Watch both sides, and **record the
+duration** — it is the number nobody has.
+
+```python
+print(q(new, "SELECT srrelid::regclass, srsubstate FROM pg_subscription_rel ORDER BY 2, 1;"))
+```
+
+States go `i` → `d` → `r`. Retained WAL on the primary should rise during the copy and fall after.
+
+**Bail-out if retained WAL threatens the primary's disk:**
+
+```python
+q(new, "ALTER SUBSCRIPTION tables_for_superset_sub_v2 DISABLE;")
+q(new, "ALTER SUBSCRIPTION tables_for_superset_sub_v2 SET (slot_name = NONE);")
+q(new, "DROP SUBSCRIPTION tables_for_superset_sub_v2;")
+
+cur = connections["default"].cursor()
+cur.execute("SELECT slot_name, active FROM pg_replication_slots WHERE slot_name = 'tables_for_superset_sub_v2';")
+print(cur.fetchall())            # proceed only when active is False
+cur.execute("SELECT pg_drop_replication_slot('tables_for_superset_sub_v2');")
+cur.close()
+```
+
+**Every name there is the `_v2` one.** `tables_for_superset_sub` is the *old* subscriber; naming it
+here is how this bail-out fails at the one moment it is needed. `pg_drop_replication_slot` also
+refuses while the slot is `active`. The old subscriber is unaffected — retry in a quieter window.
+
+### Task 6: Superset's read access
+
+The command granted `SELECT ON ALL TABLES` but not `USAGE ON SCHEMA`, without which
+`superset_readonly` cannot read anything:
+
+```python
+q(new, "GRANT USAGE ON SCHEMA public TO superset_readonly;")
+print(q(new, "SELECT has_table_privilege('superset_readonly','opportunity_uservisit','SELECT');"))
+```
+
+---
+
+## Phase 3 — Validate, with nothing at stake
+
+*15.17 is still serving. No time pressure — this phase is what makes the whole approach worthwhile.*
+
+### Task 7: Verify replication is genuinely live
+
+```python
+print(q(new, "SELECT srsubstate, count(*) FROM pg_subscription_rel GROUP BY 1;"))   # ('r', 29)
+print(q(new, "SELECT * FROM pg_stat_subscription_stats;"))                          # 0 | 0
+```
+
+Any table at `d` means its copy is stuck; at `i`, it never started; an empty result means the
+subscription has no tables at all. **Zero errors alone is not health** — that counter reads zero on
+a subscription applying nothing, which is exactly the failure this phase exists to catch.
+
+Then, in order of increasing value:
+
+1. **Row counts** against the Task 4 baseline, then **sample again minutes later and confirm they
+   moved**. A single sample cannot tell a frozen table from a current one.
+2. **Canary:** insert a synthetic row into one replicated table, confirm it arrives, then delete it
+   and confirm the delete arrives too. Log both statements. The most informative check here, and
+   this phase's one write to the primary. `DATA` *(primary, one row, reversed)*
+3. **Real dashboards:** point a Superset instance at the new analytics database read-only and run
+   the dashboards people actually use. Counts agreeing is necessary; the real queries returning the
+   real numbers is what matters.
+
+---
+
+## Phase 4 — Cutover
+
+*The only window. Minutes.*
+
+### Task 8: Announce and freeze deploys
+
+Deploys run `migrate_multi` against whichever instance the config names, so one landing mid-cutover
+is a genuine hazard. Name who enforces the freeze and who lifts it.
+
+### Task 9: Move Superset's metadata
+
+**Stop Superset before the dump and leave it down until Task 10 repoints it.** The Task 8 freeze
+covers deploys, not users: anything edited in between lands in the *old* `superset_meta` and is lost,
+and anything created after cutover is missing from 15.17 if you roll back.
+
+```bash
+pg_dump -h <old-endpoint> -U postgres -d superset_meta -Fc -f superset_meta.dump
+```
+
+**Read the ownership off the old instance rather than guessing it** — the dump carries
+`ALTER ... OWNER` for every object, and any owning role missing on the new instance leaves that
+object owned by `postgres`. Run as `postgres`; `connect_superset` is denied `CONNECT` here:
+
+```python
+old_meta = conn("<old-endpoint>", "superset_meta", "postgres")
+print(q(old_meta, "SELECT datdba::regrole FROM pg_database WHERE datname='superset_meta';"))
+print(q(old_meta, "SELECT DISTINCT tableowner FROM pg_tables WHERE schemaname='public';"))
+```
+
+Create any of those roles the new instance lacks, then the database and the extension —
+`superset_meta` carries `postgis` 3.4.3, without which the restore fails on PostGIS-dependent
+objects:
+
+```python
+maint = conn("<new-endpoint>", "postgres", "postgres")
+q(maint, "CREATE DATABASE superset_meta OWNER <datdba from above>;")   # not inside a transaction
+maint.close()
+
+meta = conn("<new-endpoint>", "superset_meta", "postgres")
+q(meta, "CREATE EXTENSION IF NOT EXISTS postgis;")
+```
+
+```bash
+pg_restore -h <new-endpoint> -U postgres -d superset_meta superset_meta.dump
+```
+
+**Do not use `--no-owner`** to paper over a missing role — it makes `postgres` own everything, which
+holds until Superset's next Alembic migration. `pg_restore` continues past errors and exits `1` if it
+ignored any, so read the error list rather than the exit code: the `postgis` owner and comment
+statements fail benignly, since `rdsadmin` owns it on both instances. Then compare table counts and
+owners against the old database.
+
+**Keep Superset's `SECRET_KEY` unchanged**, or the encrypted stored database passwords will not
+decrypt. Do not combine this with a Superset redeploy.
+
+### Task 10: Repoint and verify
+
+Superset: update `SQLALCHEMY_DATABASE_URI` and its stored analytics connection, restart, confirm
+logins and dashboards.
+
+Connect: update `SECONDARY_DATABASE_URL`, lift the freeze, deploy, confirm `migrate_multi` succeeds
+against the new secondary. Re-run Task 7 post-cutover, and open a saved Superset chart that queries
+the analytics database — that is what proves the `SECRET_KEY` and metadata move were clean.
+
+---
+
+## Phase 5 — Decommission
+
+*Promptly, but not immediately: two subscriptions roughly double WAL retention and decode work on
+the primary, while the old instance is still the rollback. Agree a date in advance.*
+
+### Task 11: Release the old subscriber and its slot
+
+```python
+old = conn("<old-endpoint>", "superset", "postgres")
+q(old, "ALTER SUBSCRIPTION tables_for_superset_sub DISABLE;")
+q(old, "ALTER SUBSCRIPTION tables_for_superset_sub SET (slot_name = NONE);")
+q(old, "DROP SUBSCRIPTION tables_for_superset_sub;")
+```
+
+`SET (slot_name = NONE)` deliberately orphans the slot on the primary, and it retains WAL forever
+until dropped:
+
+```python
+cur = connections["default"].cursor()
+cur.execute("SELECT active FROM pg_replication_slots WHERE slot_name = 'tables_for_superset_sub';")
+print(cur.fetchall())                       # drop only once this reads False
+cur.execute("SELECT pg_drop_replication_slot('tables_for_superset_sub');")
+cur.execute("""SELECT slot_name, active, pg_size_pretty(
+                        pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained
+               FROM pg_replication_slots;""")
+print(cur.fetchall()); cur.close()          # expect exactly one slot, the _v2 one
+```
+
+The walsender can still be shutting down seconds after `DROP SUBSCRIPTION`, and
+`pg_drop_replication_slot` refuses on an active slot. Nothing is at risk if it does — wait and
+re-run.
+
+**After this step the rollback no longer exists.**
+
+### Task 12: Retire the old instance
+
+Confirm subscription and slot still share a name — the invariant `setup_logical_replication` assumes:
+
+```python
+print(q(new, "SELECT subname, subslotname FROM pg_subscription;"))   # both tables_for_superset_sub_v2
+```
+
+Final snapshot, then delete. Record the snapshot identifier and retention.
+
+**For any future rebuild:** pass a new `--subscription-name`. A rebuild cannot reuse a name while a
+subscriber still holds that slot, and slots cannot be renamed.
+
+### Task 13: Close out
+
+Record the copy duration, the cutover duration, and whether RDS granted `pg_create_subscription` —
+all previously unknown. Fold them into the investigation doc.
+
+**One untested path remains:** the REFRESH branch of `setup_logical_replication` has never run
+against a real subscriber under the `_v2` name. Exercise it once deliberately — add a model to
+`REPLICATION_ALLOWED_MODELS` and re-run the command — rather than discovering it during an urgent
+change. Confirm the slot is still `tables_for_superset_sub_v2` afterwards.
+
+---
+
+## Rollback
+
+**Before Task 11:** repoint `SECONDARY_DATABASE_URL` and Superset's config back at 15.17, which has
+been running untouched with its subscription intact. This is the reason for choosing this shape.
+
+**After Task 11:** there is no rollback. The old subscription is dropped and its data is stale from
+that moment.
+
+## Abort criteria
+
+| Trigger | Action |
+|---|---|
+| Task 4 — `CREATE SUBSCRIPTION` refused | Stop. Nothing has changed anywhere. Fall back to in-place. |
+| PostGIS unavailable at ≥ 3.4.3 on the new instance | Stop at Task 1, before any further investment. |
+| Publication has fewer than 29 tables | Fix the drift first, or the new instance inherits the gap. |
+| Initial `COPY` stalls and WAL builds on the primary | Task 5 bail-out. The old subscriber is unaffected. |
+| Any table outside `r`, or non-zero error counters | Do not cut over. 15.17 keeps serving during diagnosis. |
+| Apply errors after a deploy carrying a migration | The subscriber missed it (rule 2). Migrate that instance, then confirm apply resumes. |
+| Row counts disagree after the copy | Do not cut over. The copy can be redone. |
+| Superset charts broken after the metadata restore | Repoint Superset back to 15.17; its metadata there is untouched. |


### PR DESCRIPTION
## Product Description

No user-facing change. Documentation only — two implementation plans for upgrading the Superset/analytics RDS instance from PostgreSQL 15.17 to 16.

## Technical Summary

Ticket: https://dimagi.atlassian.net/browse/CCCT-2705

The replication redesign needs PostgreSQL 16 on the Superset secondary. This PR adds both routes, designed in full so they can be compared on evidence rather than intuition.

**`...-inplace-upgrade-plan.md`** — upgrade the existing instance via RDS *Modify → engine version*, then deliberately reconnect logical replication, since `pg_upgrade` discards the subscriber's `pg_subscription_rel` and replication origin. 13 tasks, one maintenance window, no application code change. No rollback except snapshot restore, which yields a new endpoint.

**`...-parallel-upgrade-plan.md`** — build a new PG16 instance, replicate into it from the same publication, validate while 15.17 keeps serving, cut over. 13 tasks over days, requires a code change and a config change, and must move Superset's metadata. The old instance stays as a rollback until decommission.

Each plan opens with a table of production facts it depends on, all verified read-only, and ends with abort criteria. The trade-offs are stated in both — the decision is what this PR is for.

**No code here.** Both plans call for changes to `setup_logical_replication` (a `--subscription-name` option, deduping constants defined in two places, an explicit `from psycopg2 import sql`). Described, not implemented; they'd ship separately.

## Safety Assurance

### Safety story

Documentation only — no code, no migrations, nothing that executes. The risk is whether the plans are correct, since someone will follow them against production.

Confidence came from Docker rehearsals of the mechanics — that `pg_upgrade` wipes subscriber state, that a naive `ENABLE` afterwards reports zero errors while applying nothing, that the recovery path works under prod-shaped roles — plus read-only verification against production for every fact either plan relies on.

One gap was found by checking rather than reasoning: `superset_meta` carries PostGIS, which the app user cannot see. Unnoticed, it would have failed the parallel plan's metadata restore mid-cutover.

Nothing in either plan has been executed.

### Automated test coverage

None applicable; no code changes.

### QA Plan

Not required — documentation only.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
