### PR TITLE
Count duplicate visits in total/verified deliveries counts

### DIFF
--- a/commcare_connect/opportunity/helpers.py
+++ b/commcare_connect/opportunity/helpers.py
@@ -61,7 +61,8 @@ def inactive_workers_subquery(days_ago):
     return Coalesce(Subquery(subquery, output_field=IntegerField()), Value(0))
 
 
-def get_deliveries_count_subquery(status=None):
+def get_deliveries_count_subquery(status=None, sum_field=None):
+    agg = Sum(sum_field) if sum_field else Count("id", distinct=True)
     filters = {"opportunity_access__opportunity_id": OuterRef("pk")}
     if status is not None:
         filters["status"] = status
@@ -70,8 +71,8 @@ def get_deliveries_count_subquery(status=None):
         Subquery(
             CompletedWork.objects.filter(**filters)
             .values("opportunity_access__opportunity_id")
-            .annotate(count=Count("id", distinct=True))
-            .values("count"),
+            .annotate(count=agg)
+            .values("count")[:1],
             output_field=IntegerField(),
         ),
         0,
@@ -509,8 +510,10 @@ class OpportunityData:
                 CompletedWork.objects.filter(opportunity_access__opportunity_id__in=opp_ids)
                 .values("opportunity_access__opportunity_id")
                 .annotate(
-                    total_deliveries=Count("id", distinct=True),
-                    verified_deliveries=Count("id", filter=Q(status=CompletedWorkStatus.approved), distinct=True),
+                    total_deliveries=Coalesce(Sum("saved_completed_count"), Value(0)),
+                    verified_deliveries=Coalesce(
+                        Sum("saved_approved_count", filter=Q(status=CompletedWorkStatus.approved)), Value(0)
+                    ),
                 )
             )
             deliveries_by_opp = {
@@ -712,7 +715,7 @@ def get_opportunity_delivery_progress(opp_id):
         deliveries_from_yesterday=deliveries_from_yesterday_sq(),
         accrued_since_yesterday=accrued_since_yesterday_sq,
         most_recent_delivery=most_recent_delivery_sq,
-        total_deliveries=get_deliveries_count_subquery(),
+        total_deliveries=get_deliveries_count_subquery(sum_field="saved_completed_count"),
         recent_payment=recent_payment_sq,
         workers_invited=workers_invited_subquery(),
         pending_invites=pending_invites_subquery(),
@@ -729,8 +732,10 @@ def get_opportunity_worker_progress(opp_id):
     return (
         Opportunity.objects.filter(id=opp_id)
         .annotate(
-            total_deliveries=get_deliveries_count_subquery(),
-            approved_deliveries=get_deliveries_count_subquery(CompletedWorkStatus.approved),
+            total_deliveries=get_deliveries_count_subquery(sum_field="saved_completed_count"),
+            approved_deliveries=get_deliveries_count_subquery(
+                CompletedWorkStatus.approved, sum_field="saved_approved_count"
+            ),
             rejected_deliveries=get_deliveries_count_subquery(CompletedWorkStatus.rejected),
             total_accrued=total_accrued_sq(),
             total_paid=total_paid_sq(),

--- a/commcare_connect/opportunity/tests/test_helpers.py
+++ b/commcare_connect/opportunity/tests/test_helpers.py
@@ -327,7 +327,12 @@ def test_opportunity_delivery_stats(opportunity):
     payment_due = total_accrued - total_paid
 
     # total deliveries=4 deliveries_from_yesterday=3
-    cw = CompletedWorkFactory(opportunity_access=oa1, status_modified_date=now(), status=CompletedWorkStatus.pending)
+    cw = CompletedWorkFactory(
+        opportunity_access=oa1,
+        status_modified_date=now(),
+        status=CompletedWorkStatus.pending,
+        saved_completed_count=1,
+    )
     UserVisitFactory.create(
         opportunity=opportunity,
         opportunity_access=oa1,
@@ -342,6 +347,8 @@ def test_opportunity_delivery_stats(opportunity):
         status_modified_date=now(),
         status=CompletedWorkStatus.approved,
         saved_payment_accrued=10,
+        saved_completed_count=1,
+        saved_approved_count=1,
     )
     UserVisitFactory.create(
         opportunity=opportunity,
@@ -362,7 +369,12 @@ def test_opportunity_delivery_stats(opportunity):
         visit_date=today,
     )
 
-    cw = CompletedWorkFactory(opportunity_access=oa1, status_modified_date=now(), status=CompletedWorkStatus.pending)
+    cw = CompletedWorkFactory(
+        opportunity_access=oa1,
+        status_modified_date=now(),
+        status=CompletedWorkStatus.pending,
+        saved_completed_count=1,
+    )
     UserVisitFactory.create(
         opportunity=opportunity,
         opportunity_access=oa2,
@@ -372,7 +384,12 @@ def test_opportunity_delivery_stats(opportunity):
         review_created_on=now() - timedelta(days=2),
     )
 
-    cw = CompletedWorkFactory(opportunity_access=oa2, status_modified_date=now(), status=CompletedWorkStatus.pending)
+    cw = CompletedWorkFactory(
+        opportunity_access=oa2,
+        status_modified_date=now(),
+        status=CompletedWorkStatus.pending,
+        saved_completed_count=1,
+    )
     UserVisitFactory.create(
         opportunity=opportunity,
         opportunity_access=oa2,
@@ -383,7 +400,12 @@ def test_opportunity_delivery_stats(opportunity):
     )
 
     # case nm approved first but rejected later so review_created_on will not be null in this case.
-    cw = CompletedWorkFactory(opportunity_access=oa2, status_modified_date=now(), status=CompletedWorkStatus.pending)
+    cw = CompletedWorkFactory(
+        opportunity_access=oa2,
+        status_modified_date=now(),
+        status=CompletedWorkStatus.pending,
+        saved_completed_count=1,
+    )
     UserVisitFactory.create(
         opportunity=opportunity,
         opportunity_access=oa2,
@@ -391,6 +413,15 @@ def test_opportunity_delivery_stats(opportunity):
         completed_work=cw,
         visit_date=day_before_yesterday,
         review_created_on=now(),
+    )
+
+    # a CompletedWork with 2 duplicate approved visits should add 2 to total_deliveries, not 1
+    CompletedWorkFactory(
+        opportunity_access=oa1,
+        status_modified_date=now(),
+        status=CompletedWorkStatus.approved,
+        saved_completed_count=2,
+        saved_approved_count=2,
     )
 
     # recent date paid will be today total paid should be 150
@@ -413,7 +444,7 @@ def test_opportunity_delivery_stats(opportunity):
     assert result.deliveries_from_yesterday == 3
     assert result.accrued_since_yesterday == 10
     assert result.most_recent_delivery == today
-    assert result.total_deliveries == 5
+    assert result.total_deliveries == 7
     assert result.recent_payment == today
     assert result.workers_invited == 3
     assert result.pending_invites == 1
@@ -438,12 +469,22 @@ def test_opportunity_worker_progress_stats(opportunity):
     PaymentFactory(opportunity_access=access, date_paid=today, amount=100)
 
     # Total deliveries = 4
-    CompletedWorkFactory.create_batch(2, opportunity_access=access, status=CompletedWorkStatus.pending)
-    CompletedWorkFactory.create_batch(1, opportunity_access=access, status=CompletedWorkStatus.approved)
-    CompletedWorkFactory.create_batch(1, opportunity_access=access, status=CompletedWorkStatus.rejected)
+    CompletedWorkFactory.create_batch(
+        2, opportunity_access=access, status=CompletedWorkStatus.pending, saved_completed_count=1
+    )
+    CompletedWorkFactory.create_batch(
+        1,
+        opportunity_access=access,
+        status=CompletedWorkStatus.approved,
+        saved_completed_count=1,
+        saved_approved_count=1,
+    )
+    CompletedWorkFactory.create_batch(
+        1, opportunity_access=access, status=CompletedWorkStatus.rejected, saved_completed_count=1
+    )
 
     # Visits since yesterday = 2
-    cw = CompletedWorkFactory(opportunity_access=access, status=CompletedWorkStatus.pending)
+    cw = CompletedWorkFactory(opportunity_access=access, status=CompletedWorkStatus.pending, saved_completed_count=1)
     UserVisitFactory(
         opportunity=opportunity,
         opportunity_access=access,
@@ -459,11 +500,19 @@ def test_opportunity_worker_progress_stats(opportunity):
         visit_date=yesterday,
     )
 
+    # A CompletedWork with 2 duplicate approved visits should add 2 to total/approved deliveries, not 1.
+    CompletedWorkFactory(
+        opportunity_access=access,
+        status=CompletedWorkStatus.approved,
+        saved_completed_count=2,
+        saved_approved_count=2,
+    )
+
     result = get_opportunity_worker_progress(opportunity.id)
 
     assert result.id == opportunity.id
-    assert result.total_deliveries == 5
-    assert result.approved_deliveries == 1
+    assert result.total_deliveries == 7
+    assert result.approved_deliveries == 3
     assert result.rejected_deliveries == 1
     assert result.total_accrued == 300
     assert result.total_paid == 100

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -735,6 +735,31 @@ def test_opportunity_list_excludes_archived(organization):
 
 
 @pytest.mark.django_db
+def test_get_opportunity_list_data_counts_duplicate_approved_deliveries(organization):
+    today = now().date()
+    opportunity = OpportunityFactory(
+        organization=organization, end_date=today + timedelta(days=1), active=True, archived=False
+    )
+    access = OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+
+    CompletedWorkFactory(opportunity_access=access, status=CompletedWorkStatus.pending, saved_completed_count=1)
+    CompletedWorkFactory(opportunity_access=access, status=CompletedWorkStatus.rejected, saved_completed_count=1)
+    # A CompletedWork with 2 approved (duplicate) visits should count as 2 deliveries, not 1.
+    CompletedWorkFactory(
+        opportunity_access=access,
+        status=CompletedWorkStatus.approved,
+        saved_completed_count=2,
+        saved_approved_count=2,
+    )
+
+    queryset = OpportunityData(organization, True, {}).get_data()
+    opp = next(item for item in queryset if item.id == opportunity.id)
+
+    assert opp.total_deliveries == 4
+    assert opp.verified_deliveries == 2
+
+
+@pytest.mark.django_db
 def test_tiered_queryset_basic():
     users = [User.objects.create(username=f"user{i}") for i in range(5)]
     user_ids = [u.id for u in users]

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3392,7 +3392,7 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
             "icon": "fa-clipboard-list",
             "name": _("Services Delivered"),
             "status": _("Total"),
-            "value": header_with_tooltip(stats.total_deliveries, _("Total delivered so far excluding duplicates")),
+            "value": header_with_tooltip(stats.total_deliveries, _("Total delivered so far")),
             "url": f"{delivery_url}?{urlencode({'sort': '-last_active'})}",
             "incr": stats.deliveries_from_yesterday,
         },


### PR DESCRIPTION
## Product Description

Opportunity Dashboard List Page: Columns `Total Deliveries` and `Verified Deliveries` were not counting the duplicate approved deliveries. Same for `Services Delivered` in the single opportunity detail page.
This fixes them to include the duplicate counts, making it match the `Delivered` and `Approved` counts in the worker delivery table.

This makes it consistent across all the pages that displays it.

## Technical Summary

[Ticket](https://dimagi.atlassian.net/browse/CI-913)

`saved_completed_count`/`saved_approved_count` on `CompletedWork` already account for duplicates per entity. Switched the relevant aggregations (`OpportunityData.get_data_qs`, `get_deliveries_count_subquery` and its callers) from `Count(distinct CompletedWork.id)` to summing these fields, matching how the worker delivery table already computes its totals. Also removed the now-inaccurate "excluding duplicates" tooltip.

## Safety Assurance

### Safety story

Read-only aggregation change on existing stored fields; no schema or write-path changes. No existing data is impacted, only how counts are computed for display.

### Automated test coverage

Updated/added tests in `test_helpers.py` and `test_views.py` covering `get_opportunity_delivery_progress`, `get_opportunity_worker_progress`, and `OpportunityData.get_data_qs` with a duplicate-approved-visit scenario, asserting totals include the duplicate.

### QA Plan

- Verify Total/Verified Deliveries on the program manager opportunity list and single-opportunity delivery stats/worker progress tiles match the worker delivery table's Delivered/Approved totals for an opportunity with duplicate approved visits.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change