### PR TITLE
Fix local setup docs and the .env template

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,21 +1,60 @@
-CELERY_BROKER_URL=redis://localhost:6379/0
-REDIS_URL=redis://localhost:6379/0
+# Only DATABASE_URL below is uncommented, because the code default assumes a local unix
+# socket rather than the docker compose service. Everything else has a working default in
+# config/settings/; commented-out lines show that default, so uncomment and edit only what
+# you need to change.
+#
+# NOTE: an empty value is NOT the same as an unset one. `CONNECTID_URL=` overrides the
+# default with an empty string, which breaks the app and the test suite. Comment the line
+# out instead of blanking it.
+
+# Matches the docker compose service. The code default is postgres:///commcare_connect,
+# i.e. a unix socket as the current OS user.
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/commcare_connect
-DJANGO_ALLOWED_HOSTS=
-CSRF_TRUSTED_ORIGINS=
-CHATBOT_ID=
-CHATBOT_EMBED_KEY=
-COMMCARE_HQ_URL=https://www.commcarehq.org
-COMMCAREHQ_OAUTH_CLIENT_ID=
-COMMCAREHQ_OAUTH_SECRET=
-CONNECTID_URL=
-cid_client_id=
-cid_client_secret=
-TWILIO_SID=
-TWILIO_TOKEN=
-TWILIO_MESSAGING_SERVICE=
-MAPBOX_TOKEN=
-OPEN_EXCHANGE_RATES_API_ID=
-GA_MEASUREMENT_ID=
-GA_API_SECRET=
-HUBSPOT_API_ID=
+
+# REDIS_URL=redis://localhost:6379/0
+# CELERY_BROKER_URL=redis://localhost:6379/0
+
+# Additional hosts/origins to allow, on top of localhost. Needed when serving through
+# ngrok or similar. Comma separated.
+# DJANGO_ALLOWED_HOSTS=
+# CSRF_TRUSTED_ORIGINS=
+
+# macOS only, and required there: paths to the GDAL and GEOS libraries. See the
+# "GeoDjango / PostGIS Setup" section of the README for how to find them.
+# GDAL_LIBRARY_PATH=
+# GEOS_LIBRARY_PATH=
+
+# External services
+# COMMCARE_HQ_URL=https://staging.commcarehq.org
+# CONNECTID_URL=http://localhost:8080
+# OCS_BASE_URL=https://www.openchatstudio.com
+
+# ConnectID credentials
+# cid_client_id=
+# cid_client_secret=
+# CONNECTID_CREDENTIALS_CLIENT_ID=
+# CONNECTID_CREDENTIALS_CLIENT_SECRET=
+
+# Twilio, for sending SMS
+# TWILIO_SID=
+# TWILIO_TOKEN=
+# TWILIO_MESSAGING_SERVICE=
+
+# Mapbox, for the microplanning maps
+# MAPBOX_TOKEN=
+
+# Currency conversion rates
+# OPEN_EXCHANGE_RATES_API_ID=
+
+# Analytics and support widgets
+# GA_MEASUREMENT_ID=
+# GA_API_SECRET=
+# GTM_ID=
+# HUBSPOT_API_ID=
+# LIVESESSION_APP_ID=
+# CHATBOT_ID=
+# CHATBOT_EMBED_KEY=
+
+# Secondary database, only needed when working on logical replication. See the
+# "Setting up logical replication" section of the README.
+# SECONDARY_DATABASE_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ inv translations
 - **Feature flags**: django-waffle with custom `Flag` model; constants in `commcare_connect/flags/switch_names.py`
 - **Audit trail**: django-pghistory stores `username` + `user_email` in context (survives user deletion)
 - **Database**: PostgreSQL + PostGIS. `ATOMIC_REQUESTS = True` (all requests are transactions)
-- **Deployment**: Kamal (Docker-based) + Ansible. NOT Elastic Beanstalk despite README mention
+- **Deployment**: Kamal (Docker-based) + Ansible on EC2. See `deploy/README.md`
 
 ### Key directories
 
@@ -102,8 +102,9 @@ config/
 ## Gotchas
 
 - **PostGIS required everywhere** (including tests). Local dev needs `gdal`, `geos`, `proj` system libs. On macOS, set `GDAL_LIBRARY_PATH` and `GEOS_LIBRARY_PATH` in `.env`
+- **`.env` leaks into test settings**: `base.py` calls `env.read_env(BASE_DIR / ".env")`, so local `.env` values also apply under `config.settings.test`. An _empty_ value overrides a code default with `""` rather than falling back — `CONNECTID_URL=` breaks the suite. CI has no `.env`, so these failures are local-only
 - **`--reuse-db` + Currency/Country data**: These models get flushed between tests. The `ensure_currency_country_data` autouse fixture handles this — don't remove it
 - **API UUID transition**: The `API_UUID` waffle switch controls whether API endpoints accept integer PKs or UUIDs. Use `get_object_or_list_by_uuid_or_int()` from `utils/db.py` for API lookups
 - **CSRF via sessions**: `CSRF_USE_SESSIONS = True`. Templates use `hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'` on `<body>` for htmx
-- **Webpack bundle tracker**: Frontend builds write `webpack-stats.json`. Templates reference bundles from `staticfiles/bundles/`
+- **Webpack output**: Bundles are built to `commcare_connect/static/bundles/` and referenced with plain `{% static 'bundles/...' %}`, served via `STATICFILES_DIRS`. `webpack-stats.json` is written but unused — django-webpack-loader is not installed
 - **CI uses**: `postgis/postgis:15-3.5` image, Python 3.11, requires `gdal-bin libproj-dev` apt packages

--- a/README.md
+++ b/README.md
@@ -148,24 +148,15 @@ Some useful command are available via the `tasks.py` file:
 
 ### Setting Up Your Users
 
-On a fresh database `/accounts/login/` and `/accounts/signup/` both return a 500. Their
-template renders a "Log in with CommCare HQ" button, which raises `SocialApp.DoesNotExist`
-until a `commcarehq` social app exists. So create one before signing anybody up:
+No social app setup is needed: the "Log in with CommCare HQ" button only appears once a
+`commcarehq` social app exists (see
+[Setting up auth with CommCare HQ](#setting-up-auth-with-commcare-hq)).
 
-1.  Create a superuser. `--email` is not accepted, because the custom `User` model sets
-    `REQUIRED_FIELDS = []`; set the address afterwards in the admin if you need one.
+- To create a **superuser**, run the command below. `--email` is not accepted, because the
+  custom `User` model sets `REQUIRED_FIELDS = []`; set the address afterwards in the admin if
+  you need one.
 
-        $ ./manage.py createsuperuser
-
-2.  Log in at http://localhost:8000/admin/login/. That page uses Django's own template, so it
-    still works while the allauth pages are broken.
-
-3.  Add a social app with provider `commcarehq` at
-    http://localhost:8000/admin/socialaccount/socialapp/ and attach it to the current site.
-    Placeholder values for Client ID and Secret are fine unless you are actually testing the
-    OAuth flow — for that, see [Setting up auth with CommCare HQ](#setting-up-auth-with-commcare-hq).
-
-The allauth pages work from then on.
+      $ ./manage.py createsuperuser
 
 - To create a **normal user account**, go to Sign Up and fill out the form. Local settings use
   `ACCOUNT_EMAIL_VERIFICATION = "optional"`, so you are logged straight in; the confirmation

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ installed to deploy or change Django settings.
 
 Deploying a new version of the app can be done via the "Deploy" workflow on GitHub Actions.
 
-Container logs are shipped to CloudWatch, and can also be read directly with `kamal app logs`.
+Container logs are shipped to CloudWatch, and can also be read directly with `cd deploy && kamal app logs`.
 
 For details on how this action is configured see:
 

--- a/README.md
+++ b/README.md
@@ -147,17 +147,53 @@ Some useful command are available via the `tasks.py` file:
 
 ### Setting Up Your Users
 
-- To create a **normal user account**, just go to Sign Up and fill out the form. Once you submit it, you'll see a "Verify Your E-mail Address" page. Go to your console to see a simulated email verification message. Copy the link into your browser. Now the user's email should be verified and ready to go.
+On a fresh database `/accounts/login/` and `/accounts/signup/` both return a 500. Their
+template renders a "Log in with CommCare HQ" button, which raises `SocialApp.DoesNotExist`
+until a `commcarehq` social app exists. So create one before signing anybody up:
 
-- To create a **superuser account**, use this command:
+1.  Create a superuser. `--email` is not accepted, because the custom `User` model sets
+    `REQUIRED_FIELDS = []`; set the address afterwards in the admin if you need one.
 
-      $ python manage.py createsuperuser
+        $ ./manage.py createsuperuser
 
-- To promote a user to superuser, use this command:
+2.  Log in at http://localhost:8000/admin/login/. That page uses Django's own template, so it
+    still works while the allauth pages are broken.
 
-      $ python manage.py promote_user_to_superuser <email>
+3.  Add a social app with provider `commcarehq` at
+    http://localhost:8000/admin/socialaccount/socialapp/ and attach it to the current site.
+    Placeholder values for Client ID and Secret are fine unless you are actually testing the
+    OAuth flow — for that, see [Setting up auth with CommCare HQ](#setting-up-auth-with-commcare-hq).
+
+The allauth pages work from then on.
+
+- To create a **normal user account**, go to Sign Up and fill out the form. Local settings use
+  `ACCOUNT_EMAIL_VERIFICATION = "optional"`, so you are logged straight in; the confirmation
+  email is still printed to the console if you want to verify the address.
+
+- To promote an existing user to superuser, use this command:
+
+      $ ./manage.py promote_user_to_superuser <email>
 
 For convenience, you can keep your normal user logged in on Chrome and your superuser logged in on Firefox (or similar), so that you can see how the site behaves for both kinds of users.
+
+### Sample Data
+
+To populate a local database with organizations, opportunities, visits and payments:
+
+    # generate_sample_data <num_visits> <org_slug>
+    $ ./manage.py generate_sample_data 50 demo-org
+
+The organization is created if the slug does not already exist. Each run first deletes the
+existing opportunities, visits, payments and programs belonging to the two organizations it is
+about to use. Two optional flags are available:
+
+- `--invited_org_slug` — reuse a specific organization as the invited org. Without it, a new
+  invited org with a random slug is created on every run, and the previous one is left behind.
+- `--managed_opportunities` — how many managed opportunities to create (default 3)
+
+Adding yourself to the generated organization is a separate step, either through
+`/admin/organization/userorganizationmembership/` or the organization's own member admin
+pages.
 
 ### Test coverage
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ brew install weasyprint
 sudo apt-get install -y binutils libproj-dev gdal-bin
 ```
 
+**Enabling the PostGIS extension**
+
+No migration creates the `postgis` extension. The `inv up` setup works because the
+`postgis/postgis` image enables it for you when it initialises the database.
+
+If you are using your own PostgreSQL instead, create the extension in the target database
+before migrating, or the first spatial migration will fail:
+
+```bash
+psql -d commcare_connect -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+```
+
     # start docker services
     $ inv up
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Some useful command are available via the `tasks.py` file:
 
 **Test the OAuth2 flow**
 
-- Set `COMMCARE_HQ_URL=https://staging.commcarehq.org` in your `.env` file and restart the server.
+- Confirm `COMMCARE_HQ_URL` points at `https://staging.commcarehq.org`. That is the default, so
+  you only need to set it in `.env` if you have overridden it.
 - Navigate to http://[my-unique-subdomain].ngrok-free.app/accounts/login/
 - Click the "Log in with CommCare HQ" button
 - You should be redirected to CommCare HQ to log in
@@ -237,16 +238,16 @@ celery -A config.celery_app worker -B -l info
 
 ## Deployment
 
-The following details how to deploy this application.
+The application runs as Docker containers on EC2, deployed with [Kamal](https://kamal-deploy.org/).
+Ansible provisions the instances and manages the container env files. See
+[deploy/README.md](deploy/README.md) for the full picture, including the tooling you need
+installed to deploy or change Django settings.
 
-The application is running on AWS. Deploying new version of the app can be done via the "Deploy" workflow
-on Github Actions.
+Deploying a new version of the app can be done via the "Deploy" workflow on GitHub Actions.
 
-Should the deploy fail you can view the logs via the [AWS console][aws_console].
+Container logs are shipped to CloudWatch, and can also be read directly with `kamal app logs`.
 
-[aws_console]: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.logging.html?icmpid=docs_elasticbeanstalk_console
-
-For details on how this actions is configured see:
+For details on how this action is configured see:
 
 - https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/
 - https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
@@ -258,7 +259,7 @@ which is connected to the staging environment of CommCare HQ at
 [https://staging.commcarehq.org/](https://staging.commcarehq.org/).
 
 - Update [commcare-connect-staging.yml](https://github.com/dimagi/staging-branches/blob/main/commcare-connect-staging.yml) with the branches you need to include.
-- Run `.deploy/rebuildstaging` to build the `autostaging` branch
+- Run `deploy/rebuildstaging` to build the `autostaging` branch
 - After this, you can deploy to the staging environment by manually running the `deploy`
   [workflow from here](https://github.com/dimagi/commcare-connect/actions/workflows/deploy.yml).
 

--- a/commcare_connect/ocs_provider/tests/test_connect_prompt.py
+++ b/commcare_connect/ocs_provider/tests/test_connect_prompt.py
@@ -20,3 +20,18 @@ def test_connect_prompt_renders_ocs_connect_link(rf, user):
     assert "process=connect" in html
     assert "next=" in html
     assert "Connect" in html
+
+
+@pytest.mark.django_db
+def test_connect_prompt_without_a_social_app_says_ocs_is_unavailable(rf, user):
+    request = rf.get("/a/org/opportunity/tasks/")
+    request.user = user
+
+    html = render_to_string(
+        "ocs/_connect_prompt.html",
+        {"next_url": "/a/org/opportunity/tasks/"},
+        request=request,
+    )
+
+    assert "/accounts/ocs/login/" not in html
+    assert "not configured" in html

--- a/commcare_connect/templates/account/login.html
+++ b/commcare_connect/templates/account/login.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load i18n %}
 {% load socialaccount %}
+{% load socialaccount_extras %}
 {% block head_title %}
   {% translate "Sign In" %}
 {% endblock %}
@@ -64,22 +65,25 @@
         </button>
       </div>
     </form>
-    <span class="text-sm text-gray-400 text-center">or</span>
-    <div class="space-y-2 place-items-center">
-      <form method="post"
-            action="{% provider_login_url "commcarehq" process="login" %}">
-        <button class="flex gap-2 rounded-full bg-gray-100 items-center p-2 pr-4 cursor-pointer"
-                type="submit">
-          {% csrf_token %}
-          <div class="w-6 h-6">
-            <img src="{% static 'images/commcare-logo-color.svg' %}"
-                 alt="Compact Logo"
-                 class="w-full">
-          </div>
-          <span class="text-sm">Login with CommCareHQ</span>
-        </button>
-      </form>
-    </div>
+    {% configured_provider "commcarehq" as commcarehq %}
+    {% if commcarehq %}
+      <span class="text-sm text-gray-400 text-center">or</span>
+      <div class="space-y-2 place-items-center">
+        <form method="post"
+              action="{% provider_login_url commcarehq process="login" %}">
+          <button class="flex gap-2 rounded-full bg-gray-100 items-center p-2 pr-4 cursor-pointer"
+                  type="submit">
+            {% csrf_token %}
+            <div class="w-6 h-6">
+              <img src="{% static 'images/commcare-logo-color.svg' %}"
+                   alt="Compact Logo"
+                   class="w-full">
+            </div>
+            <span class="text-sm">Login with CommCareHQ</span>
+          </button>
+        </form>
+      </div>
+    {% endif %}
     <div class="text-sm text-gray-400 text-center mt-auto border-t-gray-200 border-t-2 pt-4 ">
       Don't have an account?
       <a href="{{ signup_url }}" class="text-brand-indigo font-medium">Signup</a>

--- a/commcare_connect/templates/account/signup.html
+++ b/commcare_connect/templates/account/signup.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load i18n %}
 {% load socialaccount %}
+{% load socialaccount_extras %}
 {% block head_title %}
   {% translate "Signup" %}
 {% endblock %}
@@ -57,22 +58,25 @@
         </button>
       </div>
     </form>
-    <span class="text-sm text-center text-gray-600">or</span>
-    <div class="space-y-2 place-items-center">
-      <form method="post"
-            action="{% provider_login_url "commcarehq" process="login" %}">
-        <button class="flex gap-2 rounded-full bg-gray-100 items-center p-2 pr-4 cursor-pointer"
-                type="submit">
-          {% csrf_token %}
-          <div class="w-6 h-6">
-            <img src="{% static 'images/commcare-logo-color.svg' %}"
-                 alt="Compact Logo"
-                 class="w-full">
-          </div>
-          <span class="text-sm">{% blocktranslate %}Sign up with CommCareHQ{% endblocktranslate %}</span>
-        </button>
-      </form>
-    </div>
+    {% configured_provider "commcarehq" as commcarehq %}
+    {% if commcarehq %}
+      <span class="text-sm text-center text-gray-600">or</span>
+      <div class="space-y-2 place-items-center">
+        <form method="post"
+              action="{% provider_login_url commcarehq process="login" %}">
+          <button class="flex gap-2 rounded-full bg-gray-100 items-center p-2 pr-4 cursor-pointer"
+                  type="submit">
+            {% csrf_token %}
+            <div class="w-6 h-6">
+              <img src="{% static 'images/commcare-logo-color.svg' %}"
+                   alt="Compact Logo"
+                   class="w-full">
+            </div>
+            <span class="text-sm">{% blocktranslate %}Sign up with CommCareHQ{% endblocktranslate %}</span>
+          </button>
+        </form>
+      </div>
+    {% endif %}
     <div class="pt-4 mt-auto text-sm text-center text-gray-600 border-t-2 border-t-gray-200">
       {% blocktranslate %}Already have an account?{% endblocktranslate %}
       <a href="{{ login_url }}" class="font-medium text-brand-indigo">{% translate "Login" %}</a>

--- a/commcare_connect/templates/ocs/_connect_prompt.html
+++ b/commcare_connect/templates/ocs/_connect_prompt.html
@@ -1,9 +1,16 @@
-{% load socialaccount i18n %}
+{% load socialaccount socialaccount_extras i18n %}
+{% configured_provider 'ocs' as ocs %}
 <div class="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-800"
      role="alert">
-  <p class="mb-2 text-sm">{% translate "Connect your Open Chat Studio account to configure or assign OCS tasks." %}</p>
-  <button type="submit"
-          form="ocs-connect-form"
-          formaction="{% provider_login_url 'ocs' process='connect' next=next_url %}"
-          class="button button-md primary-dark">{% translate "Connect OCS account" %}</button>
+  {% if ocs %}
+    <p class="mb-2 text-sm">{% translate "Connect your Open Chat Studio account to configure or assign OCS tasks." %}</p>
+    <button type="submit"
+            form="ocs-connect-form"
+            formaction="{% provider_login_url ocs process='connect' next=next_url %}"
+            class="button button-md primary-dark">{% translate "Connect OCS account" %}</button>
+  {% else %}
+    <p class="text-sm">
+      {% translate "Open Chat Studio is not configured on this server, so OCS tasks are unavailable." %}
+    </p>
+  {% endif %}
 </div>

--- a/commcare_connect/templates/socialaccount/connections.html
+++ b/commcare_connect/templates/socialaccount/connections.html
@@ -58,6 +58,9 @@
           </div>
         {% endwith %}
       {% endfor %}
+      {% if not socialaccount_providers %}
+        <p class="card_description">{% translate "No third-party accounts can be linked on this server." %}</p>
+      {% endif %}
     </div>
   </div>
 {% endblock content %}

--- a/commcare_connect/users/templatetags/socialaccount_extras.py
+++ b/commcare_connect/users/templatetags/socialaccount_extras.py
@@ -1,8 +1,23 @@
+from allauth.socialaccount.adapter import get_adapter
+from allauth.socialaccount.models import SocialApp
 from django import template
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
 register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def configured_provider(context, provider_id):
+    """Return the provider for ``provider_id``, or None if no social app is configured.
+
+    ``{% provider_login_url %}`` raises ``SocialApp.DoesNotExist`` for an unconfigured
+    provider, so templates that offer a single named provider need to check first.
+    """
+    try:
+        return get_adapter().get_provider(context.get("request"), provider_id)
+    except SocialApp.DoesNotExist:
+        return None
 
 
 @register.filter

--- a/commcare_connect/users/tests/test_optional_social_apps.py
+++ b/commcare_connect/users/tests/test_optional_social_apps.py
@@ -1,0 +1,48 @@
+import pytest
+from django.urls import reverse
+
+from commcare_connect.users.templatetags.socialaccount_extras import configured_provider
+from commcare_connect.users.tests.test_connections import _create_social_app
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("configured", [True, False])
+def test_configured_provider_only_returns_providers_with_a_social_app(rf, configured):
+    if configured:
+        _create_social_app("commcarehq")
+    context = {"request": rf.get("/accounts/login/")}
+
+    provider = configured_provider(context, "commcarehq")
+
+    assert (provider.id if provider else None) == ("commcarehq" if configured else None)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name", ["account_login", "account_signup"])
+def test_auth_pages_render_without_a_social_app(client, url_name):
+    response = client.get(reverse(url_name))
+
+    assert response.status_code == 200
+    assert b"CommCareHQ" not in response.content
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name", ["account_login", "account_signup"])
+def test_auth_pages_offer_commcarehq_when_it_is_configured(client, url_name):
+    _create_social_app("commcarehq")
+
+    response = client.get(reverse(url_name))
+
+    assert response.status_code == 200
+    assert b"CommCareHQ" in response.content
+    assert f'action="{reverse("commcarehq_login")}?process=login"'.encode() in response.content
+
+
+@pytest.mark.django_db
+def test_connections_page_renders_without_any_social_apps(client, user):
+    client.force_login(user)
+
+    response = client.get(reverse("socialaccount_connections"))
+
+    assert response.status_code == 200
+    assert b"No third-party accounts can be linked" in response.content

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -23,6 +23,10 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
 
+# django-allauth
+# ------------------------------------------------------------------------------
+ACCOUNT_EMAIL_VERIFICATION = "optional"
+
 # Celery
 # ------------------------------------------------------------------------------
 CELERY_TASK_ALWAYS_EAGER = True


### PR DESCRIPTION
Setting this project up from a fresh clone by following the README doesn't work. Three
things were wrong:

- Copying `.env_template` verbatim caused test failures. `base.py` calls
  `env.read_env(BASE_DIR / ".env")`, so `.env` also feeds `config.settings.test`, and a
  blank assignment overrides a code default with `""` instead of falling back (CONNECTID_URL=` was the main culprit).
- `migrate` fails against any postgres that isn't the compose service due to missing `postgis` extension which isn't called out anywhere in the REAMDE.
- `/accounts/login/` and `/accounts/signup/` 500 on a fresh database because the template called
  `provider_login_url "commcarehq"` unconditionally

Also dropped `COMMCAREHQ_OAUTH_CLIENT_ID`/`_SECRET` from the template as they aren't referenced anywhere in the repo.

## Technical Summary

Two code changes:

`ACCOUNT_EMAIL_VERIFICATION = "optional"` in `local.py`. `createsuperuser` can't set an
email (the custom `User` model has `REQUIRED_FIELDS = []`), so mandatory verification locks
the new superuser out with no address to send the link to. The alternative (adding `email`
to `REQUIRED_FIELDS`) makes superuser creation stricter than the field itself
(`null=True, blank=True`) in every environment, so I kept the fix dev-local. Happy to swap
if you'd rather fix the root cause.

I added a new `{% configured_provider %}` template tag that returns the provider or `None` instead of raising `SocialApp.DoesNotExist`, so social apps become optional rather than a setup prerequisite.
This impacted three templates: login, signup, and the OCS connect prompt. They now render the button only when that app exists. `connections.html` already looped
`{% get_providers %}` and just needed an empty state. Where the OCS button used to be, the
prompt now says OCS isn't configured.

## Safety Assurance

Provider buttons disappear where no `SocialApp` exists. Every deployed environment has one,
so this is a no-op there; the setting change is scoped to `config/settings/local.py` and
base keeps `"mandatory"`.

### Safety story

Ran the whole setup end to end on Linux against a non-compose postgres. Regenerated `.env`
from the new template and confirmed the full suite passes (1847), where the old template
produced 18 failures. Confirmed a superuser with `email=None` and no `EmailAddress` row can
log in and reach `/admin/`, and that `/accounts/login/` and `/accounts/signup/` return 200
on a database with no social apps at all.

Not verified on macOS. The `GDAL_LIBRARY_PATH`/`GEOS_LIBRARY_PATH` entries I added to the
template are commented out, so they can't affect anyone, but someone on a Mac should sanity check that section reads right.

### Automated test coverage

`users/tests/test_optional_social_apps.py` covers the tag both ways and asserts login and
signup render with and without a `commcarehq` app. Same pair of cases for the OCS
prompt in `ocs_provider/tests/test_connect_prompt.py`.

### QA Plan

N/A

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
