### PR TITLE
Show work-area popup on hover

### DIFF
--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -180,6 +180,7 @@
     </div>
     <div class="flex flex-col gap-2 xl:flex-row xl:items-stretch xl:h-[max(calc(100vh-300px),200px)]"
          x-data="mapController()">
+      {{ status_meta|json_script:"status-meta-data" }}
       <!-- Map section -->
       <div id="map-wrapper"
            x-ref="mapContainer"
@@ -306,7 +307,6 @@
           </aside>
           <aside id="lower-sidebar"
                  class="bg-white shadow-md p-4 xl:flex-1 min-h-0 overflow-auto rounded-lg">
-            {{ status_meta|json_script:"status-meta-data" }}
             <h2 class="text-lg font-semibold mb-2">{% translate "Select Work Area" %}</h2>
             <template x-if="!selectedFeature">
               <div class="flex flex-col items-center justify-center h-[80%] text-center text-gray-400 gap-2 py-8">

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -197,6 +197,22 @@
             {% translate "Click to select group · Shift+click to select single area" %}
           </div>
         {% endif %}
+        <dl x-show="hoveredWorkArea"
+            x-cloak
+            class="absolute bottom-4 right-2 z-40 pointer-events-none grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 rounded-md border border-white/10 bg-black/50 px-3 py-2 text-sm text-white shadow-lg max-w-xs">
+          <dt class="opacity-75">{% translate "Work Area" %}</dt>
+          <dd x-text="hoveredWorkArea?.slug ?? '—'">
+          </dd>
+          <dt class="opacity-75">{% translate "Work Area Group" %}</dt>
+          <dd x-text="hoveredWorkArea?.group_name ?? '—'">
+          </dd>
+          <dt class="opacity-75">{% translate "Implementation Area" %}</dt>
+          <dd x-text="hoveredWorkArea?.implementation_area_name || '—'">
+          </dd>
+          <dt class="opacity-75">{% translate "Status" %}</dt>
+          <dd x-text="hoveredWorkArea?.statusLabel ?? '—'">
+          </dd>
+        </dl>
         <div id="map" class="w-full h-full"></div>
       </div>
       <!-- Sidebars (stacked) -->
@@ -337,8 +353,7 @@
                         x-text="selectedFeature.building_count ?? '—'">
                     </dd>
                   </div>
-                  <div class="flex items-center gap-4"
-                       x-data="{statusMeta: JSON.parse(document.getElementById('status-meta-data').textContent)}">
+                  <div class="flex items-center gap-4">
                     <dt class="text-sm text-gray-500 shrink-0">{% translate "Status" %}</dt>
                     <dd class="flex-1 min-w-0">
                       <span class="block w-full text-center text-sm font-semibold rounded-lg px-3 py-2"

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -14,6 +14,8 @@
             filterQuery: '',
             pendingTileQuery: null,
             workAreaDetailRequestId: 0,
+            statusMeta: {},
+            hoveredWorkArea: null,
 
             // Assignment mode state
             assignmentMode: {{ assignment_mode|yesno:'true,false' }},
@@ -827,6 +829,8 @@
                     this.initializeMap();
                 });
 
+                this.statusMeta = JSON.parse(document.getElementById('status-meta-data').textContent);
+
                 this.$watch('selectedFeature', () => this.updateHighlightedWorkAreaId());
                 this.$watch('highlightedWorkAreaId', () => this.refreshVisitStyling());
 
@@ -1231,6 +1235,7 @@
                 });
 
                 // Tracks the currently hovered feature to apply white fill highlight
+                // and show a details overlay (`hoveredWorkArea`) with the work area's key details.
                 let hoveredId = null;
                 this.map.on('mousemove', 'workareas-fill', (e) => {
                     this.map.getCanvasContainer().style.cursor = 'pointer';
@@ -1244,6 +1249,14 @@
                     }
                     hoveredId = newId;
                     this.setWorkAreaState(hoveredId, { hovered: true });
+
+                    const props = feature.properties;
+                    this.hoveredWorkArea = {
+                        slug: props.slug,
+                        group_name: props.group_name,
+                        implementation_area_name: props.implementation_area_name,
+                        statusLabel: this.statusMeta[props.status]?.label ?? props.status
+                    };
                 });
 
                 this.map.on('mouseleave', 'workareas-fill', () => {
@@ -1253,6 +1266,7 @@
                         this.setWorkAreaState(hoveredId, { hovered: false });
                         hoveredId = null;
                     }
+                    this.hoveredWorkArea = null;
                 });
             },
 


### PR DESCRIPTION
## Product Description

Show work area details on hovering on work area in both modes

https://dimagi.atlassian.net/browse/CCCT-2695

<img width="751" height="364" alt="Screenshot 2026-08-27 at 12 32 37 PM" src="https://github.com/user-attachments/assets/7c10fe39-9cb4-48df-b970-e70f72a57efc" />


## Technical Summary

Reuses existing work details 
Reuses existing map popup style

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA
### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
