### PR TITLE
Do not show duplicates for opportunities with automatic visit verification

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -3180,9 +3180,13 @@ def worker_flag_counts(request, org_slug, opp_id):
     counts = dict(Counter(all_flags))
 
     completed_work_ids = visits.values_list("completed_work_id", flat=True)
-    duplicate_count = CompletedWork.objects.filter(id__in=completed_work_ids, saved_completed_count__gt=1).count()
-    if duplicate_count:
-        counts["Duplicate"] = duplicate_count
+
+    # Do not show duplicates for opportunities with automatic visit verification,
+    # as the duplicate flag is no longer used.
+    if not request.opportunity.automatic_visit_verification:
+        duplicate_count = CompletedWork.objects.filter(id__in=completed_work_ids, saved_completed_count__gt=1).count()
+        if duplicate_count:
+            counts["Duplicate"] = duplicate_count
 
     return render(
         request,


### PR DESCRIPTION
## Product Description

<!-- Where applicable, describe user-facing effects and include screenshots. -->

Removes the duplicate visit count from opportunities that use **automatic visit verification**, since the duplicate flag is no longer used for those opportunities.

Before: (See the small popup in `Approved` column)

<img width="3200" height="826" alt="image" src="https://github.com/user-attachments/assets/3bceadea-7924-45aa-8eef-9e42dec0aec1" />


After:

<img width="3200" height="826" alt="image" src="https://github.com/user-attachments/assets/89b24463-7f30-4433-8b5d-aef3ae2c25bd" />




## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Ticket](https://dimagi.atlassian.net/browse/CI-913)

`worker_flag_counts` in `commcare_connect/opportunity/views.py` now skips the `duplicate_count` query entirely when `request.opportunity.automatic_visit_verification` is `True`.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Small, isolated change gating an existing query behind a flag that's already used elsewhere in the same function. No data is modified.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None added — existing behavior for non-automatic-verification opportunities is unchanged.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Verify the worker flag counts view for an opportunity with automatic visit verification enabled no longer reports duplicate visits.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change