### PR TITLE
Redesign invoice PDF with itemized service summary and approvals

### DIFF
--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -778,6 +778,28 @@ class PaymentInvoice(models.Model):
     def get_status_display(self):
         return InvoiceStatus.get_label(self.status)
 
+    @cached_property
+    def approval_event(self):
+        return (
+            self.status_events.filter(status=InvoiceStatus.READY_TO_PAY)
+            .select_related("pgh_context")
+            .order_by("-pgh_created_at", "-pgh_id")
+            .first()
+        )
+
+    @cached_property
+    def approved_by(self):
+        event = self.approval_event
+        if not event:
+            return None
+
+        email = event.pgh_context.metadata.get("user_email")
+        if not email:
+            return event.pgh_context.metadata.get("username", "")
+
+        user = User.objects.filter(email=email).first()
+        return user.name if user else email
+
 
 class Payment(models.Model):
     payment_id = models.UUIDField(editable=False, default=uuid4, unique=True)

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -779,26 +779,34 @@ class PaymentInvoice(models.Model):
         return InvoiceStatus.get_label(self.status)
 
     @cached_property
-    def approval_event(self):
-        return (
-            self.status_events.filter(status=InvoiceStatus.READY_TO_PAY)
+    def nm_certification(self):
+        """The Network Manager's certification: who submitted the invoice for PM review, and when."""
+        return self._certification_for(InvoiceStatus.PENDING_PM_REVIEW)
+
+    @cached_property
+    def pm_certification(self):
+        """The Program Manager's certification: who approved the invoice for payment, and when."""
+        return self._certification_for(InvoiceStatus.READY_TO_PAY)
+
+    def _certification_for(self, status):
+        event = (
+            self.status_events.filter(status=status)
             .select_related("pgh_context")
             .order_by("-pgh_created_at", "-pgh_id")
             .first()
         )
-
-    @cached_property
-    def approved_by(self):
-        event = self.approval_event
         if not event:
             return None
+        return {"name": self._certifier_name(event), "certified_at": event.pgh_created_at}
 
+    @staticmethod
+    def _certifier_name(event):
         email = event.pgh_context.metadata.get("user_email")
         if not email:
             return event.pgh_context.metadata.get("username", "")
 
         user = User.objects.filter(email=email).first()
-        return user.name if user else email
+        return f"{user.name} ({email})" if user and user.name else email
 
 
 class Payment(models.Model):

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -795,7 +795,7 @@ class PaymentInvoice(models.Model):
             .order_by("-pgh_created_at", "-pgh_id")
             .first()
         )
-        if not event:
+        if not event or not event.pgh_context:
             return None
         return {"name": self._certifier_name(event), "certified_at": event.pgh_created_at}
 

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -802,9 +802,6 @@ class PaymentInvoice(models.Model):
     @staticmethod
     def _certifier_name(event):
         email = event.pgh_context.metadata.get("user_email")
-        if not email:
-            return event.pgh_context.metadata.get("username", "")
-
         user = User.objects.filter(email=email).first()
         return f"{user.name} ({email})" if user and user.name else email
 

--- a/commcare_connect/opportunity/tests/test_invoice_line_items.py
+++ b/commcare_connect/opportunity/tests/test_invoice_line_items.py
@@ -5,12 +5,7 @@ import pytest
 from dateutil.relativedelta import relativedelta
 from django.db.models import Sum
 
-from commcare_connect.opportunity.models import (
-    CompletedWorkInvoice,
-    CompletedWorkStatus,
-    Currency,
-    PaymentInvoice,
-)
+from commcare_connect.opportunity.models import CompletedWorkInvoice, CompletedWorkStatus, Currency, PaymentInvoice
 from commcare_connect.opportunity.tests.factories import (
     CompletedWorkFactory,
     CompletedWorkInvoiceFactory,
@@ -23,6 +18,7 @@ from commcare_connect.opportunity.utils.invoice import get_start_date_for_invoic
 from commcare_connect.opportunity.utils.invoice_line_items import (
     CENTS,
     Money,
+    ServiceSummaryLine,
     _build_billable_rows,
     bill_invoice,
     get_billable_completed_works_qs,
@@ -30,6 +26,7 @@ from commcare_connect.opportunity.utils.invoice_line_items import (
     get_billable_line_items,
     get_invoice_delivery_rows_for_export,
     get_invoice_line_items,
+    get_invoice_service_summary,
     group_line_items,
     rollback_invoice_line_items,
     total_late_delta_units,
@@ -754,3 +751,64 @@ def test_invoicing_never_writes_the_legacy_invoice_fk(billing_setup):
     rollback_invoice_line_items(invoice)
     work.refresh_from_db()
     assert work.invoice_id is None
+
+
+@pytest.mark.django_db
+class TestInvoiceServiceSummary:
+    def test_flw_and_org_pay_lines(self, billing_setup):
+        access, payment_unit = billing_setup
+        completed_work(access, payment_unit, approved=2)
+        invoice = billed_invoice(access.opportunity)
+
+        summary = get_invoice_service_summary(invoice)
+
+        assert len(summary) == 2
+        assert summary[0].amount_local == Decimal("200")
+        assert "2 verified visits x USD 100.00" in summary[0].label
+        assert summary[1].amount_local == Decimal("40")
+        assert "20% of delivered service value" in summary[1].label
+
+    def test_one_row_per_payment_unit_plus_one_aggregated_org_fee_row(self, billing_setup):
+        access, payment_unit = billing_setup
+        other_unit = PaymentUnitFactory(opportunity=access.opportunity, amount=50, org_amount=10)
+        completed_work(access, payment_unit, approved=2)
+        completed_work(access, other_unit, approved=3)
+        invoice = billed_invoice(access.opportunity)
+
+        summary = get_invoice_service_summary(invoice)
+
+        assert len(summary) == 3
+        by_amount = {line.amount_local: line for line in summary}
+        assert payment_unit.name in by_amount[Decimal("200")].label
+        assert "2 verified visits x USD 100.00" in by_amount[Decimal("200")].label
+        assert other_unit.name in by_amount[Decimal("150")].label
+        assert "3 verified visits x USD 50.00" in by_amount[Decimal("150")].label
+        # org pay is aggregated into a single row: 2*20 + 3*10 = 70
+        assert "of delivered service value" in by_amount[Decimal("70")].label
+
+    def test_omits_org_line_when_org_pay_is_zero(self, billing_setup):
+        access, payment_unit = billing_setup
+        payment_unit.org_amount = 0
+        payment_unit.save(update_fields=["org_amount"])
+        completed_work(access, payment_unit, approved=1)
+        invoice = billed_invoice(access.opportunity)
+
+        summary = get_invoice_service_summary(invoice)
+
+        assert len(summary) == 1
+        assert summary[0].amount_local == Decimal("100")
+
+    def test_custom_invoice_uses_its_own_description_and_amount(self):
+        invoice = PaymentInvoiceFactory(service_delivery=False, amount=Decimal("200.00"), description="Consulting")
+
+        summary = get_invoice_service_summary(invoice)
+
+        assert summary == [ServiceSummaryLine(label="Consulting", amount_local=Decimal("200.00"))]
+
+    def test_service_delivery_invoice_without_billed_line_items_falls_back_to_its_amount(self):
+        invoice = PaymentInvoiceFactory(service_delivery=True, amount=Decimal("150.50"))
+
+        summary = get_invoice_service_summary(invoice)
+
+        assert len(summary) == 1
+        assert summary[0].amount_local == Decimal("150.50")

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -152,6 +152,22 @@ class TestPaymentInvoice:
         assert certification["name"] == "second"
         assert certification["certified_at"] == latest_event.pgh_created_at
 
+    @pytest.mark.parametrize(
+        "prop, status",
+        [
+            ("nm_certification", InvoiceStatus.PENDING_PM_REVIEW),
+            ("pm_certification", InvoiceStatus.READY_TO_PAY),
+        ],
+    )
+    def test_certification_is_none_when_the_transition_has_no_audit_context(self, prop, status):
+        invoice = PaymentInvoiceFactory()
+
+        invoice.status = status
+        invoice.save(update_fields=["status"])
+
+        assert invoice.status_events.get(status=status).pgh_context is None
+        assert getattr(invoice, prop) is None
+
     def test_nm_and_pm_certifications_are_recorded_independently(self):
         nm = UserFactory(name="Nadia NM", email="nadia@example.com")
         pm = UserFactory(name="Priya PM", email="priya@example.com")

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -2,6 +2,7 @@ import datetime
 from datetime import date, timedelta
 from unittest import mock
 
+import pghistory
 import pytest
 from django.db.utils import IntegrityError
 from django.utils.timezone import now
@@ -38,7 +39,7 @@ from commcare_connect.opportunity.utils.invoice import generate_invoice_number
 from commcare_connect.opportunity.visit_import import update_payment_accrued
 from commcare_connect.program.tests.factories import ProgramFactory
 from commcare_connect.users.models import User
-from commcare_connect.users.tests.factories import MobileUserFactory, OrganizationFactory
+from commcare_connect.users.tests.factories import MobileUserFactory, OrganizationFactory, UserFactory
 from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 from commcare_connect.utils.ocs_api import OcsApiError
 
@@ -112,6 +113,56 @@ class TestPaymentInvoice:
         # assert expected status value for the recent event for each record
         for invoice in created_invoices:
             assert invoice.status_events.last().status == InvoiceStatus.PENDING_PM_REVIEW
+
+    def test_approval_event_is_none_before_any_approval(self):
+        invoice = PaymentInvoiceFactory()
+
+        assert invoice.approval_event is None
+        assert invoice.approved_by is None
+
+    def test_approval_event_returns_the_latest_ready_to_pay_event(self):
+        invoice = PaymentInvoiceFactory()
+
+        with pghistory.context(username="pm_first"):
+            invoice.status = InvoiceStatus.READY_TO_PAY
+            invoice.save(update_fields=["status"])
+
+        invoice.status = InvoiceStatus.REJECTED_BY_PM
+        invoice.save(update_fields=["status"])
+
+        with pghistory.context(username="pm_second"):
+            invoice.status = InvoiceStatus.READY_TO_PAY
+            invoice.save(update_fields=["status"])
+
+        assert invoice.approval_event.pgh_context.metadata["username"] == "pm_second"
+
+    def test_approved_by_resolves_the_users_name_from_the_audited_email(self):
+        user = UserFactory(name="Jane PM", email="jane@example.com")
+        invoice = PaymentInvoiceFactory()
+
+        with pghistory.context(username=user.username, user_email=user.email):
+            invoice.status = InvoiceStatus.READY_TO_PAY
+            invoice.save(update_fields=["status"])
+
+        assert invoice.approved_by == "Jane PM"
+
+    def test_approved_by_falls_back_to_the_email_when_no_user_matches_it(self):
+        invoice = PaymentInvoiceFactory()
+
+        with pghistory.context(username="pm_deleted", user_email="deleted@example.com"):
+            invoice.status = InvoiceStatus.READY_TO_PAY
+            invoice.save(update_fields=["status"])
+
+        assert invoice.approved_by == "deleted@example.com"
+
+    def test_approved_by_falls_back_to_the_username_when_no_email_was_audited(self):
+        invoice = PaymentInvoiceFactory()
+
+        with pghistory.context(username="pm_no_email"):
+            invoice.status = InvoiceStatus.READY_TO_PAY
+            invoice.save(update_fields=["status"])
+
+        assert invoice.approved_by == "pm_no_email"
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -114,55 +114,84 @@ class TestPaymentInvoice:
         for invoice in created_invoices:
             assert invoice.status_events.last().status == InvoiceStatus.PENDING_PM_REVIEW
 
-    def test_approval_event_is_none_before_any_approval(self):
+    @pytest.mark.parametrize(
+        "prop, status",
+        [
+            ("nm_certification", InvoiceStatus.PENDING_PM_REVIEW),
+            ("pm_certification", InvoiceStatus.READY_TO_PAY),
+        ],
+    )
+    def test_certification_is_none_before_the_transition_happens(self, prop, status):
         invoice = PaymentInvoiceFactory()
 
-        assert invoice.approval_event is None
-        assert invoice.approved_by is None
+        assert getattr(invoice, prop) is None
 
-    def test_approval_event_returns_the_latest_ready_to_pay_event(self):
+    @pytest.mark.parametrize(
+        "prop, status",
+        [
+            ("nm_certification", InvoiceStatus.PENDING_PM_REVIEW),
+            ("pm_certification", InvoiceStatus.READY_TO_PAY),
+        ],
+    )
+    def test_certification_uses_the_latest_transition_to_that_status(self, prop, status):
         invoice = PaymentInvoiceFactory()
 
-        with pghistory.context(username="pm_first"):
-            invoice.status = InvoiceStatus.READY_TO_PAY
+        with pghistory.context(username="first"):
+            invoice.status = status
             invoice.save(update_fields=["status"])
 
         invoice.status = InvoiceStatus.REJECTED_BY_PM
         invoice.save(update_fields=["status"])
 
-        with pghistory.context(username="pm_second"):
-            invoice.status = InvoiceStatus.READY_TO_PAY
+        with pghistory.context(username="second"):
+            invoice.status = status
             invoice.save(update_fields=["status"])
 
-        assert invoice.approval_event.pgh_context.metadata["username"] == "pm_second"
+        certification = getattr(invoice, prop)
+        latest_event = invoice.status_events.filter(status=status).latest("pgh_created_at")
+        assert certification["name"] == "second"
+        assert certification["certified_at"] == latest_event.pgh_created_at
 
-    def test_approved_by_resolves_the_users_name_from_the_audited_email(self):
-        user = UserFactory(name="Jane PM", email="jane@example.com")
+    def test_nm_and_pm_certifications_are_recorded_independently(self):
+        nm = UserFactory(name="Nadia NM", email="nadia@example.com")
+        pm = UserFactory(name="Priya PM", email="priya@example.com")
         invoice = PaymentInvoiceFactory()
 
-        with pghistory.context(username=user.username, user_email=user.email):
+        with pghistory.context(username=nm.username, user_email=nm.email):
+            invoice.status = InvoiceStatus.PENDING_PM_REVIEW
+            invoice.save(update_fields=["status"])
+        with pghistory.context(username=pm.username, user_email=pm.email):
             invoice.status = InvoiceStatus.READY_TO_PAY
             invoice.save(update_fields=["status"])
 
-        assert invoice.approved_by == "Jane PM"
+        assert invoice.nm_certification["name"] == "Nadia NM (nadia@example.com)"
+        assert invoice.pm_certification["name"] == "Priya PM (priya@example.com)"
 
-    def test_approved_by_falls_back_to_the_email_when_no_user_matches_it(self):
+    @pytest.mark.parametrize(
+        "context, expected_name",
+        [
+            pytest.param(
+                {"username": "jane", "user_email": "jane@example.com"},
+                "Jane PM (jane@example.com)",
+                id="resolves-user-name",
+            ),
+            pytest.param(
+                {"username": "pm_deleted", "user_email": "deleted@example.com"},
+                "deleted@example.com",
+                id="falls-back-to-email",
+            ),
+            pytest.param({"username": "pm_no_email"}, "pm_no_email", id="falls-back-to-username"),
+        ],
+    )
+    def test_certifier_name_resolution(self, context, expected_name):
+        UserFactory(name="Jane PM", email="jane@example.com")
         invoice = PaymentInvoiceFactory()
 
-        with pghistory.context(username="pm_deleted", user_email="deleted@example.com"):
+        with pghistory.context(**context):
             invoice.status = InvoiceStatus.READY_TO_PAY
             invoice.save(update_fields=["status"])
 
-        assert invoice.approved_by == "deleted@example.com"
-
-    def test_approved_by_falls_back_to_the_username_when_no_email_was_audited(self):
-        invoice = PaymentInvoiceFactory()
-
-        with pghistory.context(username="pm_no_email"):
-            invoice.status = InvoiceStatus.READY_TO_PAY
-            invoice.save(update_fields=["status"])
-
-        assert invoice.approved_by == "pm_no_email"
+        assert invoice.pm_certification["name"] == expected_name
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/tests/test_models.py
+++ b/commcare_connect/opportunity/tests/test_models.py
@@ -136,20 +136,20 @@ class TestPaymentInvoice:
     def test_certification_uses_the_latest_transition_to_that_status(self, prop, status):
         invoice = PaymentInvoiceFactory()
 
-        with pghistory.context(username="first"):
+        with pghistory.context(username="first", user_email="first@example.com"):
             invoice.status = status
             invoice.save(update_fields=["status"])
 
         invoice.status = InvoiceStatus.REJECTED_BY_PM
         invoice.save(update_fields=["status"])
 
-        with pghistory.context(username="second"):
+        with pghistory.context(username="second", user_email="second@example.com"):
             invoice.status = status
             invoice.save(update_fields=["status"])
 
         certification = getattr(invoice, prop)
         latest_event = invoice.status_events.filter(status=status).latest("pgh_created_at")
-        assert certification["name"] == "second"
+        assert certification["name"] == "second@example.com"
         assert certification["certified_at"] == latest_event.pgh_created_at
 
     @pytest.mark.parametrize(
@@ -196,7 +196,6 @@ class TestPaymentInvoice:
                 "deleted@example.com",
                 id="falls-back-to-email",
             ),
-            pytest.param({"username": "pm_no_email"}, "pm_no_email", id="falls-back-to-username"),
         ],
     )
     def test_certifier_name_resolution(self, context, expected_name):

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -6,6 +6,7 @@ from unittest import mock
 from urllib.parse import urlencode
 from uuid import uuid4
 
+import pghistory
 import pytest
 from django.contrib.messages import get_messages
 from django.core.files.base import ContentFile
@@ -1461,6 +1462,64 @@ class TestDownloadInvoiceView(BaseTestInvoiceView):
 
         assert response.status_code == 404
         assert "No PaymentInvoice matches the given query." in str(response.content)
+
+    def test_context_includes_service_summary_lines(self, client, setup_invoice):
+        invoice = setup_invoice["invoice"]
+        opportunity = setup_invoice["opportunity"]
+        user = setup_invoice["user"]
+
+        response = self._send_request(client, user, opportunity, invoice.payment_invoice_id)
+
+        assert response.status_code == 200
+        summary_lines = response.context["service_summary_lines"]
+        assert len(summary_lines) == 1
+        assert summary_lines[0].amount_local == invoice.amount
+
+    def test_context_includes_service_summary_lines_for_custom_invoice(self, client, setup_invoice):
+        opportunity = setup_invoice["opportunity"]
+        user = setup_invoice["user"]
+        custom_invoice = PaymentInvoiceFactory(
+            opportunity=opportunity,
+            service_delivery=False,
+            amount=200.00,
+            invoice_number="CUSTOM-001",
+            date=date(2025, 11, 1),
+        )
+
+        response = self._send_request(client, user, opportunity, custom_invoice.payment_invoice_id)
+
+        assert response.status_code == 200
+        summary_lines = response.context["service_summary_lines"]
+        assert len(summary_lines) == 1
+        assert summary_lines[0].amount_local == custom_invoice.amount
+
+    def test_context_invoice_exposes_approval_once_approved(self, client, setup_invoice):
+        invoice = setup_invoice["invoice"]
+        opportunity = setup_invoice["opportunity"]
+        user = setup_invoice["user"]
+
+        with pghistory.context(username=user.username, user_email=user.email):
+            invoice.status = InvoiceStatus.READY_TO_PAY
+            invoice.save(update_fields=["status"])
+
+        response = self._send_request(client, user, opportunity, invoice.payment_invoice_id)
+
+        assert response.status_code == 200
+        context_invoice = response.context["invoice"]
+        assert context_invoice.approval_event.pgh_context.metadata["username"] == user.username
+        assert context_invoice.approved_by == user.name
+
+    def test_context_invoice_has_no_approval_when_not_yet_approved(self, client, setup_invoice):
+        invoice = setup_invoice["invoice"]
+        opportunity = setup_invoice["opportunity"]
+        user = setup_invoice["user"]
+
+        response = self._send_request(client, user, opportunity, invoice.payment_invoice_id)
+
+        assert response.status_code == 200
+        context_invoice = response.context["invoice"]
+        assert context_invoice.approval_event is None
+        assert context_invoice.approved_by is None
 
 
 class TestAddPaymentUnitView:

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -1493,11 +1493,14 @@ class TestDownloadInvoiceView(BaseTestInvoiceView):
         assert len(summary_lines) == 1
         assert summary_lines[0].amount_local == custom_invoice.amount
 
-    def test_context_invoice_exposes_approval_once_approved(self, client, setup_invoice):
+    def test_context_invoice_exposes_both_certifications_once_approved(self, client, setup_invoice):
         invoice = setup_invoice["invoice"]
         opportunity = setup_invoice["opportunity"]
         user = setup_invoice["user"]
 
+        with pghistory.context(username="nm_user", user_email="nm@example.com"):
+            invoice.status = InvoiceStatus.PENDING_PM_REVIEW
+            invoice.save(update_fields=["status"])
         with pghistory.context(username=user.username, user_email=user.email):
             invoice.status = InvoiceStatus.READY_TO_PAY
             invoice.save(update_fields=["status"])
@@ -1506,10 +1509,10 @@ class TestDownloadInvoiceView(BaseTestInvoiceView):
 
         assert response.status_code == 200
         context_invoice = response.context["invoice"]
-        assert context_invoice.approval_event.pgh_context.metadata["username"] == user.username
-        assert context_invoice.approved_by == user.name
+        assert context_invoice.nm_certification["name"] == "nm@example.com"
+        assert context_invoice.pm_certification["name"] == f"{user.name} ({user.email})"
 
-    def test_context_invoice_has_no_approval_when_not_yet_approved(self, client, setup_invoice):
+    def test_context_invoice_has_no_certifications_when_not_yet_reviewed(self, client, setup_invoice):
         invoice = setup_invoice["invoice"]
         opportunity = setup_invoice["opportunity"]
         user = setup_invoice["user"]
@@ -1518,8 +1521,8 @@ class TestDownloadInvoiceView(BaseTestInvoiceView):
 
         assert response.status_code == 200
         context_invoice = response.context["invoice"]
-        assert context_invoice.approval_event is None
-        assert context_invoice.approved_by is None
+        assert context_invoice.nm_certification is None
+        assert context_invoice.pm_certification is None
 
 
 class TestAddPaymentUnitView:

--- a/commcare_connect/opportunity/utils/invoice_line_items.py
+++ b/commcare_connect/opportunity/utils/invoice_line_items.py
@@ -6,6 +6,7 @@ from decimal import ROUND_HALF_EVEN, Decimal
 from django.db import transaction
 from django.db.models import Exists, F, Max, OuterRef, Q, Sum
 from django.db.models.functions import Coalesce
+from django.utils.translation import gettext
 
 from commcare_connect.opportunity.models import (
     CompletedWork,
@@ -213,6 +214,80 @@ def get_invoice_line_items(invoice):
         )
         for record in records
     ]
+
+
+@dataclass(frozen=True)
+class ServiceSummaryLine:
+    """One row of the invoice PDF's 'Description of Services' summary."""
+
+    label: str
+    amount_local: Decimal
+
+
+def get_invoice_service_summary(invoice):
+    """The 'Description of Services' summary lines shown on the invoice PDF.
+
+    For a service delivery invoice, this is one row per billed (month, payment unit) combination
+    covering frontline-worker pay, plus one row for the network-management fee aggregated across
+    every month and payment unit, when nonzero. For a custom invoice, it is a single line for the
+    invoice's own amount and description.
+    """
+    if not invoice.service_delivery:
+        label = invoice.description or gettext("Custom invoice charge")
+        return [ServiceSummaryLine(label=label, amount_local=invoice.amount)]
+
+    line_items = get_invoice_line_items(invoice)
+    if not line_items:
+        label = invoice.description or gettext("Service delivery payments")
+        return [ServiceSummaryLine(label=label, amount_local=invoice.amount)]
+
+    currency = invoice.opportunity.currency_code
+    flw_total = sum(item.flw_pay.local for item in line_items)
+    org_total = sum(item.org_pay.local for item in line_items)
+
+    lines = [
+        ServiceSummaryLine(
+            label=gettext(
+                "Service delivery payments for %(payment_unit)s, %(period)s "
+                "(%(units)s verified visits x %(currency)s %(rate)s)"
+            )
+            % {
+                "payment_unit": item.payment_unit_name,
+                "period": f"{item.month:%B %Y}",
+                "units": item.number_approved,
+                "currency": currency,
+                "rate": (
+                    (item.flw_pay.local / item.number_approved).quantize(CENTS, rounding=ROUND_HALF_EVEN)
+                    if item.number_approved
+                    else Decimal("0.00")
+                ),
+            },
+            amount_local=item.flw_pay.local,
+        )
+        for item in line_items
+    ]
+    if org_total:
+        percent = (org_total / flw_total * 100).quantize(Decimal("1"), rounding=ROUND_HALF_EVEN) if flw_total else 0
+        lines.append(
+            ServiceSummaryLine(
+                label=gettext("Network management fee, %(period)s (%(percent)s%% of delivered service value)")
+                % {"period": _invoice_period_label(invoice), "percent": percent},
+                amount_local=org_total,
+            )
+        )
+    return lines
+
+
+def _invoice_period_label(invoice):
+    if (
+        invoice.start_date
+        and invoice.end_date
+        and invoice.start_date.strftime("%Y-%m") != invoice.end_date.strftime("%Y-%m")
+    ):
+        return f"{invoice.start_date:%B %Y} - {invoice.end_date:%B %Y}"
+    if invoice.start_date:
+        return f"{invoice.start_date:%B %Y}"
+    return f"{invoice.date:%B %Y}" if invoice.date else ""
 
 
 def get_invoice_delivery_rows_for_export(invoice):

--- a/commcare_connect/opportunity/utils/invoice_line_items.py
+++ b/commcare_connect/opportunity/utils/invoice_line_items.py
@@ -249,14 +249,14 @@ def get_invoice_service_summary(invoice):
         ServiceSummaryLine(
             label=gettext(
                 "Service delivery payments for %(payment_unit)s, %(period)s "
-                "(%(units)s verified visits x %(currency)s %(rate)s)"
+                "(%(units)s verified visits x %(currency)s %(per_visit_rate)s)"
             )
             % {
                 "payment_unit": item.payment_unit_name,
                 "period": f"{item.month:%B %Y}",
                 "units": item.number_approved,
                 "currency": currency,
-                "rate": (
+                "per_visit_rate": (
                     (item.flw_pay.local / item.number_approved).quantize(CENTS, rounding=ROUND_HALF_EVEN)
                     if item.number_approved
                     else Decimal("0.00")

--- a/commcare_connect/opportunity/utils/invoice_line_items.py
+++ b/commcare_connect/opportunity/utils/invoice_line_items.py
@@ -287,7 +287,7 @@ def _invoice_period_label(invoice):
         return f"{invoice.start_date:%B %Y} - {invoice.end_date:%B %Y}"
     if invoice.start_date:
         return f"{invoice.start_date:%B %Y}"
-    return f"{invoice.date:%B %Y}" if invoice.date else ""
+    return f"{invoice.date:%B %Y}" if invoice.date else gettext("Unknown")
 
 
 def get_invoice_delivery_rows_for_export(invoice):

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -193,6 +193,7 @@ from commcare_connect.opportunity.utils.invoice_line_items import (
     get_billable_line_items,
     get_invoice_delivery_rows_for_export,
     get_invoice_line_items,
+    get_invoice_service_summary,
     rollback_invoice_line_items,
     total_late_delta_units,
 )
@@ -1970,11 +1971,19 @@ def update_invoice_invoice_ticket_link(request, org_slug, opp_id, invoice_id):
 @org_member_required
 @opportunity_required
 def download_invoice(request, org_slug, opp_id, invoice_id):
-    invoice = get_object_or_404(PaymentInvoice, opportunity=request.opportunity, payment_invoice_id=invoice_id)
+    invoice = get_object_or_404(
+        PaymentInvoice.objects.select_related("exchange_rate", "payment"),
+        opportunity=request.opportunity,
+        payment_invoice_id=invoice_id,
+    )
+    context = {
+        "invoice": invoice,
+        "service_summary_lines": get_invoice_service_summary(invoice),
+    }
     return WeasyTemplateResponse(
         request=request,
         template="opportunity/invoice_download.html",
-        context={"invoice": invoice},
+        context=context,
         content_type="application/pdf",
         filename=f"invoice_{invoice_id}.pdf",
     )

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -252,6 +252,8 @@ PAYMENT_IMPORT_TASK_PARAM = "payment_import_task_id"
 # Task id of the payment import whose outcome has already been shown to the user.
 PAYMENT_IMPORT_CLAIMED_SESSION_KEY = "shown_payment_import"
 
+DIMAGI_ADDRESS = gettext_lazy("Dimagi, Inc.\n245 Main Street, 2nd Floor\nCambridge, MA 02142, USA\n+1 617.649.2214")
+
 
 def get_opportunity_or_404(pk, org_slug):
     opp = get_object_by_uuid_or_int(Opportunity.objects.all(), str(pk), uuid_field="opportunity_id")
@@ -1979,6 +1981,7 @@ def download_invoice(request, org_slug, opp_id, invoice_id):
     context = {
         "invoice": invoice,
         "service_summary_lines": get_invoice_service_summary(invoice),
+        "dimagi_address": DIMAGI_ADDRESS,
     }
     return WeasyTemplateResponse(
         request=request,

--- a/commcare_connect/templates/opportunity/invoice_download.html
+++ b/commcare_connect/templates/opportunity/invoice_download.html
@@ -1,87 +1,170 @@
-{% load static i18n %}
+{% load static i18n humanize %}
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <style>
       body {
         font-family: sans-serif;
+        color: #1a1a1a;
       }
-      .header div {
-        width: 100%;
-        text-align: center;
+      .container {
+        max-width: 700px;
+        margin: 0 auto;
+      }
+      .title-row {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        margin-bottom: 24px;
+      }
+      .logo img {
+        height: 56px;
+      }
+      h1.invoice-title {
+        margin: 0;
+        font-size: 28px;
+      }
+      .section {
+        margin-bottom: 20px;
+      }
+      .section p {
+        margin: 2px 0;
+      }
+      .section-heading {
+        font-weight: bold;
+        margin-bottom: 6px;
       }
       .table-container {
-        margin-top: 20px;
+        margin-top: 24px;
       }
-      .full-width-table {
+      .service-table {
         width: 100%;
-        border-collapse: collapse; /* Collapses borders into a single line */
-        margin-bottom: 20px; /* Add margin below the table */
+        border-collapse: collapse;
       }
-      .full-width-table td {
-        border: 1px solid; /* Add borders for visibility */
-        padding: 12px;
+      .service-table th,
+      .service-table td {
         text-align: left;
-        width: 50%;
+        padding: 8px 0;
+      }
+      .service-table th:last-child,
+      .service-table td:last-child {
+        text-align: right;
+        white-space: nowrap;
+        padding-left: 24px;
+        width: 1%;
+      }
+      .service-table thead th {
+        border-bottom: 1px solid #1a1a1a;
+      }
+      .service-table .total-row td {
+        border-top: 1px solid #1a1a1a;
+        font-weight: bold;
+      }
+      .notes {
+        margin-top: 24px;
+      }
+      .notes p {
+        margin: 4px 0;
+      }
+      .authorization {
+        margin-top: 24px;
+        border-top: 1px solid #1a1a1a;
+        padding-top: 12px;
+      }
+      .authorization p {
+        margin: 2px 0;
       }
     </style>
   </head>
   <body>
     <div class="container">
-      <div class="header">
-        <div class="org">{% trans "Organization" %}: {{ request.opportunity.organization.name|default:"" }}</div>
-        <div class="opportunity">{% trans "Opportunity" %}: {{ request.opportunity.name }}</div>
+      <div class="title-row">
+        <h1 class="invoice-title">{% trans "Invoice" %}</h1>
+        <div class="logo">
+          <img src="{% static 'images/logo-color.svg' %}"
+               alt="{% trans 'Connect' %}" />
+        </div>
+      </div>
+      <div class="section">
+        <p>
+          <strong>{{ request.opportunity.organization.name|default:"" }}</strong>
+        </p>
+        {% if request.opportunity.organization.office_address %}
+          <p>{{ request.opportunity.organization.office_address }}</p>
+        {% endif %}
+      </div>
+      <div class="section">
+        <p>{% trans "Invoice number" %}: {{ invoice.invoice_number }}</p>
+        <p>{% trans "Invoice date" %}: {{ invoice.date|default:"" }}</p>
+        <p>{% trans "Payment terms" %}: {% trans "Net 30" %}</p>
+        <p>{% trans "Invoice status" %}: {{ invoice.get_status_display }}</p>
+        <p>
+          {% trans "Paid" %}:
+          {% if invoice.is_paid %}
+            {% trans "Paid" %}
+          {% else %}
+            {% trans "Pending" %}
+          {% endif %}
+        </p>
+        {% if invoice.is_paid %}
+          <p>{% trans "Payment date" %}: {{ invoice.payment.date_paid }}</p>
+        {% endif %}
+      </div>
+      <div class="section">
+        <p class="section-heading">{% trans "Bill to" %}</p>
+        <p>{% trans "Dimagi, Inc." %}</p>
+        <p>{% trans "245 Main Street, 2nd Floor" %}</p>
+        <p>{% trans "Cambridge, MA 02142, USA" %}</p>
+        <p>+1 617.649.2214</p>
+      </div>
+      <div class="section">
+        <p>{% trans "Opportunity" %}: {{ request.opportunity.name }}</p>
+        <p>{% trans "Invoice type" %}: {{ invoice.invoice_type.label }}</p>
+        <p>{% trans "Opportunity ID" %}: {{ request.opportunity.opportunity_id }}</p>
       </div>
       <div class="table-container">
-        <table class="full-width-table">
-          <tr>
-            <td>{% trans "Invoice Number" %}</td>
-            <td>{{ invoice.invoice_number }}</td>
-          </tr>
-          <tr>
-            <td>{% trans "Amount" %}</td>
-            <td>{{ invoice.amount|default:"" }}</td>
-          </tr>
-          <tr>
-            <td>{% trans "Amount (USD)" %}</td>
-            <td>{{ invoice.amount_usd|default:"" }}</td>
-          </tr>
-          <tr>
-            <td>{% trans "Rate" %}</td>
-            <td>
-              {% if invoice.exchange_rate %}{{ invoice.exchange_rate.rate }}{% endif %}
-            </td>
-          </tr>
-          <tr>
-            <td>{% trans "Date" %}</td>
-            <td>{{ invoice.date|default:"" }}</td>
-          </tr>
-          <tr>
-            <td>{% trans "Invoice Status" %}</td>
-            <td>{{ invoice.get_status_display }}</td>
-          </tr>
-          <tr>
-            <td>{% trans "Paid" %}</td>
-            <td>
-              {% if invoice.is_paid %}
-                {% trans "Paid" %}
-              {% else %}
-                {% trans "Pending" %}
-              {% endif %}
-            </td>
-          </tr>
-          {% if invoice.is_paid %}
+        <table class="service-table">
+          <thead>
             <tr>
-              <td>{% trans "Payment Date" %}</td>
-              <td>{{ invoice.payment.date_paid }}</td>
+              <th>{% trans "Description of services" %}</th>
+              <th>{% blocktrans with currency=request.opportunity.currency_code %}Amount ({{ currency }}){% endblocktrans %}</th>
             </tr>
-          {% endif %}
-          <tr>
-            <td>{% trans "Invoice Type" %}</td>
-            <td>{{ invoice.invoice_type.label }}</td>
-          </tr>
+          </thead>
+          <tbody>
+            {% for line in service_summary_lines %}
+              <tr>
+                <td>{{ line.label }}</td>
+                <td>{{ line.amount_local|floatformat:2|intcomma }}</td>
+              </tr>
+            {% endfor %}
+            <tr class="total-row">
+              <td>{% trans "Total due" %}</td>
+              <td>{{ request.opportunity.currency_code }} {{ invoice.amount|default:0|floatformat:2|intcomma }}</td>
+            </tr>
+            <tr>
+              <td>
+                {% blocktrans with rate=invoice.exchange_rate.rate|floatformat:2 %}USD equivalent (rate {{ rate }}){% endblocktrans %}
+              </td>
+              <td>
+                <strong>USD {{ invoice.amount_usd|default:0|floatformat:2|intcomma }}</strong>
+              </td>
+            </tr>
+          </tbody>
         </table>
       </div>
+      <div class="notes">
+        <p>{% trans "If your banking details have changed, please notify us before this invoice is processed." %}</p>
+      </div>
+      {% if invoice.approval_event %}
+        <div class="authorization">
+          <p class="section-heading">{% trans "Authorization" %}</p>
+          <p>
+            {% blocktrans with name=invoice.approved_by timestamp=invoice.approval_event.pgh_created_at %}
+              Authorized by {{ name }} on {{ timestamp }}, confirming this invoice's information is current.
+            {% endblocktrans %}
+          </p>
+        </div>
+      {% endif %}
     </div>
   </body>
 </html>

--- a/commcare_connect/templates/opportunity/invoice_download.html
+++ b/commcare_connect/templates/opportunity/invoice_download.html
@@ -155,13 +155,25 @@
       <div class="notes">
         <p>{% trans "If your banking details have changed, please notify us before this invoice is processed." %}</p>
       </div>
-      {% if invoice.approval_event %}
+      {% if invoice.nm_certification or invoice.pm_certification %}
         <div class="authorization">
           <p class="section-heading">{% trans "Authorization" %}</p>
+          {% if invoice.nm_certification %}
+            <p>
+              {% blocktrans with name=invoice.nm_certification.name timestamp=invoice.nm_certification.certified_at|date:"j F Y \a\t H:i e" %}
+                Submitted by {{ name }} on {{ timestamp }}.
+              {% endblocktrans %}
+            </p>
+          {% endif %}
+          {% if invoice.pm_certification %}
+            <p>
+              {% blocktrans with name=invoice.pm_certification.name timestamp=invoice.pm_certification.certified_at|date:"j F Y \a\t H:i e" %}
+                Authorized by {{ name }} on {{ timestamp }}.
+              {% endblocktrans %}
+            </p>
+          {% endif %}
           <p>
-            {% blocktrans with name=invoice.approved_by timestamp=invoice.approval_event.pgh_created_at %}
-              Authorized by {{ name }} on {{ timestamp }}, confirming this invoice's information is current.
-            {% endblocktrans %}
+            {% trans "By submitting and authorizing this invoice, the above users attested that the organization, contact and banking details shown are current and correct." %}
           </p>
         </div>
       {% endif %}

--- a/commcare_connect/templates/opportunity/invoice_download.html
+++ b/commcare_connect/templates/opportunity/invoice_download.html
@@ -112,10 +112,7 @@
       </div>
       <div class="section">
         <p class="section-heading">{% trans "Bill to" %}</p>
-        <p>{% trans "Dimagi, Inc." %}</p>
-        <p>{% trans "245 Main Street, 2nd Floor" %}</p>
-        <p>{% trans "Cambridge, MA 02142, USA" %}</p>
-        <p>+1 617.649.2214</p>
+        <p>{{ dimagi_address|linebreaksbr }}</p>
       </div>
       <div class="section">
         <p>{% trans "Opportunity" %}: {{ request.opportunity.name }}</p>


### PR DESCRIPTION
## Product Description

The invoice PDF now shows the organization's details, breaks payments down by month and payment unit instead of one blended total, and includes payment terms, a "Bill to" section, and a note showing who approved it and when.

| Custom Invoice | Service Delivery |
|---|---|
| <img width="398" alt="Custom Invoice" src="https://github.com/user-attachments/assets/42e819ab-31bd-40da-827f-dbdcefe57f32" /> | <img width="398" alt="Service Delivery" src="https://github.com/user-attachments/assets/5aad4778-50ea-4d7d-923b-0e7ce45cd69d" /> |

## Technical Summary

[CCCT-2736](https://dimagi.atlassian.net/browse/CCCT-2736)

- Service delivery invoices now list one line per billed month and payment unit, plus one combined network management fee line, instead of a single blended total across the whole invoice.
- Added `approval_event` and `approved_by` to `PaymentInvoice` so the PDF can show who approved it.


## Safety Assurance

### Safety story

Rendered the PDF locally against real invoice data, including multi-unit, multi-month, and custom invoices, and checked the output by eye. This only changes what the PDF shows, not how invoices are created or billed.

### Automated test coverage

Added and updated tests for the new service summary grouping and the approval properties; the full opportunity test suite passes.

### QA Plan

Qa(WIP), tested manually on local and on staging.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2736]: https://dimagi.atlassian.net/browse/CCCT-2736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ