### PR TITLE
Update PR template and run check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,17 @@ In particular consider how existing data may be impacted by this change.
 - Link to QA Ticket
 -->
 
+### Deployment
+
+<!--
+    Think about whether merging this to main is enough to ship it safely.
+    Does it need a config value set, a management command run, a feature flag
+    created, a migration applied out of band, or a coordinated release with
+    another service?
+-->
+
+- [ ] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.
+
 ### Labels & Review
 
 - [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,37 @@
+name: PR Checklist
+
+# Blocks merging until the author confirms the PR is safe to deploy.
+# Runs on `edited` too, so re-running is just a matter of ticking the box.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: ['main']
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-confirmation:
+    name: Deploy confirmation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the deployment checkbox is ticked
+        # Dependabot opens PRs without the template, so it can't tick the box.
+        if: github.actor != 'dependabot[bot]'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | tr -d '\r' | grep -qiE '^[[:space:]]*-[[:space:]]*\[x\][[:space:]]*This PR can be deployed'; then
+            echo "Ready for deployment."
+            exit 0
+          fi
+
+          echo "::error::The \"This PR can be deployed\" checkbox in the PR description is not ticked."
+          echo ""
+          echo "Before merging to main, confirm this change can be deployed as-is."
+          echo "If it needs configuration, commands, or other manual steps, describe"
+          echo "them in the PR description and coordinate with whoever will deploy."
+          echo ""
+          echo "Then tick the box in the Deployment section of the PR description:"
+          echo "  - [x] This PR can be deployed: ..."
+          exit 1

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check the deployment checkbox is ticked
         # Dependabot opens PRs without the template, so it can't tick the box.
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -5,7 +5,6 @@ name: PR Checklist
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-    branches: ['main']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Technical Summary
1. The PR template now asks the user to explicitly state whether the PR is ready to be deployed

2. A check runs on defined pull request events which evaluates whether the PR can be merged (depending on the status of the checkbox)

## Safety Assurance

### Safety story
Does not touch code - only PR template.

### Automated test coverage
N.A

### QA Plan
N.A

### Deployment
- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
