### PR TITLE
Rename unplanned -> adhoc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,13 +24,13 @@ on:
           - staging
           - production
       deploy_type:
-        description: 'Whether this deploy is part of the regular schedule or an unplanned/hotfix deploy'
+        description: 'Whether this deploy is part of the regular schedule or an adhoc/hotfix deploy'
         required: true
         default: 'scheduled'
         type: choice
         options:
           - scheduled
-          - unplanned
+          - adhoc
 
 jobs:
   deploy:


### PR DESCRIPTION
## Technical Summary
This PR renames "unplanned" to "adhoc" in the github deploy script to make the terminology more inclusive for staging deploys. Saying "the staging deploy is unplanned" is just as awkward as saying "the staging deploy is scheduled" - both of these are not true. 

Using the term "adhoc" feels more appropriate whilst still capturing the concept of "this production deploy was not a scheduled deploy", which is what I think the original intention for this deploy dimension is.

## Safety Assurance

### Safety story
N.A

### Automated test coverage
N.A

### QA Plan
N.A

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
