### PR TITLE
Make opportunity dashboard currency display consistent

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -467,6 +467,10 @@ class OpportunityFinalize(OpportunityObjectMixin, OrgPMRequiredMixin, UpdateView
         return response
 
 
+def amount_with_currency(amount, currency_code):
+    return f"{currency_code + ' ' if currency_code else ''}{intcomma(int(amount or 0))}"
+
+
 class OpportunityDashboard(OpportunityObjectMixin, OrganizationUserMixin, DetailView):
     model = Opportunity
     template_name = "opportunity/dashboard.html"
@@ -543,7 +547,7 @@ class OpportunityDashboard(OpportunityObjectMixin, OrganizationUserMixin, Detail
             {
                 "name": "Max Budget",
                 "count": header_with_tooltip(
-                    f"{object.currency_code} {intcomma(object.total_budget)}",
+                    amount_with_currency(object.total_budget, object.currency_code),
                     "Maximum payments that can be made for workers and organization",
                 ),
                 "icon": "fa-money-bill",
@@ -3334,9 +3338,6 @@ def opportunity_worker_progress(request, org_slug, opp_id):
     earned_percentage = safe_percent(result.total_accrued or 0, result.total_budget or 0)
     paid_percentage = safe_percent(result.total_paid or 0, result.total_accrued or 0)
 
-    def amount_with_currency(amount):
-        return f"{result.currency_code + ' ' if result.currency_code else ''}{intcomma(amount or 0)}"
-
     worker_progress = [
         {
             "title": "Verification",
@@ -3369,7 +3370,9 @@ def opportunity_worker_progress(request, org_slug, opp_id):
             "progress": [
                 {
                     "title": "Earned",
-                    "total": header_with_tooltip(amount_with_currency(result.total_accrued), "Earned Amount"),
+                    "total": header_with_tooltip(
+                        amount_with_currency(result.total_accrued, result.currency_code), "Earned Amount"
+                    ),
                     "value": header_with_tooltip(
                         f"{earned_percentage:.0f}%",
                         "Percentage Earned by all workers out of Max Budget in the Opportunity",
@@ -3380,7 +3383,8 @@ def opportunity_worker_progress(request, org_slug, opp_id):
                 {
                     "title": "Paid",
                     "total": header_with_tooltip(
-                        amount_with_currency(result.total_paid), "Paid Amount to All Connect Workers"
+                        amount_with_currency(result.total_paid, result.currency_code),
+                        "Paid Amount to All Connect Workers",
                     ),
                     "value": header_with_tooltip(
                         f"{paid_percentage:.0f}%", "Percentage Paid to all  workers out of Earned amount"
@@ -3499,7 +3503,7 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
             "panels": deliveries_panels,
         },
         {
-            "title": f"{_('Worker Payments')} ({request.opportunity.currency_code})",
+            "title": _("Worker Payments"),
             "sub_heading": _("Last Payment"),
             "value": stats.recent_payment or "--",
             "panels": [
@@ -3508,7 +3512,8 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
                     "name": _("Payments"),
                     "status": _("Earned"),
                     "value": header_with_tooltip(
-                        intcomma(stats.total_accrued), _("Worker payment accrued based on approved service deliveries")
+                        amount_with_currency(stats.total_accrued, request.opportunity.currency_code),
+                        _("Worker payment accrued based on approved service deliveries"),
                     ),
                     "url": payment_url,
                     "incr": stats.accrued_since_yesterday,
@@ -3518,7 +3523,8 @@ def opportunity_delivery_stats(request, org_slug, opp_id):
                     "name": _("Payments"),
                     "status": _("Due"),
                     "value": header_with_tooltip(
-                        intcomma(stats.payments_due), _("Worker payments earned but yet unpaid")
+                        amount_with_currency(stats.payments_due, request.opportunity.currency_code),
+                        _("Worker payments earned but yet unpaid"),
                     ),
                 },
             ],


### PR DESCRIPTION
## Product Description

| Before | After |
| --- | --- |
| <img width="1800" height="1246" alt="before-dashboard" src="https://github.com/user-attachments/assets/18f661ff-b746-438a-8311-55d65459114a" /> | <img width="1800" height="1246" alt="after-dashboard" src="https://github.com/user-attachments/assets/0c5be612-1161-4365-b818-166746a6a3e8" /> |

## Technical Summary

Ticket: [CI-858](https://dimagi.atlassian.net/browse/CI-858)

## Safety Assurance

### Safety story

Tested locally against the opportunity dashboard with real payment data, comparing before and after screenshots to confirm every amount now renders consistently. The change is display-only: it doesn't touch how budgets or payments are calculated or stored.

### Automated test coverage

No new tests added; existing coverage in `test_helpers.py` for the delivery stats and worker progress views still passes.

### QA Plan

No QA ticket needed, tested manually on local.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-858]: https://dimagi.atlassian.net/browse/CI-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ