### PR TITLE
Fix currency conversion rate for custom invoices

### DIFF
--- a/commcare_connect/opportunity/forms.py
+++ b/commcare_connect/opportunity/forms.py
@@ -1893,20 +1893,18 @@ class AutomatedPaymentInvoiceForm(forms.ModelForm):
             return cleaned_data  # Let individual field errors handle missing values
 
         if not self.is_service_delivery:
-            exchange_rate = ExchangeRate.latest_exchange_rate(self.opportunity.currency_code, date)
+            date_of_expense = cleaned_data.get("date_of_expense")
+            if date_of_expense is None:
+                return cleaned_data  # clean_date_of_expense already raised the relevant error
+
+            exchange_rate = ExchangeRate.latest_exchange_rate(self.opportunity.currency_code, date_of_expense)
             if not exchange_rate:
                 raise ValidationError("Exchange rate not available for selected date.")
 
             cleaned_data["exchange_rate"] = exchange_rate
-            cleaned_data["amount_usd"] = round(amount / exchange_rate.rate, 2)
-
             cleaned_data["title"] = None
             cleaned_data["start_date"] = None
             cleaned_data["end_date"] = None
-
-            exchange_rate = ExchangeRate.latest_exchange_rate(self.opportunity.currency_code, date)
-            if not exchange_rate:
-                raise ValidationError("Exchange rate not available for selected date.")
 
             if cleaned_data.get("usd_currency"):
                 cleaned_data["amount_usd"] = amount

--- a/commcare_connect/opportunity/tests/test_forms.py
+++ b/commcare_connect/opportunity/tests/test_forms.py
@@ -750,6 +750,30 @@ class TestAutomatedPaymentInvoiceForm:
         assert invoice.amount == 100.0
         assert invoice.date == datetime.date(2025, 11, 6)
 
+    def test_custom_invoice_uses_exchange_rate_of_date_of_expense(self, valid_opportunity):
+        ExchangeRateFactory(currency_code=valid_opportunity.currency_code, rate=Decimal("100"), rate_date="2025-08-01")
+        ExchangeRateFactory(currency_code=valid_opportunity.currency_code, rate=Decimal("200"), rate_date="2025-09-01")
+
+        form = AutomatedPaymentInvoiceForm(
+            opportunity=valid_opportunity,
+            invoice_type="custom",
+            data={
+                "date": "2025-09-04",
+                "usd_currency": False,
+                "amount": 100.0,
+                "start_date": None,
+                "end_date": None,
+                "description": "A mandatory description",
+                "title": "",
+                "date_of_expense": "2025-08-17",
+            },
+            is_opportunity_pm=False,
+        )
+        assert form.is_valid(), form.errors
+        invoice = form.save()
+        assert invoice.exchange_rate.rate_date == datetime.date(2025, 8, 1)
+        assert invoice.amount_usd == Decimal("1.00")
+
     @patch("commcare_connect.opportunity.forms.bill_invoice")
     def test_non_service_delivery_form(self, mock_bill_invoice, valid_opportunity):
         ExchangeRateFactory(rate_date="2020-01-01")


### PR DESCRIPTION
## Product Description

Custom invoices now use the currency conversion rate from the actual expense date, instead of whatever date the invoice happened to be filed or edited on.

## Technical Summary


- The exchange rate lookup for custom invoices used the invoice's filing date instead of `date_of_expense`, so editing or reviewing an invoice weeks after the expense pulled the wrong month's rate.
- Also removed a duplicate exchange rate lookup that was doing the same query twice for no reason.

## Safety Assurance

### Safety story

Verified locally that a custom invoice with an August expense date now picks up the August rate even when the invoice itself is dated in September.

### Automated test coverage

Added a test that sets two different exchange rates a month apart and confirms the invoice uses the rate matching `date_of_expense`; existing invoice form tests still pass.

### QA Plan

No QA ticket needed, tested manually on local.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
