### PR TITLE
Skip audit reports for ended, archived, test, or empty opportunities

### DIFF
--- a/commcare_connect/audit/services.py
+++ b/commcare_connect/audit/services.py
@@ -100,13 +100,7 @@ def generate_audit_report_for_opportunity(
     opportunity: Opportunity,
     period_start: datetime.date,
     period_end: datetime.date,
-) -> AuditReport:
-    report = AuditReport.objects.create(
-        opportunity=opportunity,
-        period_start=period_start,
-        period_end=period_end,
-    )
-
+) -> AuditReport | None:
     active_accesses = (
         OpportunityAccess.objects.filter(
             opportunity=opportunity,
@@ -115,6 +109,15 @@ def generate_audit_report_for_opportunity(
         )
         .select_related("user")
         .order_by("user__name")
+    )
+
+    if not active_accesses.exists():
+        return None
+
+    report = AuditReport.objects.create(
+        opportunity=opportunity,
+        period_start=period_start,
+        period_end=period_end,
     )
 
     calcs = calculations.get_registered_calculations()

--- a/commcare_connect/audit/tasks.py
+++ b/commcare_connect/audit/tasks.py
@@ -35,6 +35,9 @@ def generate_audit_reports() -> None:
         Opportunity.objects.filter(
             Q(pk__in=flag.opportunities.values_list("pk", flat=True)) | Q(program__in=flag.programs.all()),
             active=True,
+            archived=False,
+            is_test=False,
+            end_date__gte=period_start,
         )
         .select_related("program__organization")
         .distinct()
@@ -51,7 +54,8 @@ def generate_audit_reports() -> None:
         except Exception:
             logger.exception("Failed to generate weekly report for opportunity %s", opportunity.pk)
             continue
-        generated_reports.append(report)
+        if report is not None:
+            generated_reports.append(report)
 
     try:
         send_new_audit_report_notifications(generated_reports)

--- a/commcare_connect/audit/tests/test_services.py
+++ b/commcare_connect/audit/tests/test_services.py
@@ -81,8 +81,8 @@ def test_generate_report_with_no_active_accesses(opportunity, fixed_calc):
         period_start=datetime.date(2026, 4, 13),
         period_end=datetime.date(2026, 4, 19),
     )
-    assert AuditReport.objects.filter(pk=report.pk).exists()
-    assert AuditReportEntry.objects.filter(audit_report=report).count() == 0
+    assert report is None
+    assert not AuditReport.objects.filter(opportunity=opportunity).exists()
 
 
 @pytest.mark.parametrize(

--- a/commcare_connect/audit/tests/test_tasks.py
+++ b/commcare_connect/audit/tests/test_tasks.py
@@ -9,7 +9,7 @@ from commcare_connect.audit.tasks import generate_audit_reports, send_new_audit_
 from commcare_connect.audit.tests.factories import AuditReportFactory
 from commcare_connect.flags.flag_names import WEEKLY_PERFORMANCE_REPORT
 from commcare_connect.flags.models import Flag
-from commcare_connect.opportunity.tests.factories import OpportunityFactory
+from commcare_connect.opportunity.tests.factories import OpportunityAccessFactory, OpportunityFactory
 from commcare_connect.program.tests.factories import ProgramFactory
 from commcare_connect.users.tests.factories import MembershipFactory, ProgramManagerOrganisationFactory
 
@@ -19,8 +19,9 @@ MONDAY_2AM_UTC = datetime.datetime(2026, 4, 20, 2, 0, tzinfo=datetime.UTC)
 @pytest.mark.django_db
 @mock.patch("commcare_connect.audit.tasks.timezone.now", return_value=MONDAY_2AM_UTC)
 def test_task_generates_reports_only_for_flagged_opportunities(mock_now):
-    flagged_opp = OpportunityFactory()
-    unflagged_opp = OpportunityFactory()  # noqa: F841
+    flagged_opp = OpportunityFactory(is_test=False)
+    OpportunityAccessFactory(opportunity=flagged_opp, accepted=True)
+    unflagged_opp = OpportunityFactory(is_test=False)  # noqa: F841
 
     flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
     flag.opportunities.add(flagged_opp)
@@ -33,9 +34,48 @@ def test_task_generates_reports_only_for_flagged_opportunities(mock_now):
 
 @pytest.mark.django_db
 @mock.patch("commcare_connect.audit.tasks.timezone.now", return_value=MONDAY_2AM_UTC)
+@pytest.mark.parametrize(
+    "opportunity_kwargs, create_access",
+    [
+        pytest.param({"is_test": False, "end_date": datetime.date(2026, 4, 1)}, True, id="ended_before_period"),
+        pytest.param({"is_test": False, "archived": True}, True, id="archived"),
+        pytest.param({"is_test": True}, True, id="test_opportunity"),
+        pytest.param({"is_test": False}, False, id="no_deliveries"),
+    ],
+)
+def test_task_excludes_ineligible_opportunities(mock_now, opportunity_kwargs, create_access):
+    opportunity = OpportunityFactory(**opportunity_kwargs)
+    if create_access:
+        OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+    flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
+    flag.opportunities.add(opportunity)
+
+    generate_audit_reports()
+
+    assert AuditReport.objects.filter(opportunity=opportunity).count() == 0
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.audit.tasks.timezone.now", return_value=MONDAY_2AM_UTC)
+def test_task_still_reports_opportunity_that_ended_mid_period(mock_now):
+    """An opportunity ending partway through the just-completed week still gets a final report."""
+    opportunity = OpportunityFactory(is_test=False, end_date=datetime.date(2026, 4, 16))  # Thursday of that week
+    OpportunityAccessFactory(opportunity=opportunity, accepted=True)
+    flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
+    flag.opportunities.add(opportunity)
+
+    generate_audit_reports()
+
+    assert AuditReport.objects.filter(opportunity=opportunity).count() == 1
+
+
+@pytest.mark.django_db
+@mock.patch("commcare_connect.audit.tasks.timezone.now", return_value=MONDAY_2AM_UTC)
 def test_task_continues_after_single_opportunity_failure(mock_now, caplog):
-    opp_ok = OpportunityFactory()
-    opp_fail = OpportunityFactory()
+    opp_ok = OpportunityFactory(is_test=False)
+    OpportunityAccessFactory(opportunity=opp_ok, accepted=True)
+    opp_fail = OpportunityFactory(is_test=False)
+    OpportunityAccessFactory(opportunity=opp_fail, accepted=True)
     flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
     flag.opportunities.add(opp_ok, opp_fail)
 
@@ -163,7 +203,8 @@ def test_one_org_failure_does_not_block_others(mock_send, caplog):
 @mock.patch("commcare_connect.audit.tasks.timezone.now", return_value=MONDAY_2AM_UTC)
 @mock.patch("commcare_connect.audit.tasks.send_new_audit_report_notifications")
 def test_task_sends_notifications_for_generated_reports(mock_notify, mock_now):
-    opp = OpportunityFactory()
+    opp = OpportunityFactory(is_test=False)
+    OpportunityAccessFactory(opportunity=opp, accepted=True)
     flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
     flag.opportunities.add(opp)
 
@@ -181,7 +222,8 @@ def test_task_sends_notifications_for_generated_reports(mock_notify, mock_now):
     side_effect=RuntimeError("boom"),
 )
 def test_task_survives_notification_failure(mock_notify, mock_now):
-    opp = OpportunityFactory()
+    opp = OpportunityFactory(is_test=False)
+    OpportunityAccessFactory(opportunity=opp, accepted=True)
     flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
     flag.opportunities.add(opp)
 


### PR DESCRIPTION
## Product Description

Weekly audit reports (and their email notifications) are no longer generated for opportunities that have ended, are archived, marked as test, or have no accepted workers.

## Technical Summary

Ticket: [CI-881](https://dimagi.atlassian.net/browse/CI-881)

- `generate_audit_report_for_opportunity` now returns `None` and skips creating a report when an opportunity has no active accesses, instead of creating an empty report with no entries.
- The task filters on `end_date__gte=period_start` rather than an "is active" flag, so an opportunity that ended partway through the just-completed week still gets its final report.

## Safety Assurance

### Safety story

Ran the updated test suite locally and confirmed each exclusion case (ended, archived, test, no deliveries) is skipped while a normal opportunity and one ending mid-period still generate a report.

### Automated test coverage

Added tests for each exclusion case and the mid-period edge case, and updated the existing service/task tests for the new `None` return; all pass.

### QA Plan

 tested manually on local. Will request QA

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-881]: https://dimagi.atlassian.net/browse/CI-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ