### PR TITLE
Scope visit limit counts to payment unit, not deliver unit

### DIFF
--- a/commcare_connect/form_receiver/processor.py
+++ b/commcare_connect/form_receiver/processor.py
@@ -457,7 +457,7 @@ def process_deliver_unit(user, xform: XForm, app: CommCareApp, opportunity: Oppo
             opportunity_claim=claim, payment_unit=payment_unit
         )
         counts = (
-            UserVisit.objects.filter(opportunity_access=access, deliver_unit=deliver_unit)
+            UserVisit.objects.filter(opportunity_access=access, deliver_unit__payment_unit=payment_unit)
             .exclude(status__in=[VisitValidationStatus.over_limit, VisitValidationStatus.trial])
             .aggregate(
                 daily=Count("pk", filter=Q(visit_date__date=xform.metadata.timeStart)),

--- a/commcare_connect/form_receiver/tests/test_receiver_integration.py
+++ b/commcare_connect/form_receiver/tests/test_receiver_integration.py
@@ -304,6 +304,48 @@ def test_receiver_deliver_form_max_visits_reached(
 
 
 @pytest.mark.django_db
+def test_receiver_deliver_form_daily_limit_across_deliver_units(
+    user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
+):
+    # A payment unit's max_daily/max_total limits must be enforced across ALL of its
+    # deliver units combined, not counted independently per deliver unit.
+    oauth_application = opportunity.hq_server.oauth_application
+    payment_unit = PaymentUnitFactory(opportunity=opportunity, max_daily=2, max_total=100)
+    access = OpportunityAccessFactory(user=user_with_connectid_link, opportunity=opportunity, accepted=True)
+    claim = OpportunityClaimFactory(end_date=opportunity.end_date, opportunity_access=access)
+    OpportunityClaimLimit.create_claim_limits(opportunity, claim)
+
+    deliver_unit_a = DeliverUnitFactory(app=opportunity.deliver_app, payment_unit=payment_unit)
+    deliver_unit_b = DeliverUnitFactory(app=opportunity.deliver_app, payment_unit=payment_unit)
+
+    def form_json_for(deliver_unit):
+        stub = DeliverUnitStubFactory(id=deliver_unit.slug)
+        return get_form_json(
+            form_block=stub.json,
+            domain=deliver_unit.app.cc_domain,
+            app_id=deliver_unit.app.cc_app_id,
+        )
+
+    # One visit via A, one via B: combined daily count is now 2, at the payment unit's max_daily.
+    make_request(
+        api_client, form_json_for(deliver_unit_a), user_with_connectid_link, oauth_application=oauth_application
+    )
+    make_request(
+        api_client, form_json_for(deliver_unit_b), user_with_connectid_link, oauth_application=oauth_application
+    )
+    # A third visit, via either deliver unit, should trip over_limit even though neither
+    # deliver unit individually has more than 2 visits.
+    make_request(
+        api_client, form_json_for(deliver_unit_a), user_with_connectid_link, oauth_application=oauth_application
+    )
+
+    user_visits = UserVisit.objects.filter(user=user_with_connectid_link).order_by("id")
+    assert user_visits.count() == 3
+    assert all(v.status != VisitValidationStatus.over_limit for v in user_visits[:2])
+    assert user_visits[2].status == VisitValidationStatus.over_limit
+
+
+@pytest.mark.django_db
 def test_receiver_deliver_form_end_date_reached(
     user_with_connectid_link: User, api_client: APIClient, opportunity: Opportunity
 ):


### PR DESCRIPTION
## Product Description

Fixed a bug where a payment unit's daily and total visit limits weren't being enforced correctly when a payment unit had multiple deliver units. Workers could submit more visits than the configured limit by spreading them across different deliver units under the same payment unit.

## Technical Summary

[CI-739](https://dimagi.atlassian.net/browse/CI-739)

- Visit limit counts were previously scoped per deliver unit; they're now scoped per payment unit, since `max_daily`/`max_total` are payment unit level settings and should count all visits across every deliver unit tied to that payment unit.

## Safety Assurance

### Safety story

The change is a single filter condition (deliver unit to payment unit), verified locally with a new integration test that submits visits across two deliver units under the same payment unit and confirms the combined count trips `over_limit`.

### Automated test coverage

Added an integration test covering visits split across multiple deliver units of one payment unit; existing single-deliver-unit limit tests still pass.

### QA Plan

tested manually on local. Will request QA

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-739]: https://dimagi.atlassian.net/browse/CI-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ