### PR TITLE
Fix invoice USD total rounding drift

### DIFF
--- a/commcare_connect/opportunity/management/commands/backfill_invoice_amount_usd.py
+++ b/commcare_connect/opportunity/management/commands/backfill_invoice_amount_usd.py
@@ -1,0 +1,79 @@
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from commcare_connect.opportunity.models import InvoiceStatus, PaymentInvoice
+from commcare_connect.opportunity.utils.invoice_line_items import (
+    Money,
+    get_invoice_delivery_rows_for_export,
+    group_line_items,
+)
+
+CHUNK_SIZE = 500
+
+
+# TODO One time run command (CI-927). Remove this once it has run.
+class Command(BaseCommand):
+    help = (
+        "Recompute PaymentInvoice.amount_usd for unpaid service-delivery invoices (CI-927). These "
+        "were frozen by summing each delivery's already-rounded USD instead of dividing the exact "
+        "local total once, so the stored total drifts below the correct amount. Local amounts "
+        "(invoice.amount) were not affected and are left alone. Paid invoices are skipped: their "
+        "Payment record already reflects the old total, so this would only make it inconsistent."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true", help="Show what would change without saving.")
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        invoices = (
+            PaymentInvoice.objects.filter(service_delivery=True, payment__isnull=True)
+            .exclude(status__in=[InvoiceStatus.CANCELLED_BY_NM, InvoiceStatus.REJECTED_BY_PM])
+            .order_by("id")
+        )
+        total = invoices.count()
+        self.stdout.write(f"Checking {total} unpaid service-delivery invoice(s)...")
+
+        changed = 0
+        for invoice in invoices.iterator(chunk_size=CHUNK_SIZE):
+            if self._recompute(invoice, dry_run):
+                changed += 1
+
+        prefix = "Dry run. Would update" if dry_run else "Updated"
+        self.stdout.write(self.style.SUCCESS(f"{prefix} {changed}/{total} invoice(s)."))
+
+    def _recompute(self, invoice, dry_run):
+        rows = get_invoice_delivery_rows_for_export(invoice)
+        if not rows:
+            return False
+
+        correct_usd = sum((item.total_pay for item in group_line_items(rows)), Money.zero()).usd
+        if correct_usd == invoice.amount_usd:
+            return False
+
+        old_usd = invoice.amount_usd
+        if dry_run:
+            self._log_change(invoice, old_usd, correct_usd)
+            return True
+
+        with transaction.atomic():
+            # Re-check under lock: a concurrent payment or cancellation since the unlocked read
+            # above would make updating amount_usd here wrong or pointless.
+            locked = (
+                PaymentInvoice.objects.select_for_update(of=("self",))
+                .filter(pk=invoice.pk, payment__isnull=True)
+                .exclude(status__in=[InvoiceStatus.CANCELLED_BY_NM, InvoiceStatus.REJECTED_BY_PM])
+                .first()
+            )
+            if locked is None:
+                return False
+            locked.amount_usd = correct_usd
+            locked.save(update_fields=["amount_usd"])
+
+        self._log_change(invoice, old_usd, correct_usd)
+        return True
+
+    def _log_change(self, invoice, old_usd, correct_usd):
+        self.stdout.write(
+            f"  invoice {invoice.invoice_number} ({invoice.payment_invoice_id}): {old_usd} -> {correct_usd}"
+        )

--- a/commcare_connect/opportunity/management/commands/backfill_invoice_amount_usd.py
+++ b/commcare_connect/opportunity/management/commands/backfill_invoice_amount_usd.py
@@ -75,5 +75,5 @@ class Command(BaseCommand):
 
     def _log_change(self, invoice, old_usd, correct_usd):
         self.stdout.write(
-            f"  invoice {invoice.invoice_number} ({invoice.payment_invoice_id}): {old_usd} -> {correct_usd}"
+            f"  invoice pk={invoice.pk} {invoice.invoice_number} status={invoice.status}: {old_usd} -> {correct_usd}"
         )

--- a/commcare_connect/opportunity/tests/test_invoice_line_items.py
+++ b/commcare_connect/opportunity/tests/test_invoice_line_items.py
@@ -241,6 +241,22 @@ class TestLineItemGrouping:
         # 1 delta for first payment unit, covered in february
         assert by_key[(FEB, payment_unit.name)].number_approved == 1
 
+    def test_group_total_is_not_the_sum_of_per_work_rounded_amounts(self, billing_setup):
+        """CI-927: summing each work's already-rounded USD (27.23 + 5.45, three times over -> 98.04)
+        drifts from the group's true total (360 / 3.6725 -> 98.03). The displayed total must be
+        re-derived from the exact local total at the group's single rate, not accumulated per work."""
+        access, payment_unit = billing_setup
+        access.opportunity.currency = Currency.objects.get(code="KES")
+        access.opportunity.save(update_fields=["currency"])
+        ExchangeRateFactory(currency_code="KES", rate=Decimal("3.6725"), rate_date=date(2020, 1, 1))
+        for _ in range(3):
+            completed_work(access, payment_unit)
+
+        (item,) = group_line_items(billable_rows(access.opportunity, JAN, JAN_END))
+
+        assert item.total_pay.local == Decimal("360")
+        assert item.total_pay.usd == Decimal("98.03")
+
     def test_same_named_payment_units_stay_separate_line_items(self, billing_setup):
         """Grouping is by payment unit id: `name` is not unique within an opportunity, and merging
         two units into one line item would understate the row count and hide one unit's rate."""
@@ -284,19 +300,23 @@ class TestCreateInvoiceLineItems:
         assert work.invoiced_approved_count == approved
 
     @pytest.mark.parametrize(
-        "currency_code, rate, work_count, expected_local, expected_usd",
+        "currency_code, rate, work_count, expected_local, expected_usd, expected_stored_usd_sum",
         [
-            pytest.param("USD", Decimal("1"), 2, Decimal("240"), Decimal("240"), id="usd"),
-            # Each work is 100/3.6725 -> 27.23 plus 20/3.6725 -> 5.45, so 32.68 x 3. Without
-            # per-work rounding this invoice would total 98.03 and stop matching its line items.
-            pytest.param("KES", Decimal("3.6725"), 3, Decimal("360"), Decimal("98.04"), id="kes-rounds-per-work"),
+            pytest.param("USD", Decimal("1"), 2, Decimal("240"), Decimal("240"), Decimal("240"), id="usd"),
+            # Each work is 100/3.6725 -> 27.23 plus 20/3.6725 -> 5.45, so 32.68 x 3 = 98.04 if you
+            # naively sum each work's already-rounded USD (CI-927). The invoice total must instead
+            # be the group's exact local total (360) divided once by the rate -> 98.03.
+            pytest.param(
+                "KES", Decimal("3.6725"), 3, Decimal("360"), Decimal("98.03"), Decimal("98.04"), id="kes-per-work"
+            ),
         ],
     )
-    def test_invoice_totals_equal_the_sum_of_the_frozen_rows(
-        self, billing_setup, currency_code, rate, work_count, expected_local, expected_usd
+    def test_invoice_total_is_not_the_sum_of_the_frozen_rows_usd(
+        self, billing_setup, currency_code, rate, work_count, expected_local, expected_usd, expected_stored_usd_sum
     ):
-        """USD amounts are rounded per work before summing, so an invoice total can never drift from
-        the line items stored against it."""
+        """CI-927: the invoice's USD total is re-derived from the exact local total at the billed
+        rate, not accumulated from each frozen row's already-rounded USD -- that sum drifts further
+        from the true total the more works an invoice bills."""
         access, payment_unit = billing_setup
         if currency_code != "USD":
             access.opportunity.currency = Currency.objects.get(code=currency_code)
@@ -315,7 +335,9 @@ class TestCreateInvoiceLineItems:
             usd=Sum("flw_amount_usd") + Sum("org_amount_usd"),
         )
         assert invoice.amount == stored["local"]
-        assert invoice.amount_usd == stored["usd"]
+        # The frozen per-work rows still each round individually (they're each one delivery's real
+        # value); naively summing them is the exact drift this fix avoids at the invoice level.
+        assert stored["usd"] == expected_stored_usd_sum
 
     def test_leaves_the_billing_window_alone(self, billing_setup):
         """The window is the caller's input — an NM types it — so nothing here may narrow it to the
@@ -514,6 +536,22 @@ class TestInvoicedLineItems:
         invoice = PaymentInvoiceFactory(opportunity=access.opportunity, service_delivery=True, end_date=FEB_END)
 
         assert get_invoice_line_items(invoice) == []
+
+    def test_frozen_group_total_is_not_the_sum_of_per_work_rounded_amounts(self, billing_setup):
+        """CI-927, same drift as the preview (see TestLineItemGrouping) but read back from the
+        frozen `CompletedWorkInvoice` rows shown on the invoice review page."""
+        access, payment_unit = billing_setup
+        access.opportunity.currency = Currency.objects.get(code="KES")
+        access.opportunity.save(update_fields=["currency"])
+        ExchangeRateFactory(currency_code="KES", rate=Decimal("3.6725"), rate_date=date(2020, 1, 1))
+        for _ in range(3):
+            completed_work(access, payment_unit)
+        invoice = billed_invoice(access.opportunity)
+
+        (item,) = get_invoice_line_items(invoice)
+
+        assert item.total_pay.local == Decimal("360")
+        assert item.total_pay.usd == Decimal("98.03")
 
 
 @pytest.mark.django_db

--- a/commcare_connect/opportunity/utils/invoice_line_items.py
+++ b/commcare_connect/opportunity/utils/invoice_line_items.py
@@ -99,7 +99,9 @@ class WorkPayRow:
 
     @property
     def total_pay(self) -> Money:
-        return self.flw_pay + self.org_pay
+        # Re-derived from the exact local total, not flw_pay.usd + org_pay.usd -- summing two
+        # independently-rounded USD amounts can drift a cent from a single division of the total.
+        return Money.from_local_amount(self.flw_pay.local + self.org_pay.local, self.exchange_rate.rate)
 
 
 def _build_billable_rows(works, currency_code, end_date):
@@ -146,7 +148,8 @@ class LineItem:
 
     @property
     def total_pay(self) -> Money:
-        return self.flw_pay + self.org_pay
+        # Re-derived from the exact local total, not flw_pay.usd + org_pay.usd -- see WorkPayRow.total_pay.
+        return Money.from_local_amount(self.flw_pay.local + self.org_pay.local, self.exchange_rate)
 
 
 def group_line_items(rows):
@@ -171,6 +174,13 @@ def group_line_items(rows):
             group["late_delta_units"] += row.billed_count
         group["flw_pay"] += row.flw_pay
         group["org_pay"] += row.org_pay
+
+    for group in groups.values():
+        # Re-derive USD from the exact local total at this group's single rate, rather than
+        # summing each row's already-rounded USD -- summed roundings drift from the true total.
+        rate = group["exchange_rate"]
+        group["flw_pay"] = Money.from_local_amount(group["flw_pay"].local, rate)
+        group["org_pay"] = Money.from_local_amount(group["org_pay"].local, rate)
 
     def display_order(entry):
         (month, _), group = entry
@@ -198,8 +208,6 @@ def get_invoice_line_items(invoice):
             late_delta_units=Coalesce(Sum("billed_count", filter=Q(is_delta=True)), 0),
             flw_local=Sum("flw_amount_local"),
             org_local=Sum("org_amount_local"),
-            flw_usd=Sum("flw_amount_usd"),
-            org_usd=Sum("org_amount_usd"),
             # Every row in a (month, currency) group was priced at the same rate; Max collapses them.
             rate=Max("exchange_rate__rate"),
             rate_date=Max("exchange_rate__rate_date"),
@@ -214,8 +222,9 @@ def get_invoice_line_items(invoice):
             payment_unit_name=record["payment_unit_name"],
             number_approved=record["number_approved"],
             late_delta_units=record["late_delta_units"],
-            flw_pay=Money(record["flw_local"], record["flw_usd"]),
-            org_pay=Money(record["org_local"], record["org_usd"]),
+            # Re-derived from the exact local total at this group's single rate -- see group_line_items.
+            flw_pay=Money.from_local_amount(record["flw_local"], record["rate"]),
+            org_pay=Money.from_local_amount(record["org_local"], record["rate"]),
             exchange_rate=record["rate"],
             exchange_rate_date=record["rate_date"],
             exchange_rate_fetched_at=record["rate_fetched_at"],
@@ -370,7 +379,10 @@ def _freeze_line_items(invoice, rows):
     invoice.exchange_rate = ExchangeRate.latest_exchange_rate(
         invoice.opportunity.currency_code, max(row.month for row in rows)
     )
-    total = sum(row.total_pay for row in rows)
+    # Sum each (month, payment unit) group's own precisely-derived total (local total divided once
+    # by that group's rate), not each individual delivery's already-rounded USD -- summing those
+    # directly drifts further from the true total the more deliveries the invoice bills.
+    total = sum((item.total_pay for item in group_line_items(rows)), Money.zero())
     invoice.amount = total.local
     invoice.amount_usd = total.usd
     invoice.save()


### PR DESCRIPTION
## Product Description

The invoice review page was showing a Total Pay (USD) that was slightly too low for payment types with many deliveries. This fix corrects the displayed total, and a follow-up command corrects the stored total on existing unpaid invoices.

## Technical Summary

[CI-927](https://dimagi.atlassian.net/browse/CI-927)

- Each delivery's pay is rounded to USD individually when it's frozen, and summing hundreds of those already-rounded cents drifts below the true total. The fix re-derives every total (per work, per group, and the invoice as a whole) from the exact local amount divided once by the group's rate, instead of adding up rows that were each rounded on their own.
- Applies at three places that compute a total: the unfrozen preview line items, the frozen invoice line items shown on the review page, and the invoice's own `amount_usd` field.
- Added `backfill_invoice_amount_usd` to correct `amount_usd` on invoices that were already frozen with the old, drifted total. It only touches unpaid, non-cancelled/rejected service-delivery invoices, since a paid invoice's `Payment` record already reflects the old total and rewriting it afterward would just make the two disagree. Supports `--dry-run`.

## Safety Assurance

### Safety story

The frozen per-work data is untouched, so there's no data migration or risk to existing invoice records. The code change only affects how totals are computed for display and for the invoice's stored `amount_usd`. The backfill command is scoped to unpaid invoices only and re-checks under a row lock that an invoice is still unpaid before writing, so a concurrent payment or cancellation can't race it. I verified both the new totals and the backfill's output against the exact math from the ticket's example, and dry-ran the command locally before writing this.

### Automated test coverage

Added and updated tests in `test_invoice_line_items.py` covering the group, frozen-invoice, and invoice-total cases with a currency conversion example matching this ticket's drift; all pass locally. The backfill command itself is a one-time script and isn't covered by automated tests.

### QA Plan

tested manually on local. Will request QA

### Deployment

- This PR can be deployed on its own, but `amount_usd` on invoices that were already frozen before this deploy will still show the old drifted total until `./manage.py backfill_invoice_amount_usd` is run. Run it (optionally with `--dry-run` first) against production once this is deployed.

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-927]: https://dimagi.atlassian.net/browse/CI-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ