### PR TITLE
Remove invoice status and paid fields from invoice PDF

### DIFF
--- a/commcare_connect/templates/opportunity/invoice_download.html
+++ b/commcare_connect/templates/opportunity/invoice_download.html
@@ -97,15 +97,6 @@
         <p>{% trans "Invoice number" %}: {{ invoice.invoice_number }}</p>
         <p>{% trans "Invoice date" %}: {{ invoice.date|default:"" }}</p>
         <p>{% trans "Payment terms" %}: {% trans "Net 30" %}</p>
-        <p>{% trans "Invoice status" %}: {{ invoice.get_status_display }}</p>
-        <p>
-          {% trans "Paid" %}:
-          {% if invoice.is_paid %}
-            {% trans "Paid" %}
-          {% else %}
-            {% trans "Pending" %}
-          {% endif %}
-        </p>
         {% if invoice.is_paid %}
           <p>{% trans "Payment date" %}: {{ invoice.payment.date_paid }}</p>
         {% endif %}


### PR DESCRIPTION
## Product Description

The downloaded invoice PDF no longer shows the invoice status or paid/pending state in the header; the payment date is still shown once an invoice is paid.

## Technical Summary

[CCCT-2736](https://dimagi.atlassian.net/browse/CCCT-2736)

- Feedback came on connect demo channel.

## Safety Assurance

### Safety story

Pure template change removing two display lines; verified locally that the invoice PDF still renders correctly and the payment date still appears for paid invoices.

### Automated test coverage

No test changes needed, this is a display-only template edit.

### QA Plan

No QA ticket needed, tested manually on local.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2736]: https://dimagi.atlassian.net/browse/CCCT-2736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ