### PR TITLE
Repair drifted lint gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -20,7 +20,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v3.1.0
     hooks:
       - id: prettier
         args: ['--tab-width', '2', '--single-quote']
@@ -41,14 +41,14 @@ repos:
         args: ['--target-version', '5.2']
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: v0.16.6
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.8.0
+    rev: v10.10.0
     hooks:
       - id: eslint
         files: commcare_connect/static/.*\.js$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,10 +35,10 @@ repos:
         exclude: commcare_connect/templates/prelogin/home.html
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: '1.13.0'
+    rev: '1.32.0'
     hooks:
       - id: django-upgrade
-        args: ['--target-version', '4.1']
+        args: ['--target-version', '5.2']
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         files: commcare_connect/static/.*\.js$
         exclude: commcare_connect/static/bundles/
         additional_dependencies:
-          - eslint@10.8.0
+          - eslint@10.10.0
           - '@eslint/js@10.0.1'
           - globals@17.8.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,12 +40,6 @@ repos:
       - id: django-upgrade
         args: ['--target-version', '5.2']
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
-    hooks:
-      - id: pyupgrade
-        args: [--py311-plus]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.17
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ celery -A config.celery_app worker -B -l info
 pytest                              # run all tests
 pytest path/to/test_file.py::test_name  # run single test
 
-# Linting (runs ruff, ruff-format, pyupgrade, django-upgrade, prettier)
+# Linting (runs ruff, ruff-format, django-upgrade, prettier, djlint, eslint)
 prek run -a
 
 # Requirements (uv)
@@ -76,7 +76,7 @@ config/
 
 - **Python**: ruff for linting, formatting, and import sorting (line length 119, target py311)
 - **JS/CSS**: prettier (tab-width 2, single-quote). Templates excluded from prettier
-- **prek hooks enforce all of the above** (reading `.pre-commit-config.yaml`) plus pyupgrade (--py311-plus) and django-upgrade (--target-version 4.1)
+- **prek hooks enforce all of the above** (reading `.pre-commit-config.yaml`) plus django-upgrade (--target-version 5.2); ruff's UP rules cover what pyupgrade used to
 - Django models should extend `BaseModel` from `commcare_connect/utils/db.py` (provides `created_by`, `modified_by`, `date_created`, `date_modified`)
 - Custom `User` model uses single `name` field instead of `first_name`/`last_name`
 - **Single Responsibility**: Functions should do one thing (or a few closely related things). If a function is doing too much, split it

--- a/commcare_connect/audit/chc_indicators.py
+++ b/commcare_connect/audit/chc_indicators.py
@@ -506,7 +506,7 @@ def _muac_no_skipped_bins(bin_counts, total_count) -> bool:
     sig = [i for i, c in enumerate(bin_counts) if c >= threshold]
     if len(sig) <= 1:
         return True
-    return all(c != 0 for c in bin_counts[sig[0] : sig[-1] + 1])  # noqa: E203
+    return all(c != 0 for c in bin_counts[sig[0] : sig[-1] + 1])
 
 
 def _muac_no_plateau(bin_counts, max_count) -> bool:
@@ -526,7 +526,7 @@ def _muac_no_plateau(bin_counts, max_count) -> bool:
     plateau_start = 0
     for i in range(1, len(high_bins)):
         if high_bins[i][0] == high_bins[i - 1][0] + 1:
-            segment = high_bins[plateau_start : i + 1]  # noqa: E203
+            segment = high_bins[plateau_start : i + 1]
             segment_counts = [x[1] for x in segment]
             if max(segment_counts) - min(segment_counts) <= tolerance:
                 longest_plateau = max(longest_plateau, len(segment))

--- a/commcare_connect/audit/tests/test_chc_indicators.py
+++ b/commcare_connect/audit/tests/test_chc_indicators.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import random
-from datetime import timezone
 
 import pytest
 
@@ -27,9 +26,9 @@ from commcare_connect.opportunity.tests.factories import DeliverUnitFactory, Opp
 
 PERIOD_START = datetime.date(2026, 4, 13)  # Monday
 PERIOD_END = datetime.date(2026, 4, 19)  # Sunday
-IN_PERIOD = datetime.datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
-OUT_OF_PERIOD = datetime.datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-AFTER_PERIOD = datetime.datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+IN_PERIOD = datetime.datetime(2026, 4, 15, 12, 0, tzinfo=datetime.UTC)
+OUT_OF_PERIOD = datetime.datetime(2026, 4, 5, 12, 0, tzinfo=datetime.UTC)
+AFTER_PERIOD = datetime.datetime(2026, 4, 25, 12, 0, tzinfo=datetime.UTC)
 
 
 def make_visit(access, work_area=None, visit_date=IN_PERIOD, **kwargs):

--- a/commcare_connect/audit/tests/test_tasks.py
+++ b/commcare_connect/audit/tests/test_tasks.py
@@ -20,7 +20,7 @@ MONDAY_2AM_UTC = datetime.datetime(2026, 4, 20, 2, 0, tzinfo=datetime.UTC)
 @mock.patch("commcare_connect.audit.tasks.timezone.now", return_value=MONDAY_2AM_UTC)
 def test_task_generates_reports_only_for_flagged_opportunities(mock_now):
     flagged_opp = OpportunityFactory()
-    unflagged_opp = OpportunityFactory()  # noqa: F841
+    unflagged_opp = OpportunityFactory()
 
     flag, _ = Flag.objects.get_or_create(name=WEEKLY_PERFORMANCE_REPORT)
     flag.opportunities.add(flagged_opp)

--- a/commcare_connect/commcarehq/api.py
+++ b/commcare_connect/commcarehq/api.py
@@ -143,10 +143,7 @@ def bulk_create_or_update_cases(
     cases = []
     with httpx.Client(headers=headers) as client:
         for i in range(0, len(cases_data), HQ_CASE_BULK_CHUNK_SIZE):
-            chunk = [
-                {**case_data, "create": create}
-                for case_data in cases_data[i : i + HQ_CASE_BULK_CHUNK_SIZE]  # noqa: E203
-            ]
+            chunk = [{**case_data, "create": create} for case_data in cases_data[i : i + HQ_CASE_BULK_CHUNK_SIZE]]
             try:
                 response = client.post(url, json=chunk)
                 response.raise_for_status()

--- a/commcare_connect/form_receiver/tests/xforms.py
+++ b/commcare_connect/form_receiver/tests/xforms.py
@@ -40,53 +40,40 @@ MOCK_FORM = {
     },
 }
 
-MODULE_XML_TEMPLATE = (
-    """<data>
-<module xmlns="%s" id="{id}">
+MODULE_XML_TEMPLATE = """<data>
+<module xmlns="{xmlns}" id="{id}">
     <name>{name}</name>
     <description>{description}</description>
     <time_estimate>{time_estimate}</time_estimate>
 </module>
 </data>
 """
-    % CCC_LEARN_XMLNS
-)
 
-TASK_XML_TEMPLATE = (
-    """<data>
-<task xmlns="%s" id="{id}">
+TASK_XML_TEMPLATE = """<data>
+<task xmlns="{xmlns}" id="{id}">
     <name>{name}</name>
     <description>{description}</description>
 </task>
 </data>
 """
-    % CCC_LEARN_XMLNS
-)
 
-ASSESSMENT_XML_TEMPLATE = (
-    """<data>
-<assessment xmlns="%s" id="{id}">
+ASSESSMENT_XML_TEMPLATE = """<data>
+<assessment xmlns="{xmlns}" id="{id}">
     <user_score>{score}</user_score>
 </assessment>
 </data>"""
-    % CCC_LEARN_XMLNS
-)
 
-DELIVER_UNIT_XML_TEMPLATE = (
-    """<data>
-<deliver xmlns="%s" id="{id}">
+DELIVER_UNIT_XML_TEMPLATE = """<data>
+<deliver xmlns="{xmlns}" id="{id}">
     <name>{name}</name>
     <entity_id>{entity_id}</entity_id>
     <entity_name>{entity_name}</entity_name>
     <work_area_id>{work_area_id}</work_area_id>
 </deliver>
 </data>"""
-    % CCC_LEARN_XMLNS
-)
 
-WORK_AREA_UPDATE_XML_TEMPLATE = (
-    """<data>
-<work_area_update xmlns="%s" id="{id}">
+WORK_AREA_UPDATE_XML_TEMPLATE = """<data>
+<work_area_update xmlns="{xmlns}" id="{id}">
     <work_area_id>{work_area_id}</work_area_id>
     <status>{status}</status>
     <reason>{reason}</reason>
@@ -94,8 +81,6 @@ WORK_AREA_UPDATE_XML_TEMPLATE = (
     <additional_details>{additional_details}</additional_details>
 </work_area_update>
 </data>"""
-    % CCC_LEARN_XMLNS
-)
 
 
 def get_form_json(xmlns=DEFAULT_XMLNS, form_block=None, **kwargs):
@@ -123,7 +108,11 @@ class LearnModuleJsonFactory(factory.StubFactory):
     @factory.lazy_attribute
     def json(self):
         xml = MODULE_XML_TEMPLATE.format(
-            id=self.id, name=self.name, description=self.description, time_estimate=self.time_estimate
+            xmlns=CCC_LEARN_XMLNS,
+            id=self.id,
+            name=self.name,
+            description=self.description,
+            time_estimate=self.time_estimate,
         )
         _, module = xml2json(xml)
         return module
@@ -136,7 +125,7 @@ class TaskJsonFactory(factory.StubFactory):
 
     @factory.lazy_attribute
     def json(self):
-        xml = TASK_XML_TEMPLATE.format(id=self.id, name=self.name, description=self.description)
+        xml = TASK_XML_TEMPLATE.format(xmlns=CCC_LEARN_XMLNS, id=self.id, name=self.name, description=self.description)
         _, task = xml2json(xml)
         return task
 
@@ -147,7 +136,7 @@ class AssessmentStubFactory(factory.StubFactory):
 
     @factory.lazy_attribute
     def json(self):
-        xml = ASSESSMENT_XML_TEMPLATE.format(id=self.id, score=self.score)
+        xml = ASSESSMENT_XML_TEMPLATE.format(xmlns=CCC_LEARN_XMLNS, id=self.id, score=self.score)
         _, module = xml2json(xml)
         return module
 
@@ -162,6 +151,7 @@ class DeliverUnitStubFactory(factory.StubFactory):
     @factory.lazy_attribute
     def json(self):
         xml = DELIVER_UNIT_XML_TEMPLATE.format(
+            xmlns=CCC_LEARN_XMLNS,
             id=self.id,
             name=self.name,
             entity_id=self.entity_id,
@@ -183,6 +173,7 @@ class WorkAreaUpdateStubFactory(factory.StubFactory):
     @factory.lazy_attribute
     def json(self):
         xml = WORK_AREA_UPDATE_XML_TEMPLATE.format(
+            xmlns=CCC_LEARN_XMLNS,
             id=self.id,
             work_area_id=self.work_area_id,
             status=self.status,

--- a/commcare_connect/microplanning/helpers.py
+++ b/commcare_connect/microplanning/helpers.py
@@ -152,7 +152,7 @@ def exclude_work_areas_for_opportunity(opportunity, work_area_ids, user, exclusi
     pghistory_ctx = dict(reason=exclusion_reason, username=user.username, user_email=user.email)
 
     for i in range(0, len(needs_hq), HQ_BULK_CHUNK_SIZE):
-        chunk = needs_hq[i : i + HQ_BULK_CHUNK_SIZE]  # noqa: E203
+        chunk = needs_hq[i : i + HQ_BULK_CHUNK_SIZE]
         # HQ's "unassigned" convention is "-"; empty string falls back to the submitting user.
         updates = [{"case_id": str(wa.case_id), "owner_id": "-"} for wa in chunk]
         try:

--- a/commcare_connect/microplanning/tests/test_views.py
+++ b/commcare_connect/microplanning/tests/test_views.py
@@ -4,7 +4,7 @@ import csv as csv_mod
 import io
 import json
 import uuid
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
@@ -379,13 +379,13 @@ class TestWorkAreaBoundsView(BaseMicroplanningFlagTest):
                 opportunity=opportunity,
                 user=access.user,
                 work_area=in_range,
-                visit_date=datetime(2025, 6, 1, tzinfo=timezone.utc),
+                visit_date=datetime(2025, 6, 1, tzinfo=UTC),
             )
         UserVisitFactory(
             opportunity=opportunity,
             user=access.user,
             work_area=out_of_range,
-            visit_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            visit_date=datetime(2025, 1, 1, tzinfo=UTC),
         )
 
         bounds = self.get_bounds(
@@ -1401,12 +1401,12 @@ class TestDownloadWorkAreas(BaseMicroplanningFlagTest):
         UserVisitFactory(
             opportunity=opportunity,
             work_area=wa_with_visit,
-            visit_date=datetime(2025, 6, 15, tzinfo=timezone.utc),
+            visit_date=datetime(2025, 6, 15, tzinfo=UTC),
         )
         UserVisitFactory(
             opportunity=opportunity,
             work_area=wa_without_visit,
-            visit_date=datetime(2025, 3, 1, tzinfo=timezone.utc),
+            visit_date=datetime(2025, 3, 1, tzinfo=UTC),
         )
         client.force_login(org_user_admin)
 

--- a/commcare_connect/opportunity/app_xml.py
+++ b/commcare_connect/opportunity/app_xml.py
@@ -12,7 +12,7 @@ from commcare_connect.opportunity.models import CommCareApp
 from commcare_connect.utils.commcarehq_api import CommCareHQAPIException
 
 XMLNS = "http://commcareconnect.com/data/v1/learn"
-XMLNS_PREFIX = "{%s}" % XMLNS
+XMLNS_PREFIX = f"{{{XMLNS}}}"
 
 
 @dataclass

--- a/commcare_connect/opportunity/management/commands/download_attachments.py
+++ b/commcare_connect/opportunity/management/commands/download_attachments.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
         processed = 0
 
         for start in range(0, total, chunk_size):
-            batch_ids = visit_ids[start : start + chunk_size]  # noqa: E203
+            batch_ids = visit_ids[start : start + chunk_size]
             for visit_id in batch_ids:
                 processed += 1
                 error = self._download_visit_with_retries(visit_id, processed, total, max_retries, delay)
@@ -127,7 +127,7 @@ class Command(BaseCommand):
         for attempt in range(1, max_retries + 1):
             try:
                 download_user_visit_attachments.run(visit_id)
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 if attempt >= max_retries:
                     self.stderr.write(
                         self.style.ERROR(

--- a/commcare_connect/opportunity/models.py
+++ b/commcare_connect/opportunity/models.py
@@ -318,7 +318,7 @@ class TaskType(models.Model):
     is_active = models.BooleanField(default=True)
     duration = models.IntegerField(null=True, blank=True)
     mode = models.CharField(
-        choices=TaskTypeModeChoices.choices,
+        choices=TaskTypeModeChoices,
         default=TaskTypeModeChoices.RELEARN,
         max_length=CHOICE_FIELD_MAX_LENGTH,
     )
@@ -476,7 +476,7 @@ class AssignedTask(XFormBaseModel):
     duration = models.DurationField(null=True)
     xform_id = models.CharField(max_length=50, null=True)
     status = models.CharField(
-        choices=AssignedTaskStatus.choices,
+        choices=AssignedTaskStatus,
         default=AssignedTaskStatus.ASSIGNED,
         max_length=CHOICE_FIELD_MAX_LENGTH,
     )
@@ -757,7 +757,7 @@ class PaymentInvoice(models.Model):
     description = models.TextField(null=True, blank=True)
     date_of_expense = models.DateField(null=True, blank=True)
     status = models.CharField(
-        choices=InvoiceStatus.choices, default=InvoiceStatus.PENDING_NM_REVIEW, max_length=CHOICE_FIELD_MAX_LENGTH
+        choices=InvoiceStatus, default=InvoiceStatus.PENDING_NM_REVIEW, max_length=CHOICE_FIELD_MAX_LENGTH
     )
     archived_date = models.DateTimeField(null=True, blank=True)
     invoice_ticket_link = models.URLField(null=True, blank=True)
@@ -842,7 +842,7 @@ class CompletedWork(models.Model):
     opportunity_access = models.ForeignKey(OpportunityAccess, on_delete=models.CASCADE)
     payment_unit = models.ForeignKey(PaymentUnit, on_delete=models.DO_NOTHING)
     status = models.CharField(
-        max_length=CHOICE_FIELD_MAX_LENGTH, choices=CompletedWorkStatus.choices, default=CompletedWorkStatus.incomplete
+        max_length=CHOICE_FIELD_MAX_LENGTH, choices=CompletedWorkStatus, default=CompletedWorkStatus.incomplete
     )
     last_modified = models.DateTimeField(auto_now=True)
     entity_id = models.CharField(max_length=255, null=True, blank=True)
@@ -1035,7 +1035,7 @@ class UserVisit(XFormBaseModel):
     visit_date = models.DateTimeField()
     status = models.CharField(
         max_length=CHOICE_FIELD_MAX_LENGTH,
-        choices=VisitValidationStatus.choices,
+        choices=VisitValidationStatus,
         default=VisitValidationStatus.pending,
     )
     form_json = models.JSONField()
@@ -1052,7 +1052,7 @@ class UserVisit(XFormBaseModel):
     )
     status_modified_date = models.DateTimeField(null=True, default=now)
     review_status = models.CharField(
-        max_length=CHOICE_FIELD_MAX_LENGTH, choices=VisitReviewStatus.choices, default=VisitReviewStatus.pending
+        max_length=CHOICE_FIELD_MAX_LENGTH, choices=VisitReviewStatus, default=VisitReviewStatus.pending
     )
     review_status_modified_date = models.DateTimeField(blank=True, null=True, default=now)
     review_created_on = models.DateTimeField(blank=True, null=True)
@@ -1220,7 +1220,7 @@ class UserInvite(models.Model):
     opportunity_access = models.OneToOneField(OpportunityAccess, on_delete=models.CASCADE, null=True, blank=True)
     message_sid = models.CharField(max_length=50, null=True, blank=True)
     status = models.CharField(
-        max_length=CHOICE_FIELD_MAX_LENGTH, choices=UserInviteStatus.choices, default=UserInviteStatus.invited
+        max_length=CHOICE_FIELD_MAX_LENGTH, choices=UserInviteStatus, default=UserInviteStatus.invited
     )
     notification_date = models.DateTimeField(null=True)
 

--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -509,7 +509,7 @@ class PaymentInvoiceTable(OpportunityContextTable):
                         {disabled}>
                         {_("Pay")}
                     </button>
-                """  # noqa: E501
+                """
         return mark_safe(f'<div class="flex gap-2">{review_button}{pay_button}</div>')
 
 
@@ -1405,7 +1405,7 @@ class WorkerLearnTable(OrgContextTable):
         accessor="modules_completed_percentage",
         template_code="""
             {% include "components/progressbar/simple-progressbar.html" with text=flag percentage=value|default:0 %}
-        """,  # noqa: E501
+        """,
     )
     completed_learning = DMYTColumn(accessor="completed_learn_date", verbose_name="Completed Learning")
     assessment = tables.Column(accessor="assessment_status_rank")

--- a/commcare_connect/opportunity/tests/factories.py
+++ b/commcare_connect/opportunity/tests/factories.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta, timezone
+from datetime import UTC, date, timedelta
 
 from factory import DictFactory, Faker, LazyAttribute, LazyFunction, SelfAttribute, SubFactory
 from factory.django import DjangoModelFactory
@@ -138,8 +138,8 @@ class UserVisitFactory(DjangoModelFactory):
     opportunity_access = SubFactory(OpportunityAccessFactory)
     deliver_unit = SubFactory(DeliverUnitFactory)
     status = Faker("enum", enum_cls=VisitValidationStatus)
-    visit_date = Faker("date_time", tzinfo=timezone.utc)
-    date_created = Faker("date_time", tzinfo=timezone.utc)
+    visit_date = Faker("date_time", tzinfo=UTC)
+    date_created = Faker("date_time", tzinfo=UTC)
     form_json = Faker("pydict", value_types=[str, int, float, bool])
     xform_id = Faker("uuid4")
     completed_work = SubFactory(CompletedWorkFactory)
@@ -180,7 +180,7 @@ class CompletedModuleFactory(DjangoModelFactory):
     opportunity = SubFactory(OpportunityFactory)
     user = SubFactory("commcare_connect.users.tests.factories.UserFactory")
     opportunity_access = SubFactory(OpportunityAccessFactory)
-    date = Faker("date_time", tzinfo=timezone.utc)
+    date = Faker("date_time", tzinfo=UTC)
     module = SubFactory(LearnModuleFactory, app=SelfAttribute("..opportunity.learn_app"))
     duration = Faker("time_delta")
 
@@ -196,7 +196,7 @@ class AssessmentFactory(DjangoModelFactory):
     passed = True
     score = Faker("pyint", min_value=75, max_value=100)
     passing_score = Faker("pyint", min_value=1, max_value=50)
-    date = Faker("date_time", tzinfo=timezone.utc)
+    date = Faker("date_time", tzinfo=UTC)
 
     class Meta:
         model = "opportunity.Assessment"
@@ -253,7 +253,7 @@ class DeliveryTypeFactory(DjangoModelFactory):
 class PaymentFactory(DjangoModelFactory):
     opportunity_access = SubFactory(OpportunityAccessFactory)
     amount = Faker("pydecimal", min_value=1, max_value=10000)
-    date_paid = Faker("date_time", tzinfo=timezone.utc)
+    date_paid = Faker("date_time", tzinfo=UTC)
 
     class Meta:
         model = "opportunity.Payment"
@@ -262,7 +262,7 @@ class PaymentFactory(DjangoModelFactory):
 class PaymentInvoiceFactory(DjangoModelFactory):
     opportunity = SubFactory(OpportunityFactory)
     amount = Faker("pydecimal", min_value=0, max_value=1000)
-    date = Faker("date_time", tzinfo=timezone.utc)
+    date = Faker("date_time", tzinfo=UTC)
     invoice_number = Faker("pystr")
 
     class Meta:
@@ -282,7 +282,7 @@ class TaskTypeFactory(DjangoModelFactory):
 class AssignedTaskFactory(DjangoModelFactory):
     task_type = SubFactory(TaskTypeFactory)
     opportunity_access = SubFactory(OpportunityAccessFactory)
-    completed_at = Faker("date_time", tzinfo=timezone.utc)
+    completed_at = Faker("date_time", tzinfo=UTC)
     duration = LazyFunction(lambda: timedelta(hours=1))
     status = AssignedTaskStatus.ASSIGNED
     due_date = LazyFunction(lambda: date.today() + timedelta(days=7))
@@ -295,7 +295,7 @@ class AssignedTaskFactory(DjangoModelFactory):
 class ExchangeRateFactory(DjangoModelFactory):
     currency_code = "USD"
     rate = 1.0
-    rate_date = Faker("date_time", tzinfo=timezone.utc)
+    rate_date = Faker("date_time", tzinfo=UTC)
 
     class Meta:
         model = "opportunity.ExchangeRate"

--- a/commcare_connect/opportunity/tests/test_cleanup_historical_exports.py
+++ b/commcare_connect/opportunity/tests/test_cleanup_historical_exports.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from io import StringIO
 from unittest import mock
 
@@ -57,7 +57,7 @@ class TestCleanupHistoricalExportsCommand:
     @mock.patch("commcare_connect.opportunity.management.commands.cleanup_historical_exports.boto3")
     def test_dry_run_does_not_delete(self, mock_boto3, settings):
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
-        old_date = datetime.now(timezone.utc) - timedelta(days=60)
+        old_date = datetime.now(UTC) - timedelta(days=60)
         mock_bucket = mock.MagicMock()
         mock_boto3.resource.return_value.Bucket.return_value = mock_bucket
         mock_bucket.objects.filter.return_value = [
@@ -73,8 +73,8 @@ class TestCleanupHistoricalExportsCommand:
     @mock.patch("commcare_connect.opportunity.management.commands.cleanup_historical_exports.boto3")
     def test_deletes_matching_old_files(self, mock_boto3, settings):
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
-        old_date = datetime.now(timezone.utc) - timedelta(days=60)
-        recent_date = datetime.now(timezone.utc) - timedelta(days=5)
+        old_date = datetime.now(UTC) - timedelta(days=60)
+        recent_date = datetime.now(UTC) - timedelta(days=5)
         mock_bucket = mock.MagicMock()
         mock_boto3.resource.return_value.Bucket.return_value = mock_bucket
         mock_bucket.objects.filter.return_value = [

--- a/commcare_connect/opportunity/tests/test_invoice_line_items.py
+++ b/commcare_connect/opportunity/tests/test_invoice_line_items.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from decimal import ROUND_HALF_EVEN, Decimal
 
 import pytest
@@ -39,9 +39,9 @@ FEB = date(2026, 2, 1)
 FEB_END = date(2026, 2, 28)
 MAR = date(2026, 3, 1)
 MAR_END = date(2026, 3, 31)
-JAN_APPROVAL = datetime(2026, 1, 15, tzinfo=timezone.utc)
-FEB_APPROVAL = datetime(2026, 2, 20, tzinfo=timezone.utc)
-APR_APPROVAL = datetime(2026, 4, 2, tzinfo=timezone.utc)
+JAN_APPROVAL = datetime(2026, 1, 15, tzinfo=UTC)
+FEB_APPROVAL = datetime(2026, 2, 20, tzinfo=UTC)
+APR_APPROVAL = datetime(2026, 4, 2, tzinfo=UTC)
 APR_END = date(2026, 4, 30)
 
 
@@ -687,7 +687,7 @@ class TestBillableLineItemsAcrossMonths:
 
     def test_total_includes_org_pay(self, access):
         payment_unit = PaymentUnitFactory(opportunity=access.opportunity, amount=10, org_amount=4)
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         self._pin_monthly_rates(access.opportunity, [(now, "2")])
         self._create_approved_completed_work(access, now, payment_unit, approved=2)
 
@@ -703,8 +703,8 @@ class TestBillableLineItemsAcrossMonths:
 
     def _billable_items(self, opportunity):
         """These tests span three months back, so bill from before the earliest through today."""
-        start_date = (datetime.now(tz=timezone.utc) - relativedelta(months=4)).date()
-        return get_billable_line_items(opportunity, start_date, datetime.now(tz=timezone.utc).date())
+        start_date = (datetime.now(tz=UTC) - relativedelta(months=4)).date()
+        return get_billable_line_items(opportunity, start_date, datetime.now(tz=UTC).date())
 
     def _create_approved_completed_work(self, opp_access, status_modified_date, payment_unit, approved=1):
         return CompletedWorkFactory(
@@ -717,7 +717,7 @@ class TestBillableLineItemsAcrossMonths:
         )
 
     def _recent_months(self):
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         return now - relativedelta(months=2), now - relativedelta(months=1), now
 
     def _pin_monthly_rates(self, opportunity, rates):

--- a/commcare_connect/opportunity/tests/test_views.py
+++ b/commcare_connect/opportunity/tests/test_views.py
@@ -1476,9 +1476,8 @@ class TestDownloadInvoiceView(BaseTestInvoiceView):
 
         assert response.status_code == 200
         assert response.headers["Content-Type"] == "application/pdf"
-        assert response.headers["Content-Disposition"] == 'attachment;filename="invoice_{}.pdf"'.format(
-            invoice.payment_invoice_id
-        )
+        expected_disposition = f'attachment;filename="invoice_{invoice.payment_invoice_id}.pdf"'
+        assert response.headers["Content-Disposition"] == expected_disposition
 
     def test_missing_invoice(self, client, setup_invoice):
         opportunity = setup_invoice["opportunity"]

--- a/commcare_connect/program/models.py
+++ b/commcare_connect/program/models.py
@@ -59,7 +59,7 @@ class ProgramApplication(BaseModel):
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
     status = models.CharField(
         max_length=20,
-        choices=ProgramApplicationStatus.choices,
+        choices=ProgramApplicationStatus,
         default=ProgramApplicationStatus.INVITED,
     )
 

--- a/commcare_connect/program/tasks.py
+++ b/commcare_connect/program/tasks.py
@@ -115,7 +115,7 @@ def send_monthly_delivery_reminder_email():
     organizations_with_pending_deliveries = Organization.objects.filter(
         Q(opportunity__opportunityaccess__completedwork__status=CompletedWorkStatus.pending)
         | Q(
-            program__opportunity__opportunityaccess__completedwork__uservisit__review_status=VisitReviewStatus.pending  # noqa:E501
+            program__opportunity__opportunityaccess__completedwork__uservisit__review_status=VisitReviewStatus.pending
         ),
     ).distinct()
 

--- a/commcare_connect/program/utils.py
+++ b/commcare_connect/program/utils.py
@@ -48,7 +48,7 @@ def populate_currency_and_country_fk_for_model(apps, model_name, app_label, tota
     print(f"Populating {total_label} currency_fk & country for {total} records...")
 
     for start in range(0, total, BATCH_SIZE):
-        batch = list(qs[start : start + BATCH_SIZE])  # noqa: E203
+        batch = list(qs[start : start + BATCH_SIZE])
         for record in batch:
             raw_code = (record.currency or "").strip().upper()
             if not raw_code:

--- a/commcare_connect/reports/management/commands/generate_sample_data.py
+++ b/commcare_connect/reports/management/commands/generate_sample_data.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
@@ -167,7 +167,7 @@ class Command(BaseCommand):
             if opp.deliver_app and opp.deliver_app.id not in deliver_units_cache:
                 deliver_units_cache[opp.deliver_app.id] = DeliverUnitFactory(app=opp.deliver_app)
 
-        start_date = datetime(2024, 7, 1, tzinfo=timezone.utc)
+        start_date = datetime(2024, 7, 1, tzinfo=UTC)
         end_date = djtimezone.now()
         works_to_create = []
 
@@ -225,7 +225,7 @@ class Command(BaseCommand):
             for _ in range(num_invoices):
                 invoice = PaymentInvoiceFactory(
                     opportunity=opp,
-                    date=fake.date_time_between(start_date="-30d", end_date="now", tzinfo=timezone.utc),
+                    date=fake.date_time_between(start_date="-30d", end_date="now", tzinfo=UTC),
                     invoice_number=fake.pystr(),
                 )
                 if random.choice([True, False]):

--- a/commcare_connect/reports/management/commands/generate_test_data.py
+++ b/commcare_connect/reports/management/commands/generate_test_data.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
@@ -36,8 +36,8 @@ class Command(BaseCommand):
                 OpportunityAccessFactory(user=user, opportunity=opportunity)
 
         # Generate completed work and user visits
-        start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-        end_date = datetime.now(timezone.utc)
+        start_date = datetime(2024, 1, 1, tzinfo=UTC)
+        end_date = datetime.now(UTC)
 
         for count in range(num_visits):
             print(f"{count + 1}/{num_visits}...")

--- a/commcare_connect/reports/tests/test_commands.py
+++ b/commcare_connect/reports/tests/test_commands.py
@@ -1,5 +1,4 @@
 import datetime
-from datetime import timezone
 
 from django.core.management import call_command
 
@@ -27,33 +26,33 @@ class TestBackfillUserAnalyticsData:
             access = OpportunityAccessFactory(
                 user=user,
                 opportunity=opportunity,
-                date_learn_started=datetime.datetime(2023 + idx, 1, 2, tzinfo=timezone.utc),
-                completed_learn_date=datetime.datetime(2023 + idx, 1, 3, tzinfo=timezone.utc),
+                date_learn_started=datetime.datetime(2023 + idx, 1, 2, tzinfo=datetime.UTC),
+                completed_learn_date=datetime.datetime(2023 + idx, 1, 3, tzinfo=datetime.UTC),
                 accepted=True,
             )
 
             AssessmentFactory(
                 opportunity_access=access,
                 passed=True,
-                date=datetime.datetime(2023 + idx, 1, 4, tzinfo=timezone.utc),
+                date=datetime.datetime(2023 + idx, 1, 4, tzinfo=datetime.UTC),
             )
 
             claim = OpportunityClaimFactory(opportunity_access=access)
-            claim.date_claimed = datetime.datetime(2023 + idx, 1, 5, tzinfo=timezone.utc)
+            claim.date_claimed = datetime.datetime(2023 + idx, 1, 5, tzinfo=datetime.UTC)
             claim.save()
 
             completed_work = CompletedWorkFactory(
                 opportunity_access=access,
                 payment_unit=payment_unit,
                 status=CompletedWorkStatus.approved,
-                status_modified_date=datetime.datetime(2023 + idx, 1, 9, tzinfo=timezone.utc),
+                status_modified_date=datetime.datetime(2023 + idx, 1, 9, tzinfo=datetime.UTC),
             )
-            completed_work.date_created = datetime.datetime(2023 + idx, 1, 6, tzinfo=timezone.utc)
+            completed_work.date_created = datetime.datetime(2023 + idx, 1, 6, tzinfo=datetime.UTC)
             completed_work.save()
 
             PaymentFactory(
                 opportunity_access=access,
-                date_paid=datetime.datetime(2023 + idx, 1, 7, tzinfo=timezone.utc),
+                date_paid=datetime.datetime(2023 + idx, 1, 7, tzinfo=datetime.UTC),
             )
 
         assert not UserAnalyticsData.objects.filter(user=user).exists()

--- a/commcare_connect/users/management/commands/backfill_hq_user_uuid.py
+++ b/commcare_connect/users/management/commands/backfill_hq_user_uuid.py
@@ -164,7 +164,7 @@ class Command(BaseCommand):
 
         total = len(to_be_updated)
         for start in range(0, total, batch_size):
-            batch = to_be_updated[start : start + batch_size]  # noqa: E203
+            batch = to_be_updated[start : start + batch_size]
             self._bulk_update_with_retry(batch)
             self.stdout.write(self.style.SUCCESS(f"Updated {min(start + batch_size, total)}/{total} records."))
         return path

--- a/commcare_connect/users/tests/factories.py
+++ b/commcare_connect/users/tests/factories.py
@@ -12,7 +12,7 @@ from commcare_connect.users.models import ConnectIDUserLink
 
 
 class UserFactory(DjangoModelFactory):
-    username = Sequence(lambda n: "user_%d" % n)
+    username = Sequence(lambda n: f"user_{n}")
     email = Faker("email")
     name = Faker("name")
     password = Password(
@@ -33,7 +33,7 @@ class UserFactory(DjangoModelFactory):
 
 class ConnectIdUserLinkFactory(DjangoModelFactory):
     user = SubFactory(UserFactory)
-    commcare_username = Sequence(lambda n: "commcare_user_%d" % n)
+    commcare_username = Sequence(lambda n: f"commcare_user_{n}")
     hq_server = SubFactory(HQServerFactory)
 
     class Meta:
@@ -42,7 +42,7 @@ class ConnectIdUserLinkFactory(DjangoModelFactory):
 
 
 class MobileUserFactory(DjangoModelFactory):
-    username = Sequence(lambda n: "mobile_user_%d" % n)
+    username = Sequence(lambda n: f"mobile_user_{n}")
     name = Faker("name")
 
     class Meta:

--- a/commcare_connect/utils/tests/test_migrations.py
+++ b/commcare_connect/utils/tests/test_migrations.py
@@ -1,0 +1,13 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_no_pending_migrations():
+    out = StringIO()
+    try:
+        call_command("makemigrations", check_changes=True, dry_run=True, stdout=out, stderr=StringIO())
+    except SystemExit:
+        raise AssertionError("Model changes without a migration:\n" + out.getvalue()) from None

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -90,7 +90,7 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 # Anymail
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
-INSTALLED_APPS += ["anymail"]  # noqa: F405
+INSTALLED_APPS += ["anymail"]
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 # https://anymail.readthedocs.io/en/stable/esps/amazon_ses/

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -59,7 +59,7 @@ STORAGES["default"]["BACKEND"] = "commcare_connect.utils.storages.MediaRootS3Bot
 # Anymail
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
-INSTALLED_APPS += ["anymail"]  # noqa: F405
+INSTALLED_APPS += ["anymail"]
 # https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
 ANYMAIL = {}
 

--- a/manage.py
+++ b/manage.py
@@ -8,12 +8,12 @@ if __name__ == "__main__":
 
     try:
         from django.core.management import execute_from_command_line
-    except ImportError:
+    except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        )
+        ) from exc
 
     # This allows easy placement of apps within the interior
     # commcare_connect directory.

--- a/manage.py
+++ b/manage.py
@@ -9,19 +9,11 @@ if __name__ == "__main__":
     try:
         from django.core.management import execute_from_command_line
     except ImportError:
-        # The above import may fail for some other reason. Ensure that the
-        # issue is really that Django is missing to avoid masking other
-        # exceptions on Python 2.
-        try:
-            import django  # noqa
-        except ImportError:
-            raise ImportError(
-                "Couldn't import Django. Are you sure it's installed and "
-                "available on your PYTHONPATH environment variable? Did you "
-                "forget to activate a virtual environment?"
-            )
-
-        raise
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        )
 
     # This allows easy placement of apps within the interior
     # commcare_connect directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ python_files = [
     "tests.py",
     "test_*.py",
 ]
-norecursedirs = [".*", "node_modules"]
+norecursedirs = ["*.egg", ".*", "_darcs", "build", "CVS", "dist", "node_modules", "venv", "{arch}"]
 
 # ==== Coverage ====
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ extend-exclude = ["**/migrations/*.py"]
 
 [tool.ruff.lint]
 # E/W: pycodestyle, F: pyflakes (flake8 defaults), I: isort
-select = ["E", "F", "W", "I", "RUF100"]
+select = ["E", "F", "W", "I", "UP", "RUF100"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["commcare_connect", "config"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ python_files = [
 [tool.coverage.run]
 include = ["commcare_connect/**"]
 omit = ["*/migrations/*", "*/tests/*"]
-plugins = ["django_coverage_plugin"]
 
 
 # ==== ruff ====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-django>=4.5.2",
     "pytest-httpx>=0.24.0",
-    "ruff>=0.15.17",
+    "ruff>=0.16.6",
     "xml2json",
 ]
 production = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ extend-exclude = ["**/migrations/*.py"]
 
 [tool.ruff.lint]
 # E/W: pycodestyle, F: pyflakes (flake8 defaults), I: isort
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "RUF100"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["commcare_connect", "config"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ python_files = [
     "tests.py",
     "test_*.py",
 ]
+norecursedirs = [".*", "node_modules"]
 
 # ==== Coverage ====
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -326,14 +326,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.6"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/bd/fedc277e7351917b6c4e0ac751853a97af261278a4c7808babafa8ef2120/click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd", size = 336051, upload-time = "2023-07-18T20:05:13.823Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/70/e63223f8116931d365993d4a6b7ef653a4d920b41d03de7c59499962821f/click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5", size = 97909, upload-time = "2023-07-18T20:05:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -504,7 +501,7 @@ dev = [
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-django", specifier = ">=4.5.2" },
     { name = "pytest-httpx", specifier = ">=0.24.0" },
-    { name = "ruff", specifier = ">=0.15.17" },
+    { name = "ruff", specifier = ">=0.16.6" },
     { name = "xml2json", git = "https://github.com/dimagi/xml2json?rev=041b1ef" },
 ]
 production = [
@@ -931,26 +928,30 @@ wheels = [
 
 [[package]]
 name = "djlint"
-version = "1.36.4"
+version = "1.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama" },
     { name = "cssbeautifier" },
     { name = "jsbeautifier" },
     { name = "json5" },
     { name = "pathspec" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/89/ecf5be9f5c59a0c53bcaa29671742c5e269cc7d0e2622e3f65f41df251bf/djlint-1.36.4.tar.gz", hash = "sha256:17254f218b46fe5a714b224c85074c099bcb74e3b2e1f15c2ddc2cf415a408a1", size = 47849, upload-time = "2024-12-24T13:06:36.36Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/f1/053ff6c5c046dccfc0bbfa9f1ab020b35279fe91ecf9bdcc4deacdc44dd5/djlint-1.46.0.tar.gz", hash = "sha256:ac32f0a513824bea0a6eb2c517d9bef5e981a1b9478eebe1415bfdfb76ce8c9d", size = 126194, upload-time = "2026-09-07T17:38:44.835Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/68/18ecd1e4d54a523e1d077f01419d669116e5dede97f97f1eb8ddb918a872/djlint-1.36.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d68da0ed10ee9ca1e32e225cbb8e9b98bf7e6f8b48a8e4836117b6605b88cc7", size = 344261, upload-time = "2024-12-24T13:06:01.136Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/03/005cf5c66e57ca2d26249f8385bc64420b2a95fea81c5eb619c925199029/djlint-1.36.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c0478d5392247f1e6ee29220bbdbf7fb4e1bc0e7e83d291fda6fb926c1787ba7", size = 319580, upload-time = "2024-12-24T13:06:03.824Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/88/aea3c81343a273a87362f30442abc13351dc8ada0b10e51daa285b4dddac/djlint-1.36.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:962f7b83aee166e499eff916d631c6dde7f1447d7610785a60ed2a75a5763483", size = 407070, upload-time = "2024-12-24T13:06:05.356Z" },
-    { url = "https://files.pythonhosted.org/packages/60/77/0f767ac0b72e9a664bb8c92b8940f21bc1b1e806e5bd727584d40a4ca551/djlint-1.36.4-cp311-cp311-win_amd64.whl", hash = "sha256:53cbc450aa425c832f09bc453b8a94a039d147b096740df54a3547fada77ed08", size = 360775, upload-time = "2024-12-24T13:06:10.176Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/67/f7aeea9be6fb3bd984487af8d0d80225a0b1e5f6f7126e3332d349fb13fe/djlint-1.36.4-py3-none-any.whl", hash = "sha256:e9699b8ac3057a6ed04fb90835b89bee954ed1959c01541ce4f8f729c938afdd", size = 52290, upload-time = "2024-12-24T13:06:33.76Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/c4334d62a5fc0ffd371ee29a8b629f59b8607dec3bb4f1116fb907b5eacd/djlint-1.46.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:db6a524fee609781f0657d8532fb8a218ed3523fa40a4b2ddc0af86d26e1f1da", size = 1319275, upload-time = "2026-09-07T17:37:19.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2b/3d1039e755820e9d50c278ccbe6d2a95c9b8e87fa9918b45cc0c6429fbae/djlint-1.46.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e44bcf54058f22cfae952723681a05752e66d92bf8f492f563d267d39da3767f", size = 1249294, upload-time = "2026-09-07T17:37:21.152Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1c/e87bfdeac742005156c4218fd1d72bcb3253d735383e81ad2bdb57dada74/djlint-1.46.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b72737cf8c30b1022f7a57b5d2106195e39f5b2026e5942a91565fbf81e71e7", size = 1314429, upload-time = "2026-09-07T17:37:22.714Z" },
+    { url = "https://files.pythonhosted.org/packages/62/aa/ecaf647b249368ee5502ecf1ad179a74f9dd57d7ae3ef7cc87cfea078b98/djlint-1.46.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31068ae3dec5dd72b4057d82907c735f9b43aa4f9adad21b307c7cf68db4e1d3", size = 1364170, upload-time = "2026-09-07T17:37:23.875Z" },
+    { url = "https://files.pythonhosted.org/packages/db/05/f5ce28a61909d0a79fc677764d8889baf5f28533cc6f6ee07e67b01ecc4d/djlint-1.46.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f83d253ae94013809c4766d8175928e619859e97dde65d443c2868bdee47b0f4", size = 1334399, upload-time = "2026-09-07T17:37:25.279Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/3e733a63ba8f364b83655e4bf42aa453fd7f877664dd9e635b51ce7a9079/djlint-1.46.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cc22d1ac1a2cb735037bef4133127a2241f0f19f39cfa3670842962712d0498c", size = 1386893, upload-time = "2026-09-07T17:37:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d0/b5f0a5e3014bb461ac71ed5079003b41d02cb9095b14c75e2ffd135d8696/djlint-1.46.0-cp311-cp311-win32.whl", hash = "sha256:818f962925f371b4ad164d2fd65274235e4aeb27fb5baf76025cf06f1741b081", size = 1019158, upload-time = "2026-09-07T17:37:27.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/07/87ae14f39953ab60b9e9cbf21dbfb6a30b3e5a7022304595c2f8469b6d10/djlint-1.46.0-cp311-cp311-win_amd64.whl", hash = "sha256:230082cc06d224d8ae978d89865a662c0baa8efee909763a23a048b1ef7ba9d7", size = 1164705, upload-time = "2026-09-07T17:37:28.807Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4e/0a87371804314d7b2c0ee57f49afee67ad5240b9b6213280e09a9e767887/djlint-1.46.0-cp311-cp311-win_arm64.whl", hash = "sha256:3a560dd7ba939cbc6ab48cb9d299ffdb1daeb08d852bcd68850e5d20eaf1e573", size = 1024368, upload-time = "2026-09-07T17:37:30.142Z" },
+    { url = "https://files.pythonhosted.org/packages/32/9b/e6a581ba9acb9303931b894a5c6479f6a64200e09c3c095564835a9b9b2b/djlint-1.46.0-py3-none-any.whl", hash = "sha256:3f7d12e2063df7d99476cbdfc74f481b13f05eb6260cd6dbdc3c185f6d7047bf", size = 160268, upload-time = "2026-09-07T17:38:43.443Z" },
 ]
 
 [[package]]
@@ -1979,27 +1980,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.17"
+version = "0.16.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
-    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
-    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
-    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
-    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
-    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
-    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
 ]
 
 [[package]]
@@ -2150,18 +2151,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/03/6111ed99e9bf7dfa1c30baeef0e0fb7e0bd387bd07f8e5b270776fe1de3f/tinyhtml5-2.0.0.tar.gz", hash = "sha256:086f998833da24c300c414d9fe81d9b368fd04cb9d2596a008421cbc705fcfcc", size = 179507, upload-time = "2024-10-29T15:37:14.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/de/27c57899297163a4a84104d5cec0af3b1ac5faf62f44667e506373c6b8ce/tinyhtml5-2.0.0-py3-none-any.whl", hash = "sha256:13683277c5b176d070f82d099d977194b7a1e26815b016114f581a74bbfbf47e", size = 39793, upload-time = "2024-10-29T15:37:11.743Z" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
First tranche from a sweep of the repo's quality gates: fixes the checks that were configured but no longer doing their job, and adds a test that fails when a model change has no migration. No application behaviour changes.

## Technical Summary

- Remove unused 'no-qa' comments (`RUF100`)
- The django-upgrade rewrite passes `Choices` classes to `choices=` directly.
- Add `makemigrations --check` test to fail on outdated / missing migrations.
- Replace `pyupgrade` with `ruff` `UP` rules
- Update pre-commit hooks

## Safety Assurance

Full suite green locally. `prek run -a` passes with the new hook versions and the local ruff dev dependency now matches the hook, so `uv run ruff` and the hook agree.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
