### PR TITLE
Block invites to an opportunity with no end date

### DIFF
--- a/commcare_connect/opportunity/api/serializers/automation.py
+++ b/commcare_connect/opportunity/api/serializers/automation.py
@@ -178,6 +178,11 @@ class UserInviteSerializer(serializers.Serializer):
         opportunity = self.context["opportunity"]
         if not opportunity.active:
             raise serializers.ValidationError(_("Opportunity must be active to invite users."))
+        if opportunity.end_date is None:
+            # `has_ended` is False when end_date is NULL, so without this check an
+            # opportunity that was never given an end date passes both guards and
+            # is pushed to the worker's device.
+            raise serializers.ValidationError(_("Opportunity must have an end date to invite users."))
         if opportunity.has_ended:
             raise serializers.ValidationError(_("Opportunity has ended."))
         return data

--- a/commcare_connect/opportunity/tests/test_automation_api.py
+++ b/commcare_connect/opportunity/tests/test_automation_api.py
@@ -374,6 +374,19 @@ class TestInviteUsers:
         )
         assert response.status_code == 400
 
+    def test_invite_users_opportunity_without_end_date(
+        self, api_client, program_manager_org_user_admin, active_managed_opportunity
+    ):
+        active_managed_opportunity.end_date = None
+        active_managed_opportunity.save(update_fields=["end_date"])
+        api_client.force_authenticate(program_manager_org_user_admin)
+        response = api_client.post(
+            f"/api/opportunities/{active_managed_opportunity.opportunity_id}/invite_users/",
+            {"phone_numbers": ["+265999111222"]},
+            format="json",
+        )
+        assert response.status_code == 400
+
 
 @pytest.mark.django_db
 class TestFullPipeline:


### PR DESCRIPTION
Closes #1401

## Motivation

`Opportunity.end_date` is nullable, and nothing on the invite path stops an opportunity without one from reaching a worker's device. When it does, the CommCare Android app crash-loops on every opportunity sync, so the worker loses access to **all** their opportunities, not just the malformed one. The issue reports 11 such rows in production, one of them with a worker already invited.

The gap is that the two guards in `UserInviteSerializer.validate` both pass for a null `end_date`:

```python
if not opportunity.active:      # the `active` FIELD, which is True
    ...
if opportunity.has_ended:       # False, because has_ended is `end_date and end_date < today`
    ...
```

A null-end_date opportunity is therefore simultaneously *not active* (`is_active` requires `end_date`) and *not ended* — so it slips through and gets pushed to devices.

## Change

Reject the invite when `end_date` is missing, checked **before** `has_ended` since `has_ended` cannot say anything meaningful about a null date.

This is option 3 from the issue — the minimum that closes the crash vector. I deliberately did not take options 1 or 2 (making the column non-nullable, or requiring `end_date` at the write boundary): both need a data migration that backfills the existing null rows, which touches production data and seems like a call for the team rather than something to slip into a drive-by PR. Happy to follow up with that migration if you want it, and I'd suggest the audit the issue mentions — existing null-`end_date` rows that already have an `OpportunityAccess` are still bricking those workers' apps today, and this change does not repair them.

I also left the `is_active` / `has_ended` disagreement alone. Making `has_ended` treat a null date as ended would be a broader semantic change across every call site, and it isn't needed to close this path.

## Review guidance

Two files, readable together. The serializer change is five lines; the rest is the test.

The one thing worth a second opinion is the **error message wording** — I used "Opportunity must have an end date to invite users." to match the style of the two existing messages, but if you'd rather it point the caller at completing setup generally, that's an easy change.

## Tests

`test_invite_users_opportunity_without_end_date` sits alongside the existing `test_invite_users_inactive_opportunity`, sets `end_date = None` on an otherwise active opportunity, and asserts the invite is rejected with 400.

### On verification — please read before merging

**I was not able to get a working local test run, so treat CI as the first real signal on this.**

I set up PostGIS and Redis via `docker compose` and installed the project with `uv`, but the suite needs GDAL/GEOS and my macOS `brew install gdal` stalled part-way through its dependency tree. I retried inside a `bookworm-slim` container, which needed `git` (for the git-sourced deps) and `build-essential` (for `jsonobject`'s C extension) added before `uv sync` completed.

When pytest finally ran, **all four tests in `TestInviteUsers` failed, including the three that predate this change** — so my container is missing project configuration rather than the change being wrong. I suspect a missing `.env`; `.env_template` warns that a blank value is not the same as an unset one and that this breaks the test suite. I ran out of a sensible time budget before isolating it, and I would rather say so than imply a green run I did not get.

What I am confident about, from reading the code: `has_ended` is `bool(self.end_date and self.end_date < now().date())`, which is `False` for a null date, and `active` is the raw boolean field, so neither guard rejects the null-end_date case today. The new check is a plain `is None` test placed before `has_ended`.

If the maintainers would rather I come back with a verified local run before this is looked at, that is completely fair — say the word and I will set up `.env` properly and report back.
