### PR TITLE
Fix ProtectedError when deleting stale opportunities with shared DeliverUnits

### DIFF
--- a/commcare_connect/opportunity/deletion.py
+++ b/commcare_connect/opportunity/deletion.py
@@ -7,7 +7,7 @@ import sentry_sdk
 from django.apps import apps
 from django.db import transaction
 
-from commcare_connect.opportunity.models import Opportunity
+from commcare_connect.opportunity.models import DeliverUnit, Opportunity
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,19 @@ def delete_opportunity(opportunity_or_id):
     try:
         with transaction.atomic():
             for deletion in OPPORTUNITY_DELETIONS:
+                if deletion.app_label == "opportunity" and deletion.model_name == "DeliverUnit":
+                    # A DeliverUnit can be reassigned to a different opportunity's PaymentUnit while
+                    # its deliver_app is reused (see add_payment_unit/edit_payment_unit), so by now
+                    # (this opportunity's own UserVisits were already cascade-deleted via its
+                    # OpportunityAccess above) any DeliverUnit still referenced by a UserVisit
+                    # belongs to another, still-active opportunity. Deleting it would violate that
+                    # other opportunity's data, so detach it from this opportunity instead.
+                    detached = DeliverUnit.objects.filter(
+                        payment_unit__opportunity_id=opportunity_id, uservisit__isnull=False
+                    ).update(payment_unit=None)
+                    if detached:
+                        logger.info("Detached %s DeliverUnit(s) still referenced by another opportunity", detached)
+
                 deleted = deletion.delete(opportunity_id)
                 total_deleted += deleted
                 logger.info(

--- a/commcare_connect/opportunity/tests/test_deletion.py
+++ b/commcare_connect/opportunity/tests/test_deletion.py
@@ -54,6 +54,42 @@ def test_delete_opportunity_clears_registered_models(opportunity_factory):
 
 
 @pytest.mark.django_db
+def test_delete_opportunity_detaches_deliver_unit_still_used_by_another_opportunity():
+    # Opp A: the DeliverUnit's original owner, still has visit history against it.
+    opp_a = factories.OpportunityFactory()
+    opp_a_access = factories.OpportunityAccessFactory(opportunity=opp_a)
+    opp_a_payment_unit = factories.PaymentUnitFactory(opportunity=opp_a)
+    shared_deliver_unit = factories.DeliverUnitFactory(payment_unit=opp_a_payment_unit)
+    factories.UserVisitFactory(
+        opportunity=opp_a,
+        opportunity_access=opp_a_access,
+        deliver_unit=shared_deliver_unit,
+    )
+    opp_a.active = False
+    opp_a.save()
+
+    # Opp B: reused the same DeliverUnit for its own PaymentUnit (see add_payment_unit/
+    # edit_payment_unit, which lets a new opportunity claim a DeliverUnit from an inactive
+    # opportunity's PaymentUnit by reassigning the FK rather than creating a new DeliverUnit row).
+    # Opp B is the one being deleted here.
+    opp_b = factories.OpportunityFactory()
+    opp_b_payment_unit = factories.PaymentUnitFactory(opportunity=opp_b)
+    shared_deliver_unit.payment_unit = opp_b_payment_unit
+    shared_deliver_unit.save()
+
+    result = delete_opportunity(opp_b)
+
+    # Opp B is still deleted successfully, as it has no visits of its own...
+    assert result is True
+    assert not Opportunity.objects.filter(pk=opp_b.pk).exists()
+    # ...but the shared DeliverUnit is detached (not deleted), since Opp A's visit history still
+    # needs it to exist.
+    shared_deliver_unit.refresh_from_db()
+    assert shared_deliver_unit.payment_unit_id is None
+    assert opp_a.uservisit_set.filter(deliver_unit=shared_deliver_unit).exists()
+
+
+@pytest.mark.django_db
 def test_delete_opportunity_with_nm_payment_linked_to_invoice():
     opportunity = factories.OpportunityFactory()
     invoice = factories.PaymentInvoiceFactory(opportunity=opportunity)


### PR DESCRIPTION
## Product Description

No user-facing change.

## Technical Summary

Sentry: https://dimagi.sentry.io/issues/COMMCARE-CONNECT-TH

- A `DeliverUnit` can be reassigned to a different opportunity's `PaymentUnit` while the original opportunity's `UserVisit` history still points at it, so deleting the owning opportunity was hitting a `ProtectedError` on that shared `DeliverUnit`.
- Before running the registered deletions, we now detach (set `payment_unit` to null) any `DeliverUnit` tied to the opportunity being deleted that's still referenced by a `UserVisit` from another opportunity, instead of trying to delete it.

**Note:** This issue has been occurring in production since 9 February 2026, with 134 occurrences through 7 September 2026. Given the duration and recurrence, it may be worth periodically reviewing long-running unresolved Sentry issues to catch similar cases earlier.

## Safety Assurance

### Safety story

Added a test that reproduces the exact scenario from the Sentry error (a `DeliverUnit` reused by a second opportunity while the first opportunity's visit history still references it) and confirms the second opportunity deletes cleanly while the shared `DeliverUnit` is detached, not deleted.

### Automated test coverage

Added a new test in `test_deletion.py` covering the detach path; full suite passes.

### QA Plan

No QA ticket needed, tested manually on local.

### Deployment

No config, commands, or migrations needed. Merging to main is enough to ship this.

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


