### PR TITLE
Fix query fan-out in active_flags_for_user

### DIFF
--- a/commcare_connect/flags/models.py
+++ b/commcare_connect/flags/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import Exists, OuterRef
 from django.db.models.signals import m2m_changed
 from django.utils.translation import gettext_lazy
 from waffle.models import CACHE_EMPTY, AbstractUserFlag
@@ -45,13 +46,25 @@ class Flag(AbstractUserFlag):
 
     @classmethod
     def active_flags_for_user(cls, user, include_role_flags=False):
-        filters = (
-            models.Q(users=user)
-            | models.Q(organizations__members=user)
-            | models.Q(opportunities__organization__members=user)
-            | models.Q(opportunities__opportunityaccess__user=user)
-            | models.Q(programs__organization__members=user)
+        # Each relation path is checked via a correlated EXISTS subquery rather than
+        # joining all of them into the same query — joining organizations, opportunities
+        # (via opportunityaccess) and programs together in one query multiplies their
+        # join cardinalities against each other, causing an expensive row fan-out that
+        # .distinct() then has to collapse. EXISTS keeps each check independent and
+        # index-driven, with no fan-out and no need for distinct().
+        organization_membership = Exists(
+            cls.organizations.through.objects.filter(flag_id=OuterRef("pk"), organization__members=user)
         )
+        opportunity_access = Exists(
+            cls.opportunities.through.objects.filter(flag_id=OuterRef("pk")).filter(
+                models.Q(opportunity__organization__members=user) | models.Q(opportunity__opportunityaccess__user=user)
+            )
+        )
+        program_membership = Exists(
+            cls.programs.through.objects.filter(flag_id=OuterRef("pk"), program__organization__members=user)
+        )
+
+        filters = models.Q(users=user) | organization_membership | opportunity_access | program_membership
 
         if include_role_flags:
             filters |= models.Q(everyone=True)
@@ -60,7 +73,7 @@ class Flag(AbstractUserFlag):
             if user.is_superuser:
                 filters |= models.Q(superusers=True)
 
-        return cls.objects.filter(filters).distinct()
+        return cls.objects.filter(filters)
 
     def is_active_for(self, obj: Organization | Opportunity | Program):
         # A transient/unsaved Flag (e.g. waffle's default for a missing flag) has no


### PR DESCRIPTION
## Product Description

No user-facing change.

## Technical Summary

[CI-847](https://dimagi.atlassian.net/browse/CI-847)

- `Flag.active_flags_for_user` joined organizations, opportunities (via opportunityaccess) and programs into one query with `.distinct()`. Joining independent relations like that multiplies their row counts against each other before Postgres can filter and dedupe them, so the cost scales with the product of all three relation sizes instead of the sum.
- Rewrote it so each relation is checked with its own correlated `EXISTS` subquery. Each one runs independently per flag row, so there's no cross-relation fan-out and `.distinct()` is no longer needed.
- Measured against prod with a read-only `EXPLAIN (ANALYZE, BUFFERS)` for a real user:

  | | Old query | New query |
  |---|---|---|
  | Execution time | 147-208 ms | 18-19 ms |
  | Planner cost estimate | ~201.7 billion | ~740 |
  | Planner row estimate | ~5.8 trillion | ~1,424 |
  | Disk reads | up to 6 | 0 |

  **Net result: ~8-11x faster execution, zero disk reads instead of up to 6, and a planner cost estimate roughly 272 million times lower.** Both queries return the same flags. The old query's row estimate is off by a factor of about 4 million, which is what makes the timeout intermittent instead of constant: how bad the fan-out gets depends on that particular user's org and opportunity footprint at request time.

## Safety Assurance

### Safety story
Reproduced the fan-out locally with a synthetic dataset first, then confirmed the improvement against real prod data with a read-only `EXPLAIN ANALYZE` (no writes) using one of the busiest real users I could find. Both queries returned identical flag sets in every case tested.

### Automated test coverage
Existing tests for `active_flags_for_user` (direct user flags, org/opportunity/program relation paths, role flags) pass unchanged, along with the full flags and toggle-view test suites (56 tests).

### QA Plan
No QA ticket needed, tested manually on local (full test suite) and verified against production data with a read-only EXPLAIN ANALYZE comparison.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CI-847]: https://dimagi.atlassian.net/browse/CI-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ