### PR TITLE
Add read endpoint for implementation area boundaries

### DIFF
--- a/commcare_connect/data_export/serializer.py
+++ b/commcare_connect/data_export/serializer.py
@@ -1,3 +1,4 @@
+import json
 from collections import OrderedDict
 
 from django.contrib.gis.geos import GEOSException, GEOSGeometry
@@ -12,7 +13,7 @@ from commcare_connect.microplanning.helpers import (
     assign_work_areas_and_sync_to_hq,
     unassign_work_areas_for_opportunity,
 )
-from commcare_connect.microplanning.models import SRID, WorkArea, WorkAreaGroup, WorkAreaStatus
+from commcare_connect.microplanning.models import SRID, ImplementationArea, WorkArea, WorkAreaGroup, WorkAreaStatus
 from commcare_connect.microplanning.tasks import parse_lon_lat_centroid, send_work_area_assignment_notification
 from commcare_connect.opportunity.api.serializers.mobile import (
     CommCareAppSerializer,
@@ -400,10 +401,19 @@ class WorkAreaGroupDataSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "ward", "opportunity"]
 
 
-class WorkAreaDataSerializer(serializers.ModelSerializer):
-    work_area_group_name = serializers.SerializerMethodField()
+class GeoCentroidBoundarySerializer(serializers.ModelSerializer):
     centroid = serializers.SerializerMethodField()
     boundary = serializers.SerializerMethodField()
+
+    def get_centroid(self, obj) -> dict:
+        return json.loads(obj.centroid.geojson)
+
+    def get_boundary(self, obj) -> dict:
+        return json.loads(obj.boundary.geojson)
+
+
+class WorkAreaDataSerializer(GeoCentroidBoundarySerializer):
+    work_area_group_name = serializers.SerializerMethodField()
 
     class Meta:
         model = WorkArea
@@ -427,11 +437,11 @@ class WorkAreaDataSerializer(serializers.ModelSerializer):
             return None
         return obj.work_area_group.name
 
-    def get_centroid(self, obj) -> dict:
-        return {"type": "Point", "coordinates": [obj.centroid.x, obj.centroid.y]}
 
-    def get_boundary(self, obj) -> dict:
-        return {"type": "Polygon", "coordinates": obj.boundary.coords}
+class ImplementationAreaDataSerializer(GeoCentroidBoundarySerializer):
+    class Meta:
+        model = ImplementationArea
+        fields = ["id", "name", "centroid", "boundary"]
 
 
 class LLOEntityDataSerializer(serializers.ModelSerializer):

--- a/commcare_connect/data_export/tests/test_views.py
+++ b/commcare_connect/data_export/tests/test_views.py
@@ -179,6 +179,31 @@ class TestWorkAreaDataView:
 
 
 @pytest.mark.django_db
+class TestImplementationAreaDataView:
+    def test_returns_implementation_area_list(self, v2_export_client, opportunity):
+        area = ImplementationAreaFactory(opportunity=opportunity)
+        url = reverse("data_export:implementation_area_data", kwargs={"opp_id": opportunity.id})
+        response = v2_export_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["results"]) == 1
+        result = data["results"][0]
+        assert result["id"] == area.id
+        assert result["name"] == area.name
+        assert result["centroid"]["type"] == "Point"
+        assert result["centroid"]["coordinates"] == [area.centroid.x, area.centroid.y]
+        assert result["boundary"]["type"] == "Polygon"
+        assert result["boundary"]["coordinates"] == [[list(coord) for coord in ring] for ring in area.boundary.coords]
+
+    def test_returns_404_for_unauthorized_opportunity(self, api_client, opportunity, user):
+        _add_export_credentials(api_client, user)
+        _add_v2_header(api_client)
+        url = reverse("data_export:implementation_area_data", kwargs={"opp_id": opportunity.id})
+        response = api_client.get(url)
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
 class TestLLOEntityDataView:
     def test_returns_organization_profiles(self, api_client, user):
         org = OrgWithUsersFactory(

--- a/commcare_connect/data_export/urls.py
+++ b/commcare_connect/data_export/urls.py
@@ -80,4 +80,9 @@ urlpatterns = [
         views.ImplementationAreaBulkCreateView.as_view(),
         name="implementation_area_bulk_create",
     ),
+    path(
+        "opportunity/<int:opp_id>/implementation_areas/",
+        views.ImplementationAreaDataView.as_view(),
+        name="implementation_area_data",
+    ),
 ]

--- a/commcare_connect/data_export/views.py
+++ b/commcare_connect/data_export/views.py
@@ -39,6 +39,7 @@ from commcare_connect.data_export.serializer import (
     AuditReportEntryDataSerializer,
     CompletedModuleDataSerializer,
     CompletedWorkDataSerializer,
+    ImplementationAreaDataSerializer,
     InvoiceDataSerializer,
     LabsRecordDataSerializer,
     LLOEntityDataSerializer,
@@ -57,7 +58,7 @@ from commcare_connect.data_export.serializer import (
     WorkAreaGroupWriteSerializer,
 )
 from commcare_connect.flags.flag_names import MICROPLANNING
-from commcare_connect.microplanning.models import WorkArea, WorkAreaGroup
+from commcare_connect.microplanning.models import ImplementationArea, WorkArea, WorkAreaGroup
 from commcare_connect.microplanning.tasks import ImplementationAreaCSVImporter, WorkAreaCSVImporter
 from commcare_connect.opportunity.models import (
     Assessment,
@@ -692,6 +693,13 @@ class WorkAreaDataView(OpportunityDataExportView, BaseDataExportListViewV2):
 
     def get_queryset(self, *args, **kwargs):
         return WorkArea.objects.filter(opportunity=self.opportunity).select_related("work_area_group")
+
+
+class ImplementationAreaDataView(OpportunityDataExportView, BaseDataExportListViewV2):
+    serializer_class = ImplementationAreaDataSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        return ImplementationArea.objects.filter(opportunity=self.opportunity)
 
 
 class LLOEntityDataView(BaseDataExportListViewV2):


### PR DESCRIPTION
## Product Description

No user-facing change. Adds a read endpoint so Labs can pull implementation area (ward boundary) data from Connect; there was previously only a write path.

## Technical Summary

Ticket: [CI-936](https://dimagi.atlassian.net/browse/CI-936)

- Added a list endpoint for reading `ImplementationArea`, 

## Safety Assurance

### Safety story

This is a new, additive read-only endpoint scoped to a single opportunity and gated by the existing export token/permission checks, so it can't affect existing data or other endpoints. Confirmed the WorkArea serializer output is unchanged after the shared base class refactor.

### Automated test coverage

Added tests for the new endpoint (list response shape and 404 on unauthorized opportunity); full `data_export` test suite passes.

### QA Plan

No QA ticket needed, tested manually on local.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CI-936]: https://dimagi.atlassian.net/browse/CI-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ