### PR TITLE
Clarify invoice delivery export columns

### DIFF
--- a/commcare_connect/opportunity/tables.py
+++ b/commcare_connect/opportunity/tables.py
@@ -1839,10 +1839,14 @@ class InvoiceDeliveriesTable(tables.Table):
     username = tables.Column(
         accessor="completed_work__opportunity_access__user__name", verbose_name=gettext_lazy("Worker")
     )
-    date_created = DMYTColumn(accessor="completed_work__date_created", verbose_name=gettext_lazy("Date of Delivery"))
-    date_approved = DMYTColumn(
-        accessor="completed_work__status_modified_date", verbose_name=gettext_lazy("Date Approved")
+    first_visit_date = DMYTColumn(
+        accessor="completed_work__date_created", verbose_name=gettext_lazy("First Visit Date")
     )
+    first_approved_date = DMYTColumn(
+        accessor="completed_work__status_modified_date", verbose_name=gettext_lazy("First Approved Date")
+    )
+    billing_month = tables.Column(accessor="month", verbose_name=gettext_lazy("Billing Month"))
+    billing_type = tables.Column(accessor="is_delta", verbose_name=gettext_lazy("Billing Type"))
     approved_count = tables.Column(accessor="billed_count", verbose_name=gettext_lazy("Approved Deliveries"))
     flw_amount_local = tables.Column(accessor="flw_pay__local", verbose_name=gettext_lazy("FLW Pay"))
     org_amount_local = tables.Column(accessor="org_pay__local", verbose_name=gettext_lazy("Org Pay"))
@@ -1868,14 +1872,22 @@ class InvoiceDeliveriesTable(tables.Table):
             "opportunity",
             "entity_name",
             "username",
-            "date_created",
-            "date_approved",
+            "first_visit_date",
+            "first_approved_date",
+            "billing_month",
+            "billing_type",
             "approved_count",
             "flw_amount_local",
             "org_amount_local",
             "total_amount_local",
             "total_amount_usd",
         )
+
+    def render_billing_month(self, value):
+        return value.strftime("%B %Y")
+
+    def render_billing_type(self, value):
+        return _("Additional Delivery") if value else _("First Billing")
 
 
 _task_select_td_extra = {

--- a/commcare_connect/opportunity/tests/test_tables.py
+++ b/commcare_connect/opportunity/tests/test_tables.py
@@ -73,7 +73,8 @@ def test_invoice_deliveries_table_org_column_visibility(show_org):
     assert "Total Pay (USD)" in headers
 
 
-def test_invoice_deliveries_table_total_folds_in_org_pay():
+@pytest.mark.parametrize(("is_delta", "billing_type"), [(False, "First Billing"), (True, "Additional Delivery")])
+def test_invoice_deliveries_table_row_values(is_delta, billing_type):
     delivery = WorkPayRow(
         completed_work=CompletedWork(
             entity_name="Baby A",
@@ -87,7 +88,7 @@ def test_invoice_deliveries_table_total_folds_in_org_pay():
         flw_pay=Money(Decimal("40"), Decimal("4")),
         org_pay=Money(Decimal("10"), Decimal("1")),
         exchange_rate=ExchangeRate(rate=Decimal("10")),
-        is_delta=True,
+        is_delta=is_delta,
     )
     table = InvoiceDeliveriesTable("KES", [delivery], show_org=True)
 
@@ -99,6 +100,10 @@ def test_invoice_deliveries_table_total_folds_in_org_pay():
     assert row["Org Pay (KES)"] == 10
     assert row["Total Pay (KES)"] == 50  # 40 + 10
     assert row["Total Pay (USD)"] == 5  # 4 + 1
+    assert row["Billing Month"] == "January 2026"
+    assert row["Billing Type"] == billing_type
+    assert "First Visit Date" in headers
+    assert "First Approved Date" in headers
 
 
 def _make_table(opportunity, per_page=25):


### PR DESCRIPTION
## Product Description

Follow up to [Invoice line items work](https://github.com/dimagi/commcare-connect/pull/1431)

Column changes to the invoice deliveries CSV export: _(This has been confirmed with Product)_

| Before | After |
| --- | --- |
| Date of Delivery | First Visit Date |
| Date Approved | First Approved Date |
| — | Billing Month |
| — | Billing Type |

The two renames: neither value is per-delivery. A work can span multiple visits, so there is no single delivery date — the value is when the work's first visit reached the system. Likewise the approval date is the work's *first* approval. For duplicate work this was actively misleading, since additional deliveries billed later keep the original dates.

`Billing Month` states the month the billed units are attributed to, so it's clear when duplicate work is being billed. `Billing Type` is `First Billing` (billed for the first time) or `Additional Delivery` (new deliveries for previously billed work).

## Technical Summary

Follow up for [ticket](https://dimagi.atlassian.net/browse/CCCT-2526)

`InvoiceDeliveriesTable` only backs the CSV export (`download_invoice_line_items`), so there is no UI change. Both new columns read fields the export rows already carry — `WorkPayRow.month` and `WorkPayRow.is_delta`, frozen per row on `CompletedWorkInvoice` — so the billable preview and the per-invoice export both pick them up with no query or schema changes.

## Safety Assurance

### Safety story

Presentation-only: two header renames plus two columns read from existing row fields. No model, query, or billing-math change, and no existing data is touched.

### Automated test coverage

`test_invoice_deliveries_table_row_values` (parametrized over `is_delta`) asserts the new headers and both `Billing Type` labels alongside the existing pay assertions.

### QA Plan

Download the invoice line items CSV both from the invoice creation window and from an existing invoice; confirm the renamed headers and that a work billed a second time shows `Additional Delivery` with the later billing month.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
