### PR TITLE
Draw building footprints client-side from Overture PMTiles

### DIFF
--- a/commcare_connect/microplanning/buildings.py
+++ b/commcare_connect/microplanning/buildings.py
@@ -1,0 +1,69 @@
+"""
+Building footprints for the microplanning map.
+
+Overture publishes its buildings as a PMTiles archive and Mapbox GL reads PMTiles natively, so the
+browser fetches footprints straight from Overture. This module only works out what to point it at:
+there is no proxy view, no cache and no table behind the overlay, and no building data passes
+through this process.
+
+The one thing needing care is the release. Overture's buckets drop everything older than 60 days,
+so a release that is fine today is a dead URL in two months -- see ``OVERTURE_RELEASE``.
+"""
+
+# The Overture release footprints are read from. Overture keeps only the two most recent releases
+# -- its buckets carry a 60 day retention rule -- so this has to move forward every month or so,
+# which currently means a deploy. Pinned here rather than in settings because it is not per
+# environment: every environment wants the same, current release.
+OVERTURE_RELEASE = "2026-08-19.0"
+
+# https://docs.overturemaps.org/examples/overture-tiles/
+OVERTURE_TILES_URL = (
+    "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/{release}/buildings.pmtiles"
+)
+
+OVERTURE_BUILDINGS_LAYER = "building"
+
+# A fact about the archive, handed to the Mapbox *source* as `maxzoom`: Overture builds tiles down
+# to zoom 14 and no deeper. Declaring it is what makes Mapbox overzoom those z14 tiles for closer
+# views; without it Mapbox requests z15+ tiles that do not exist and the overlay comes up empty.
+OVERTURE_ARCHIVE_MAX_ZOOM = 14
+
+# Our display policy, handed to the Mapbox *layers* as `minzoom`: the zoom at which footprints
+# start being drawn at all.
+#
+# Set to the archive's max zoom, so footprints appear at Overture's own deepest tiles and are drawn
+# at native resolution there; only the zooms past it are overzoomed. These two are not a range --
+# one is a property of the data, this one is a choice.
+#
+# Do not drop it below the archive max. z14 is the last complete level: Overture thins the lower
+# zooms hard (a z13 tile over Kibera carries about a fifth of the buildings its z14 tiles do), so
+# drawing there would show a partial set of buildings while looking complete.
+BUILDINGS_DISPLAY_MIN_ZOOM = 14
+
+# Overture's buildings are largely OpenStreetMap derived, so both need crediting. This is the
+# attribution Overture ships in the archive's own metadata.
+OVERTURE_ATTRIBUTION = (
+    '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap</a> '
+    '<a href="https://docs.overturemaps.org/attribution" target="_blank">&copy; Overture Maps Foundation</a>'
+)
+
+
+def buildings_overlay_config():
+    """
+    Return the config the map needs to draw building footprints, or ``None`` if it cannot.
+
+    ``None`` means the overlay is unavailable and its control should not be rendered: with no
+    release configured there is no archive to point the browser at, and a toggle that switches on
+    an empty layer is worse than no toggle.
+    """
+    release = (OVERTURE_RELEASE or "").strip()
+    if not release:
+        return None
+
+    return {
+        "tilesUrl": OVERTURE_TILES_URL.format(release=release),
+        "sourceLayer": OVERTURE_BUILDINGS_LAYER,
+        "archiveMaxZoom": OVERTURE_ARCHIVE_MAX_ZOOM,
+        "displayMinZoom": BUILDINGS_DISPLAY_MIN_ZOOM,
+        "attribution": OVERTURE_ATTRIBUTION,
+    }

--- a/commcare_connect/microplanning/tests/test_buildings.py
+++ b/commcare_connect/microplanning/tests/test_buildings.py
@@ -1,0 +1,56 @@
+import pytest
+
+from commcare_connect.microplanning import buildings
+from commcare_connect.microplanning.buildings import buildings_overlay_config
+
+
+@pytest.fixture
+def release(monkeypatch):
+    """Set the pinned Overture release for one test."""
+
+    def _set(value):
+        monkeypatch.setattr(buildings, "OVERTURE_RELEASE", value)
+
+    return _set
+
+
+@pytest.mark.parametrize("pinned", ["2026-08-19.0", " 2026-08-19.0\n"])
+def test_config_points_at_the_configured_release(release, pinned):
+    """The release is stripped before use: a stray newline must not reach the tile URL."""
+    release(pinned)
+
+    config = buildings_overlay_config()
+
+    assert config["tilesUrl"].endswith("/tiles/2026-08-19.0/buildings.pmtiles")
+    assert config["sourceLayer"] == "building"
+    assert config["archiveMaxZoom"] == 14
+    assert config["displayMinZoom"] == 14
+    # Footprints must never start below the archive's deepest level: the lower zooms are thinned,
+    # so drawing there would show a partial set of buildings while looking complete.
+    assert config["displayMinZoom"] >= config["archiveMaxZoom"]
+
+
+def test_config_credits_openstreetmap_and_overture():
+    """Overture's buildings are largely OSM derived, so both are required in the attribution."""
+    attribution = buildings_overlay_config()["attribution"]
+
+    assert "OpenStreetMap" in attribution
+    assert "Overture Maps Foundation" in attribution
+
+
+def test_the_pinned_release_is_usable():
+    """The pin ships in code, so a blank one would silently disable the overlay for everyone."""
+    assert buildings_overlay_config() is not None
+
+
+@pytest.mark.parametrize("pinned", [None, "", "   "])
+def test_no_config_without_a_release(release, pinned):
+    """
+    A missing release makes the overlay unavailable rather than pointing the browser at a bad URL.
+
+    The map itself has to keep working; only the footprint control goes away. Nothing can blank the
+    pin today, but the release is due to move to the database, where absence is a real state.
+    """
+    release(pinned)
+
+    assert buildings_overlay_config() is None

--- a/commcare_connect/microplanning/views.py
+++ b/commcare_connect/microplanning/views.py
@@ -47,6 +47,7 @@ from waffle.decorators import waffle_flag
 
 from commcare_connect.commcarehq.api import create_or_update_case_by_work_area
 from commcare_connect.flags.flag_names import MICROPLANNING
+from commcare_connect.microplanning.buildings import buildings_overlay_config
 from commcare_connect.microplanning.const import (
     MAX_AUTOZOOM_ZOOM,
     MAX_EXCLUDE_WORK_AREAS,
@@ -246,6 +247,7 @@ def microplanning_home(request, *args, **kwargs):
         "show_rerun_clear_work_area_groups_btn": show_rerun_clear_work_area_groups_btn,
         "clustering_is_rerun": show_rerun_clear_work_area_groups_btn,
         "mapbox_api_key": settings.MAPBOX_TOKEN,
+        "buildings_config": buildings_overlay_config(),
         "task_id": request.GET.get("task_id"),
         "import_status_url": import_status_url,
         "opportunity": opportunity,

--- a/commcare_connect/static/js/mapbox.js
+++ b/commcare_connect/static/js/mapbox.js
@@ -191,10 +191,14 @@ const MapboxUtils = {
    *   and finish loading. Only ever true while footprints are shown.
    * @param {function(boolean): void} [options.onAvailabilityChange] - called with whether the map
    *   is zoomed in far enough for footprints to draw at all.
+   * @param {function(): void} [options.onFailed] - called once if the archive turns out to be
+   *   unreadable, so the caller can withdraw the toggle and say so. Never called for a failure
+   *   the overlay can recover from.
    * @returns {{setVisible: function(boolean): void}} handle for toggling the footprints on and off
    */
   addBuildingsOverlay(map, config, options = {}) {
-    const { beforeId, onLoadingChange, onAvailabilityChange } = options;
+    const { beforeId, onLoadingChange, onAvailabilityChange, onFailed } =
+      options;
     const FILL_COLOR = '#1d4ed8';
     const FILL_OPACITY = 0.25;
     const OUTLINE_COLOR = '#1e3a8a';
@@ -256,9 +260,14 @@ const MapboxUtils = {
 
     // sourcedataloading covers the archive header and directory reads as well as the tiles, so the
     // first toggle reports progress while Mapbox is still working out where the tiles are.
+    let everLoaded = false;
     ['sourcedataloading', 'sourcedata'].forEach((event) => {
       map.on(event, (e) => {
-        if (e.sourceId === BUILDINGS_SOURCE) syncLoading();
+        if (e.sourceId !== BUILDINGS_SOURCE) return;
+        // Remembered so the error handler can tell a dead archive from a tile that dropped out of
+        // one that works: reaching loaded even once proves the archive itself is readable.
+        if (map.isSourceLoaded(BUILDINGS_SOURCE)) everLoaded = true;
+        syncLoading();
       });
     });
     // An idle map has nothing in flight, so this clears the indicator outright instead of asking
@@ -267,11 +276,16 @@ const MapboxUtils = {
     map.on('idle', () => setLoading(false));
     // The release this points at is retired by Overture after 60 days, at which point the archive
     // 404s and the overlay silently draws nothing. Surface that rather than spinning forever.
+
+    let failed = false;
     map.on('error', (e) => {
       if (e.sourceId !== BUILDINGS_SOURCE) return;
       setLoading(false);
       // eslint-disable-next-line no-console -- the retired-release case has no other signal
       console.error('Overture buildings source failed to load', e.error);
+      if (everLoaded || failed) return;
+      failed = true;
+      if (onFailed) onFailed();
     });
 
     // One threshold, applied twice from here: as the layers' Mapbox `minzoom`, and as the

--- a/commcare_connect/static/js/mapbox.js
+++ b/commcare_connect/static/js/mapbox.js
@@ -124,6 +124,10 @@ function addCatchmentAreas(map, catchments) {
 
 window.addCatchmentAreas = addCatchmentAreas;
 
+const BUILDINGS_SOURCE = 'overture-buildings';
+const BUILDINGS_FILL_LAYER = 'overture-buildings-fill';
+const BUILDINGS_OUTLINE_LAYER = 'overture-buildings-outline';
+
 const MapboxUtils = {
   setAccessToken(token) {
     if (!token) {
@@ -164,6 +168,109 @@ const MapboxUtils = {
     );
     map.addControl(draw, 'top-left');
     return draw;
+  },
+
+  /**
+   * Draw Overture building footprints, read by the browser straight from Overture's PMTiles archive.
+   *
+   * `archiveMaxZoom` is where Overture's tiles stop; `displayMinZoom` is where we choose to start
+   * drawing. Declaring the former is what makes Mapbox overzoom the deepest tiles for closer views
+   * rather than request tiles that do not exist.
+   *
+   * The source and layers are created on the first `setVisible(true)` rather than up front: adding
+   * a PMTiles source is not lazy in Mapbox, so doing it eagerly costs the provider plugin and an
+   * S3 range read of the archive header on every map load, even for the users who never switch
+   * footprints on.
+   *
+   * @param {mapboxgl.Map} map - Mapbox Map
+   * @param {{tilesUrl: string, sourceLayer: string, archiveMaxZoom: number, displayMinZoom: number, attribution: string}} config
+   * @param {object} [options]
+   * @param {string} [options.beforeId] - existing layer to insert the footprints beneath, so they
+   *   sit under the map's own layers rather than over them.
+   * @param {function(boolean): void} [options.onAvailabilityChange] - called with whether the map
+   *   is zoomed in far enough for footprints to draw at all.
+   * @returns {{setVisible: function(boolean): void}} handle for toggling the footprints on and off
+   */
+  addBuildingsOverlay(map, config, options = {}) {
+    const { beforeId, onAvailabilityChange } = options;
+    const FILL_COLOR = '#1d4ed8';
+    const FILL_OPACITY = 0.25;
+    const OUTLINE_COLOR = '#1e3a8a';
+    const OUTLINE_WIDTH = 0.8;
+
+    let added = false;
+    const addSourceAndLayers = () => {
+      if (added) return;
+      added = true;
+
+      map.addSource(BUILDINGS_SOURCE, {
+        type: 'vector',
+        url: config.tilesUrl,
+        maxzoom: config.archiveMaxZoom,
+        attribution: config.attribution,
+      });
+
+      // Below displayMinZoom footprints are too small to tell apart, so Mapbox is told not to draw
+      // them rather than the overlay policing zoom itself.
+      const shared = {
+        source: BUILDINGS_SOURCE,
+        'source-layer': config.sourceLayer,
+        minzoom: config.displayMinZoom,
+      };
+
+      map.addLayer(
+        {
+          ...shared,
+          id: BUILDINGS_FILL_LAYER,
+          type: 'fill',
+          paint: { 'fill-color': FILL_COLOR, 'fill-opacity': FILL_OPACITY },
+        },
+        beforeId,
+      );
+
+      map.addLayer(
+        {
+          ...shared,
+          id: BUILDINGS_OUTLINE_LAYER,
+          type: 'line',
+          paint: { 'line-color': OUTLINE_COLOR, 'line-width': OUTLINE_WIDTH },
+        },
+        beforeId,
+      );
+    };
+
+    // The release this points at is retired by Overture after 60 days, at which point the archive
+    // 404s and the overlay silently draws nothing. Surface that rather than failing quietly.
+    map.on('error', (e) => {
+      if (e.sourceId !== BUILDINGS_SOURCE) return;
+      // eslint-disable-next-line no-console -- the retired-release case has no other signal
+      console.error('Overture buildings source failed to load', e.error);
+    });
+
+    // One threshold, applied twice from here: as the layers' Mapbox `minzoom`, and as the
+    // availability reported to the caller. Callers never re-derive it, so the control cannot end up
+    // offering a toggle for a zoom at which Mapbox draws nothing.
+    let available = null;
+    const syncAvailability = () => {
+      const next = map.getZoom() >= config.displayMinZoom;
+      if (next === available) return;
+      available = next;
+      if (onAvailabilityChange) onAvailabilityChange(available);
+    };
+    syncAvailability();
+    map.on('zoomend', syncAvailability);
+
+    return {
+      setVisible(visible) {
+        if (visible) addSourceAndLayers();
+        if (!added) return;
+
+        const visibility = visible ? 'visible' : 'none';
+        [BUILDINGS_FILL_LAYER, BUILDINGS_OUTLINE_LAYER].forEach((layer) => {
+          map.setLayoutProperty(layer, 'visibility', visibility);
+        });
+      },
+    };
   },
 
   createMarker(map, opts) {

--- a/commcare_connect/static/js/mapbox.js
+++ b/commcare_connect/static/js/mapbox.js
@@ -187,12 +187,14 @@ const MapboxUtils = {
    * @param {object} [options]
    * @param {string} [options.beforeId] - existing layer to insert the footprints beneath, so they
    *   sit under the map's own layers rather than over them.
+   * @param {function(boolean): void} [options.onLoadingChange] - called when footprint tiles start
+   *   and finish loading. Only ever true while footprints are shown.
    * @param {function(boolean): void} [options.onAvailabilityChange] - called with whether the map
    *   is zoomed in far enough for footprints to draw at all.
    * @returns {{setVisible: function(boolean): void}} handle for toggling the footprints on and off
    */
   addBuildingsOverlay(map, config, options = {}) {
-    const { beforeId, onAvailabilityChange } = options;
+    const { beforeId, onLoadingChange, onAvailabilityChange } = options;
     const FILL_COLOR = '#1d4ed8';
     const FILL_OPACITY = 0.25;
     const OUTLINE_COLOR = '#1e3a8a';
@@ -239,10 +241,35 @@ const MapboxUtils = {
       );
     };
 
+    // Mapbox does the fetching, so progress has to be read back off its source events rather than
+    // tracked around a request of our own. Hidden layers load no tiles, so `shown` gates this: an
+    // idle map with the overlay off is not "loading", it has nothing to load.
+    let shown = false;
+    let loading = false;
+    const setLoading = (next) => {
+      if (next === loading) return;
+      loading = next;
+      if (onLoadingChange) onLoadingChange(loading);
+    };
+    const syncLoading = () =>
+      setLoading(shown && added && !map.isSourceLoaded(BUILDINGS_SOURCE));
+
+    // sourcedataloading covers the archive header and directory reads as well as the tiles, so the
+    // first toggle reports progress while Mapbox is still working out where the tiles are.
+    ['sourcedataloading', 'sourcedata'].forEach((event) => {
+      map.on(event, (e) => {
+        if (e.sourceId === BUILDINGS_SOURCE) syncLoading();
+      });
+    });
+    // An idle map has nothing in flight, so this clears the indicator outright instead of asking
+    // the source again: a tile that failed leaves the source looking unloaded forever, and reading
+    // it here would leave the indicator spinning on a load that has already given up.
+    map.on('idle', () => setLoading(false));
     // The release this points at is retired by Overture after 60 days, at which point the archive
-    // 404s and the overlay silently draws nothing. Surface that rather than failing quietly.
+    // 404s and the overlay silently draws nothing. Surface that rather than spinning forever.
     map.on('error', (e) => {
       if (e.sourceId !== BUILDINGS_SOURCE) return;
+      setLoading(false);
       // eslint-disable-next-line no-console -- the retired-release case has no other signal
       console.error('Overture buildings source failed to load', e.error);
     });
@@ -269,6 +296,8 @@ const MapboxUtils = {
         [BUILDINGS_FILL_LAYER, BUILDINGS_OUTLINE_LAYER].forEach((layer) => {
           map.setLayoutProperty(layer, 'visibility', visibility);
         });
+        shown = visible;
+        syncLoading();
       },
     };
   },

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -190,19 +190,17 @@
           {% if buildings_config %}
             {% include "microplanning/map_layer_toggles.html" %}
           {% endif %}
+          {% if assignment_mode %}
+            <div x-show="isHoveringWorkArea"
+                 x-effect="if (isHoveringWorkArea) { clearTimeout(hintTimeout); hintTimeout = setTimeout(() => isHoveringWorkArea = false, 3000) }"
+                 x-cloak
+                 class="map-hint">{% translate "Click to select group · Shift+click to select single area" %}</div>
+          {% endif %}
           <div id="toast-container" class="map-toast opacity-0">
             <i id="toast-icon" class="text-lg"></i>
             <span id="toast-message"></span>
           </div>
         </div>
-        {% if assignment_mode %}
-          <div x-show="isHoveringWorkArea"
-               x-effect="if (isHoveringWorkArea) { clearTimeout(hintTimeout); hintTimeout = setTimeout(() => isHoveringWorkArea = false, 3000) }"
-               x-cloak
-               class="absolute top-4 right-2 z-40 pointer-events-none px-2 py-2 rounded-md shadow-lg border border-white/10 text-sm text-white bg-black/50">
-            {% translate "Click to select group · Shift+click to select single area" %}
-          </div>
-        {% endif %}
         <dl x-show="hoveredWorkArea"
             x-cloak
             class="absolute bottom-4 right-2 z-40 pointer-events-none grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 rounded-md border border-white/10 bg-black/50 px-3 py-2 text-sm text-white shadow-lg max-w-xs">

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -186,10 +186,14 @@
       <div id="map-wrapper"
            x-ref="mapContainer"
            class="relative min-w-0 xl:flex-1 shadow-md h-[max(calc(100vh-300px),200px)] xl:h-full">
-        <div id="toast-container"
-             class="absolute top-4 right-4 z-50 flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg text-sm text-white opacity-0 transition-opacity duration-300">
-          <i id="toast-icon" class="text-lg"></i>
-          <span id="toast-message"></span>
+        <div class="map-control-stack">
+          {% if buildings_config %}
+            {% include "microplanning/map_layer_toggles.html" %}
+          {% endif %}
+          <div id="toast-container" class="map-toast opacity-0">
+            <i id="toast-icon" class="text-lg"></i>
+            <span id="toast-message"></span>
+          </div>
         </div>
         {% if assignment_mode %}
           <div x-show="isHoveringWorkArea"
@@ -215,9 +219,6 @@
           <dd x-text="hoveredWorkArea?.statusLabel ?? '—'">
           </dd>
         </dl>
-        {% if buildings_config %}
-          {% include "microplanning/map_layer_toggles.html" %}
-        {% endif %}
         <div id="map" class="w-full h-full"></div>
       </div>
       <!-- Sidebars (stacked) -->

--- a/commcare_connect/templates/microplanning/home.html
+++ b/commcare_connect/templates/microplanning/home.html
@@ -181,6 +181,7 @@
     <div class="flex flex-col gap-2 xl:flex-row xl:items-stretch xl:h-[max(calc(100vh-300px),200px)]"
          x-data="mapController()">
       {{ status_meta|json_script:"status-meta-data" }}
+      {% if buildings_config %}{{ buildings_config|json_script:"buildings-config" }}{% endif %}
       <!-- Map section -->
       <div id="map-wrapper"
            x-ref="mapContainer"
@@ -214,6 +215,9 @@
           <dd x-text="hoveredWorkArea?.statusLabel ?? '—'">
           </dd>
         </dl>
+        {% if buildings_config %}
+          {% include "microplanning/map_layer_toggles.html" %}
+        {% endif %}
         <div id="map" class="w-full h-full"></div>
       </div>
       <!-- Sidebars (stacked) -->

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -12,6 +12,11 @@
             showReviewInaccessibilityModal: false,
             showVisits: false,
             showImplementationAreas: false,
+
+            // Building footprint overlay. `buildingsAvailable` tracks whether the map is zoomed in
+            // far enough for footprints to be drawn at all; it is driven by the overlay.
+            showBuildings: false,
+            buildingsAvailable: false,
             filterQuery: '',
             pendingTileQuery: null,
             workAreaDetailRequestId: 0,
@@ -1050,6 +1055,10 @@
 
                 await new Promise(resolve => this.map.once('load', resolve));
 
+                // Footprints are inserted beneath the Work Area layers (see `beforeId`): they are
+                // context for the areas, and the areas are what the user is here to read.
+                this.initBuildings();
+
                 // Workareas are served using django-vectortiles,
                 // promoteId maps the feature's 'id' property as the feature ID,
                 // which is required for setFeatureState (hover/select) to work correctly.
@@ -1389,6 +1398,21 @@
                     }
                     this.hoveredWorkArea = null;
                 });
+            },
+
+            // Sets up the Building Data overlay, if it is configured. The overlay owns the source,
+            // the layers and the zoom threshold; this only wires its state to the control, which is
+            // hidden below that threshold rather than offering a toggle that appears to do nothing.
+            initBuildings() {
+                const configElement = document.getElementById('buildings-config');
+                if (!configElement) return;
+
+                const buildings = MapboxUtils.addBuildingsOverlay(this.map, JSON.parse(configElement.textContent), {
+                    beforeId: 'workareas-fill',
+                    onAvailabilityChange: (available) => { this.buildingsAvailable = available; },
+                });
+
+                this.$watch('showBuildings', (visible) => buildings.setVisible(visible));
             },
 
             // Sets up the Implementation Area overlay: a GeoJSON source, a black outline layer,

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -18,6 +18,7 @@
             showBuildings: false,
             buildingsAvailable: false,
             buildingsLoading: false,
+            buildingsFailed: false,
             filterQuery: '',
             pendingTileQuery: null,
             workAreaDetailRequestId: 0,
@@ -1412,6 +1413,10 @@
                     beforeId: 'workareas-fill',
                     onLoadingChange: (loading) => { this.buildingsLoading = loading; },
                     onAvailabilityChange: (available) => { this.buildingsAvailable = available; },
+                    onFailed: () => {
+                        this.buildingsFailed = true;
+                        this.showBuildings = false;
+                    },
                 });
 
                 this.$watch('showBuildings', (visible) => buildings.setVisible(visible));

--- a/commcare_connect/templates/microplanning/map_handler.html
+++ b/commcare_connect/templates/microplanning/map_handler.html
@@ -14,9 +14,10 @@
             showImplementationAreas: false,
 
             // Building footprint overlay. `buildingsAvailable` tracks whether the map is zoomed in
-            // far enough for footprints to be drawn at all; it is driven by the overlay.
+            // far enough for footprints to be drawn at all; both flags are driven by the overlay.
             showBuildings: false,
             buildingsAvailable: false,
+            buildingsLoading: false,
             filterQuery: '',
             pendingTileQuery: null,
             workAreaDetailRequestId: 0,
@@ -1409,6 +1410,7 @@
 
                 const buildings = MapboxUtils.addBuildingsOverlay(this.map, JSON.parse(configElement.textContent), {
                     beforeId: 'workareas-fill',
+                    onLoadingChange: (loading) => { this.buildingsLoading = loading; },
                     onAvailabilityChange: (available) => { this.buildingsAvailable = available; },
                 });
 

--- a/commcare_connect/templates/microplanning/map_layer_toggles.html
+++ b/commcare_connect/templates/microplanning/map_layer_toggles.html
@@ -1,14 +1,23 @@
 {% load i18n %}
-{% translate "Show building footprints from Overture Maps. Data from OpenStreetMap and the Overture Maps Foundation." as buildings_hint %}
 <div x-show="buildingsAvailable"
      x-transition.opacity
      x-cloak
      class="map-control-panel">
-  <label for="show-buildings-toggle" class="title-sm">{% translate "Show Building Data" %}</label>
-  <span x-tooltip.raw="{{ buildings_hint|escapejs }}">
-    <input id="show-buildings-toggle"
-           type="checkbox"
-           class="simple-toggle"
-           x-model="showBuildings">
-  </span>
+  <div class="map-control-row">
+    <label for="show-buildings-toggle" class="title-sm">{% translate "Show Building Data" %}</label>
+    <span x-tooltip.raw="{% translate 'Show building footprints from Overture Maps. Data from OpenStreetMap and the Overture Maps Foundation.' %}">
+      <input id="show-buildings-toggle"
+             type="checkbox"
+             class="simple-toggle"
+             x-model="showBuildings">
+    </span>
+  </div>
+  <p x-show="buildingsLoading"
+     x-cloak
+     class="map-control-status"
+     role="status"
+     aria-live="polite">
+    <i class="fa-solid fa-spinner fa-spin" aria-hidden="true"></i>
+    {% translate "Loading buildings…" %}
+  </p>
 </div>

--- a/commcare_connect/templates/microplanning/map_layer_toggles.html
+++ b/commcare_connect/templates/microplanning/map_layer_toggles.html
@@ -3,7 +3,7 @@
      x-transition.opacity
      x-cloak
      class="map-control-panel">
-  <div class="map-control-row">
+  <div x-show="!buildingsFailed" class="map-control-row">
     <label for="show-buildings-toggle" class="title-sm">{% translate "Show Building Data" %}</label>
     <span x-tooltip.raw="{% translate 'Show building footprints from Overture Maps. Data from OpenStreetMap and the Overture Maps Foundation.' %}">
       <input id="show-buildings-toggle"
@@ -12,7 +12,15 @@
              x-model="showBuildings">
     </span>
   </div>
-  <p x-show="buildingsLoading"
+  <p x-show="buildingsFailed"
+     x-cloak
+     class="map-control-status"
+     role="status"
+     aria-live="polite">
+    <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+    {% translate "Building data unavailable" %}
+  </p>
+  <p x-show="buildingsLoading && !buildingsFailed"
      x-cloak
      class="map-control-status"
      role="status"

--- a/commcare_connect/templates/microplanning/map_layer_toggles.html
+++ b/commcare_connect/templates/microplanning/map_layer_toggles.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% translate "Show building footprints from Overture Maps. Data from OpenStreetMap and the Overture Maps Foundation." as buildings_hint %}
+<div x-show="buildingsAvailable"
+     x-transition.opacity
+     x-cloak
+     class="map-control-panel">
+  <label for="show-buildings-toggle" class="title-sm">{% translate "Show Building Data" %}</label>
+  <span x-tooltip.raw="{{ buildings_hint|escapejs }}">
+    <input id="show-buildings-toggle"
+           type="checkbox"
+           class="simple-toggle"
+           x-model="showBuildings">
+  </span>
+</div>

--- a/tailwind/tailwind.css
+++ b/tailwind/tailwind.css
@@ -909,6 +909,15 @@ select:disabled,
     @apply pointer-events-auto flex flex-col gap-2 rounded-lg bg-white px-3 py-2 shadow-md;
   }
 
+  .map-control-row {
+    @apply flex items-center justify-between gap-3;
+  }
+
+  /* Progress note under a control, e.g. footprint tiles still loading. */
+  .map-control-status {
+    @apply flex items-center gap-2 text-xs text-gray-500;
+  }
+
   /* Positioned by `.map-control-stack`, and in the DOM even when hidden, so it must never take the
      pointer -- an invisible toast would otherwise eat clicks on the map beneath it. Callers toggle
      `opacity-0`/`opacity-100` and the background colour on the element itself, so those stay out

--- a/tailwind/tailwind.css
+++ b/tailwind/tailwind.css
@@ -899,9 +899,21 @@ select:disabled,
 
 /*--- floating map control panel ------------------- */
 @layer components {
-  /* Shares the map's top-right corner with the toast and the assignment hint, and is the only one
-     of the three the user can click, so it stacks above both rather than under them. */
+  /* The map's top-right corner. Everything in here is laid out in one column so a message can
+     never land on top of the controls */
+  .map-control-stack {
+    @apply pointer-events-none absolute right-4 top-4 z-50 flex flex-col items-end gap-2;
+  }
+
   .map-control-panel {
-    @apply absolute right-4 top-4 z-[60] flex flex-col gap-2 rounded-lg bg-white px-3 py-2 shadow-md;
+    @apply pointer-events-auto flex flex-col gap-2 rounded-lg bg-white px-3 py-2 shadow-md;
+  }
+
+  /* Positioned by `.map-control-stack`, and in the DOM even when hidden, so it must never take the
+     pointer -- an invisible toast would otherwise eat clicks on the map beneath it. Callers toggle
+     `opacity-0`/`opacity-100` and the background colour on the element itself, so those stay out
+     of here. */
+  .map-toast {
+    @apply pointer-events-none flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-white shadow-lg transition-opacity duration-300;
   }
 }

--- a/tailwind/tailwind.css
+++ b/tailwind/tailwind.css
@@ -896,3 +896,12 @@ select:disabled,
     }
   }
 }
+
+/*--- floating map control panel ------------------- */
+@layer components {
+  /* Shares the map's top-right corner with the toast and the assignment hint, and is the only one
+     of the three the user can click, so it stacks above both rather than under them. */
+  .map-control-panel {
+    @apply absolute right-4 top-4 z-[60] flex flex-col gap-2 rounded-lg bg-white px-3 py-2 shadow-md;
+  }
+}

--- a/tailwind/tailwind.css
+++ b/tailwind/tailwind.css
@@ -918,6 +918,12 @@ select:disabled,
     @apply flex items-center gap-2 text-xs text-gray-500;
   }
 
+  /* Positioned by `.map-control-stack`. Hover-driven and passive: x-show drops it out of the
+     column entirely when hidden, so the toast below it does not move on its account. */
+  .map-hint {
+    @apply pointer-events-none rounded-md border border-white/10 bg-black/50 px-2 py-2 text-sm text-white shadow-lg;
+  }
+
   /* Positioned by `.map-control-stack`, and in the DOM even when hidden, so it must never take the
      pointer -- an invisible toast would otherwise eat clicks on the map beneath it. Callers toggle
      `opacity-0`/`opacity-100` and the background colour on the element itself, so those stay out


### PR DESCRIPTION
## Product Description

A user will now see a **Show Building Data** toggle on the progress and assignment maps, which draws building footprints (from Overture) from zoom level 14 and up, with a loading indicator showing under the toggle while tiles are loading. Below zoom 14 the control and overlay both leave the map.

[Screencast from 10-09-2026 09:13:42.webm](https://github.com/user-attachments/assets/2e7dbb70-4a95-441e-85eb-233b0e440010)

When an error occurs loading the data:
<img width="1754" height="949" alt="image" src="https://github.com/user-attachments/assets/f0e22216-f748-40d7-9ef0-51043ce81eaa" />


## Technical Summary

[CCCT-2750](https://dimagi.atlassian.net/browse/CCCT-2750)

The building data is fetched from Overture, which publishes releases as a PMTiles archive. Mapbox knows how to read PMTiles vector sources natively since 3.21 (we ship 3.24), so having Mapbox read the buildings data directly [instead of us having to read it ourselves and parse it for Mapbox](https://github.com/dimagi/commcare-connect/pull/1492) is a big win. Not only is it faster by having Mapbox read the pre-rendered data, but we also don't have to install a bunch of new libraries as in the manual approach mentioned earlier.

What this PR adds is a mapbox source, two mapbox layers and a toggle to the top of the map. The map loads buildings once the user reaches the minimum zoom level `BUILDINGS_DISPLAY_MIN_ZOOM` (z14). Zoom levels smaller than this (i.e. when the user is zoomed out) hides the "Show buildings" panel.

### Note
Overture keep only the latest two releases accessible and creates a new release monthly. Currently `OVERTURE_RELEASE` is hardcoded, so [this PR](https://github.com/dimagi/commcare-connect/pull/1523) exists to make sure we keep up with the releases automatically.

## Safety Assurance

### Safety story

The feature sit's behind the existing flag-gated `MICROPLANNING` flag and it's an opt-in feature - the user needs to select a toggle to load the data.

### Automated test coverage

`test_buildings.py` covers the entire Python surface: the tile URL for a configured release, the OSM + Overture attribution, and the unconfigured path (`None`/empty/whitespace release) that hides the overlay instead of emitting a bad URL.

### QA Plan

QA planned.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CCCT-2750]: https://dimagi.atlassian.net/browse/CCCT-2750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
