### PR TITLE
Catch CommCareHQAPIException in sync_deliver_units

### DIFF
--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -2237,11 +2237,11 @@ def sync_deliver_units(request, org_slug, opp_id):
         create_learn_modules_and_deliver_units(request.opportunity.pk)
     except AppNoBuildException:
         status = HTTPStatus.BAD_REQUEST
-        message = "Failed to retrieve updates. No available build at the moment."
+        message = _("Failed to retrieve updates. No available build at the moment.")
     except (CommCareHQAPIException, httpx.RequestError, httpx.TimeoutException, httpx.ConnectError):
         logger.exception("Failed to sync delivery units for opportunity %s", opp_id)
         status = HTTPStatus.BAD_GATEWAY
-        message = "Failed to retrieve updates from CommCare HQ. Please try again."
+        message = _("Failed to retrieve updates from CommCare HQ. Please try again.")
 
     return HttpResponse(content=message, status=status)
 

--- a/commcare_connect/opportunity/views.py
+++ b/commcare_connect/opportunity/views.py
@@ -8,6 +8,7 @@ from functools import cached_property, partial
 from http import HTTPStatus
 from urllib.parse import urlencode, urlparse, urlunsplit
 
+import httpx
 import pghistory
 from celery.result import AsyncResult
 from crispy_forms.utils import render_crispy_form
@@ -2237,6 +2238,10 @@ def sync_deliver_units(request, org_slug, opp_id):
     except AppNoBuildException:
         status = HTTPStatus.BAD_REQUEST
         message = "Failed to retrieve updates. No available build at the moment."
+    except (CommCareHQAPIException, httpx.RequestError, httpx.TimeoutException, httpx.ConnectError):
+        logger.exception("Failed to sync delivery units for opportunity %s", opp_id)
+        status = HTTPStatus.BAD_GATEWAY
+        message = "Failed to retrieve updates from CommCare HQ. Please try again."
 
     return HttpResponse(content=message, status=status)
 


### PR DESCRIPTION
## Product Description

No user-facing UI change. Delivery unit sync now fails with a clear "try again" message instead of a generic error when CommCare HQ is unreachable/slow.

## Technical Summary

Ticket: [CI-664](https://dimagi.atlassian.net/browse/CI-664)

Added a catch for HQ API and network/timeout errors in sync_deliver_units, so it returns a clear "try again" message instead of a generic server error, matching how other views already handle this.

## Safety Assurance

### Safety story

Minimal, additive `except` clause on an existing try/except; no change to the happy path.

### Automated test coverage

None added for this specific branch yet; existing `opportunity/tests/test_views.py` suite (182 tests) passes unchanged.

### QA Plan

Manual: trigger sync with HQ unreachable and confirm a 502 with the new message instead of a 500.

### Deployment

- [x] This PR can be deployed: any required configuration, commands, or other manual steps required before this PR can be deployed are done.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[CI-664]: https://dimagi.atlassian.net/browse/CI-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ